### PR TITLE
Changed dep.protobuf.version to dep.protobuf-bom.version

### DIFF
--- a/java/flight/flight-jdbc-driver/pom.xml
+++ b/java/flight/flight-jdbc-driver/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${dep.protobuf.version}</version>
+            <version>${dep.protobuf-bom.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
The dep.protobuf.version variable was used in this fork https://github.com/rafael-telles/arrow/tree/flight-jdbc-driver where it was referencing variables in the parent pom that does not exist in the official arrow fork of flight-sql-jdbc which this branch is based off of. This caused a build issue where dep.protobuf.version is not defined. Changing it to dep.protobuf-bom.version fixes the build issue