### PR TITLE
Fix rest of `flightsql-odbc` build issues 

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -342,7 +342,8 @@ takes precedence over ccache if a storage backend is configured" ON)
                 "Build the Arrow Flight SQL ODBC extension"
                 OFF
                 DEPENDS
-                ARROW_FLIGHT_SQL)                
+                ARROW_FLIGHT_SQL
+                ARROW_COMPUTE)                
 
   define_option(ARROW_GANDIVA
                 "Build the Gandiva libraries"

--- a/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
@@ -43,6 +43,16 @@ if(WIN32)
   list(APPEND ARROW_FLIGHT_SQL_ODBC_SRCS odbc.def)
 endif()
 
+if(WIN32)
+  if (MSVC_VERSION GREATER_EQUAL 1900)
+    set(ODBCINST legacy_stdio_definitions odbccp32 shlwapi)
+  endif()
+elseif(APPLE)
+  set(ODBCINST iodbcinst)
+else()
+  set(ODBCINST odbcinst)
+endif()
+
 add_arrow_lib(arrow_flight_sql_odbc
               CMAKE_PACKAGE_NAME ArrowFlightSqlOdbc
               PKG_CONFIG_NAME arrow-flight-sql-odbc
@@ -54,7 +64,7 @@ add_arrow_lib(arrow_flight_sql_odbc
               SHARED_INSTALL_INTERFACE_LIBS ArrowFlight::arrow_flight_sql_shared
               STATIC_LINK_LIBS arrow_flight_sql_static
               STATIC_INSTALL_INTERFACE_LIBS ArrowFlight::arrow_flight_sql_static
-              SHARED_PRIVATE_LINK_LIBS ODBC::ODBC odbcabstraction arrow_odbc_spi_impl)
+              SHARED_PRIVATE_LINK_LIBS ${ODBC_LIBRARIES} ${ODBCINST} odbcabstraction arrow_odbc_spi_impl)
 
 foreach(LIB_TARGET ${ARROW_FLIGHT_SQL_ODBC_LIBRARIES})
   target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_FLIGHT_SQL_ODBC_EXPORTING)

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/CMakeLists.txt
@@ -88,38 +88,35 @@ add_library(arrow_odbc_spi_impl
             flight_sql_statement_get_type_info.h
             flight_sql_stream_chunk_buffer.cc
             flight_sql_stream_chunk_buffer.h
-            # TODO - fix build issues from get_info_cache
-            # get_info_cache.cc
-            # get_info_cache.h
+            get_info_cache.cc
+            get_info_cache.h
             json_converter.cc
             json_converter.h
             record_batch_transformer.cc
             record_batch_transformer.h
             scalar_function_reporter.cc
             scalar_function_reporter.h
-            # TODO - fix build issues from system_trust_store
-            # system_trust_store.cc
-            # system_trust_store.h
+            system_trust_store.cc
+            system_trust_store.h
             utils.cc)
 target_include_directories(arrow_odbc_spi_impl PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
-# TODO - fix build errors with configuration window
-# if(WIN32)
-#   target_sources(arrow_odbc_spi_impl PRIVATE
-#                  include/flight_sql/config/configuration.h
-#                  include/flight_sql/config/connection_string_parser.h
-#                  include/flight_sql/ui/add_property_window.h
-#                  include/flight_sql/ui/custom_window.h
-#                  include/flight_sql/ui/dsn_configuration_window.h
-#                  include/flight_sql/ui/window.h
-#                  config/configuration.cc
-#                  config/connection_string_parser.cc
-#                  ui/custom_window.cc
-#                  ui/window.cc
-#                  ui/dsn_configuration_window.cc
-#                  ui/add_property_window.cc
-#                  system_dsn.cc)
-# endif()
+if(WIN32)
+  target_sources(arrow_odbc_spi_impl PRIVATE
+                 include/flight_sql/config/configuration.h
+                 include/flight_sql/config/connection_string_parser.h
+                 include/flight_sql/ui/add_property_window.h
+                 include/flight_sql/ui/custom_window.h
+                 include/flight_sql/ui/dsn_configuration_window.h
+                 include/flight_sql/ui/window.h
+                 config/configuration.cc
+                 config/connection_string_parser.cc
+                 ui/custom_window.cc
+                 ui/window.cc
+                 ui/dsn_configuration_window.cc
+                 ui/add_property_window.cc
+                 system_dsn.cc)
+endif()
 
 find_package(ArrowFlightSql)
 
@@ -160,32 +157,20 @@ set_target_properties(arrow_odbc_spi_impl_cli
 target_link_libraries(arrow_odbc_spi_impl_cli arrow_odbc_spi_impl)
 
 # Unit tests
-# TODO - fix test build errors and enable "Run tests" command
-# add_executable(arrow_odbc_spi_impl_test
-#                accessors/boolean_array_accessor_test.cc
-#                accessors/binary_array_accessor_test.cc
-#                accessors/date_array_accessor_test.cc
-#                accessors/decimal_array_accessor_test.cc
-#                accessors/primitive_array_accessor_test.cc
-#                accessors/string_array_accessor_test.cc
-#                accessors/time_array_accessor_test.cc
-#                accessors/timestamp_array_accessor_test.cc
-#                flight_sql_connection_test.cc
-#                parse_table_types_test.cc
-#                json_converter_test.cc
-#                record_batch_transformer_test.cc
-#                utils_test.cc)
-
-# set_target_properties(arrow_odbc_spi_impl_test
-#                       PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-#                                  ${CMAKE_BINARY_DIR}/test/$<CONFIG>/bin)
-# target_link_libraries(arrow_odbc_spi_impl_test arrow_odbc_spi_impl gtest gtest_main)
-
-# add_test(connection_test arrow_odbc_spi_impl_test)
-# add_test(transformer_test arrow_odbc_spi_impl_test)
-
-# add_custom_command(TARGET arrow_odbc_spi_impl_test
-#                    COMMENT "Run tests"
-#                    POST_BUILD
-#                    COMMAND ${CMAKE_BINARY_DIR}/test/$<CONFIG>/bin/arrow_odbc_spi_impl_test
-# )
+add_arrow_test(arrow_odbc_spi_impl_test
+               SOURCES
+               accessors/boolean_array_accessor_test.cc
+               accessors/binary_array_accessor_test.cc
+               accessors/date_array_accessor_test.cc
+               accessors/decimal_array_accessor_test.cc
+               accessors/primitive_array_accessor_test.cc
+               accessors/string_array_accessor_test.cc
+               accessors/time_array_accessor_test.cc
+               accessors/timestamp_array_accessor_test.cc
+               flight_sql_connection_test.cc
+               parse_table_types_test.cc
+               json_converter_test.cc
+               record_batch_transformer_test.cc
+               utils_test.cc
+               EXTRA_LINK_LIBS
+               arrow_odbc_spi_impl)

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor_test.cc
@@ -24,7 +24,7 @@
 namespace {
 
 using namespace arrow;
-namespace driver::odbcabstraction {
+using namespace driver::odbcabstraction;
 
 using driver::flight_sql::ThrowIfNotOK;
 
@@ -59,7 +59,7 @@ std::string ConvertNumericToString(NUMERIC_STRUCT& numeric) {
 
   return string;
 }
-}  // namespace driver::odbcabstraction
+}
 
 namespace driver {
 namespace flight_sql {
@@ -121,4 +121,3 @@ TEST(DecimalArrayFlightSqlAccessor,
 
 }  // namespace flight_sql
 }  // namespace driver
-}  // namespace

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor_test.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/flight/sql/odbc/flight_sql/timestamp_array_accessor.h"
+#include "arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.h"
 #include "arrow/flight/sql/odbc/flight_sql/utils.h"
 #include "arrow/testing/builder.h"
 #include "gtest/gtest.h"

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
@@ -16,13 +16,13 @@
 // under the License.
 
 #include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/configuration.h"
+#include "arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h"
 
+#include <sstream>
+#include <iterator>
 #include <odbcinst.h>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
-#include <iterator>
-#include <sstream>
-#include "arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h"
 
 namespace driver {
 namespace flight_sql {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
@@ -28,7 +28,7 @@
 
 #include <utility>
 
-using namespace driver::flight_sql; //-AL- todo see if this is needed.
+using namespace driver::flight_sql;
 
 namespace driver {
 namespace flight_sql {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
@@ -39,8 +39,7 @@
 #include <sql.h>
 #include <sqlext.h>
 
-// TODO - fix build issues from system_trust_store
-// #include "arrow/flight/sql/odbc/flight_sql/system_trust_store.h"
+#include "arrow/flight/sql/odbc/flight_sql/system_trust_store.h"
 
 #ifndef NI_MAXHOST
 #  define NI_MAXHOST 1025
@@ -106,9 +105,6 @@ constexpr auto SYSTEM_TRUST_STORE_DEFAULT = true;
 constexpr auto STORES = {"CA", "MY", "ROOT", "SPC"};
 
 inline std::string GetCerts() {
-  // TODO - fix build issues from system_trust_store and return proper value
-  return "";
-  /*
   std::string certs;
 
   for (auto store : STORES) {
@@ -125,7 +121,6 @@ inline std::string GetCerts() {
   }
 
   return certs;
-  */
 }
 
 #else
@@ -209,8 +204,7 @@ void FlightSqlConnection::Connect(const ConnPropertyMap& properties,
     // connection properties to allow reporting a user for other auth mechanisms
     // and also decouple the database user from user credentials.
 
-    // TODO - fix build issues from get_info_cache
-    // info_.SetProperty(SQL_USER_NAME, auth_method->GetUser());
+    info_.SetProperty(SQL_USER_NAME, auth_method->GetUser());
     attribute_[CONNECTION_DEAD] = static_cast<uint32_t>(SQL_FALSE);
 
     PopulateMetadataSettings(properties);
@@ -432,10 +426,6 @@ boost::optional<Connection::Attribute> FlightSqlConnection::GetAttribute(
 }
 
 Connection::Info FlightSqlConnection::GetInfo(uint16_t info_type) {
-  // TODO - fix build issues from get_info_cache and return proper value.
-  uint16_t result = 0;
-  return result;
-  /*
   auto result = info_.GetInfo(info_type);
   if (info_type == SQL_DBMS_NAME || info_type == SQL_SERVER_NAME) {
     // Update the database component reported in error messages.
@@ -443,15 +433,13 @@ Connection::Info FlightSqlConnection::GetInfo(uint16_t info_type) {
     diagnostics_.SetDataSourceComponent(boost::get<std::string>(result));
   }
   return result;
-  */
 }
 
 FlightSqlConnection::FlightSqlConnection(OdbcVersion odbc_version,
                                          const std::string& driver_version)
     : diagnostics_("Apache Arrow", "Flight SQL", odbc_version),
       odbc_version_(odbc_version),
-      // TODO - fix build issues from get_info_cache and set proper value.
-      // info_(call_options_, sql_client_, driver_version),
+      info_(call_options_, sql_client_, driver_version),
       closed_(true) {
   attribute_[CONNECTION_DEAD] = static_cast<uint32_t>(SQL_TRUE);
   attribute_[LOGIN_TIMEOUT] = static_cast<uint32_t>(0);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
@@ -19,12 +19,12 @@
 
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/connection.h"
 
-#include <vector>
+
 #include "arrow/flight/api.h"
 #include "arrow/flight/sql/api.h"
+#include <vector>
 
-// TODO - fix build issues from get_info_cache
-// #include "arrow/flight/sql/odbc/flight_sql/get_info_cache.h"
+#include "arrow/flight/sql/odbc/flight_sql/get_info_cache.h"
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h"
 
 namespace driver {
@@ -46,8 +46,7 @@ class FlightSqlConnection : public odbcabstraction::Connection {
   arrow::flight::FlightClientOptions client_options_;
   arrow::flight::FlightCallOptions call_options_;
   std::unique_ptr<arrow::flight::sql::FlightSqlClient> sql_client_;
-// TODO - fix build issues from get_info_cache
-//   GetInfoCache info_;
+  GetInfoCache info_;
   odbcabstraction::Diagnostics diagnostics_;
   odbcabstraction::OdbcVersion odbc_version_;
   bool closed_;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
@@ -123,7 +123,7 @@ TEST(BuildLocationTests, ForTcp) {
       missing_attr, ssl_config);
 
   Location expected_location;
-  ASSERT_TRUE(Location::ForGrpcTcp("localhost", 32010, &expected_location).ok());
+  ASSERT_TRUE(Location::ForGrpcTcp("localhost", 32010).Value(&expected_location).ok());
   ASSERT_EQ(expected_location, actual_location1);
   ASSERT_NE(expected_location, actual_location2);
 }
@@ -204,3 +204,8 @@ TEST(PopulateCallOptionsTest, GenericOptionWithSpaces) {
 
 }  // namespace flight_sql
 }  // namespace driver
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/get_info_cache.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/get_info_cache.cc
@@ -319,7 +319,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             // String properties
             case SqlInfoOptions::FLIGHT_SQL_SERVER_NAME: {
               std::string server_name(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view());
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view());
 
               // TODO: Consider creating different properties in GetSqlInfo.
               // TODO: Investigate if SQL_SERVER_NAME should just be the host
@@ -334,7 +334,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case SqlInfoOptions::FLIGHT_SQL_SERVER_VERSION: {
               info_[SQL_DBMS_VER] = ConvertToDBMSVer(std::string(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view()));
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view()));
               break;
             }
             case SqlInfoOptions::FLIGHT_SQL_SERVER_ARROW_VERSION: {
@@ -343,32 +343,32 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case SqlInfoOptions::SQL_SEARCH_STRING_ESCAPE: {
               info_[SQL_SEARCH_PATTERN_ESCAPE] = std::string(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view());
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view());
               break;
             }
             case ARROW_SQL_IDENTIFIER_QUOTE_CHAR: {
               info_[SQL_IDENTIFIER_QUOTE_CHAR] = std::string(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view());
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view());
               break;
             }
             case SqlInfoOptions::SQL_EXTRA_NAME_CHARACTERS: {
               info_[SQL_SPECIAL_CHARACTERS] = std::string(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view());
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view());
               break;
             }
             case ARROW_SQL_SCHEMA_TERM: {
               info_[SQL_SCHEMA_TERM] = std::string(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view());
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view());
               break;
             }
             case ARROW_SQL_PROCEDURE_TERM: {
               info_[SQL_PROCEDURE_TERM] = std::string(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view());
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view());
               break;
             }
             case ARROW_SQL_CATALOG_TERM: {
               std::string catalog_term(std::string(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view()));
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view()));
               if (catalog_term.empty()) {
                 info_[SQL_CATALOG_NAME] = "N";
                 info_[SQL_CATALOG_NAME_SEPARATOR] = "";
@@ -379,7 +379,7 @@ bool GetInfoCache::LoadInfoFromServer() {
                 info_[SQL_CATALOG_LOCATION] = static_cast<uint16_t>(SQL_CL_START);
               }
               info_[SQL_CATALOG_TERM] = std::string(
-                  reinterpret_cast<arrow::StringScalar*>(scalar->value.get())->view());
+                  reinterpret_cast<arrow::StringScalar*>(scalar->child_value().get())->view());
 
               break;
             }
@@ -399,7 +399,7 @@ bool GetInfoCache::LoadInfoFromServer() {
               break;
             case SqlInfoOptions::SQL_DDL_SCHEMA: {
               bool supports_schema_ddl =
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value;
               // Note: this is a bitmask and we can't describe cascade or restrict
               // flags.
               info_[SQL_DROP_SCHEMA] = static_cast<uint32_t>(SQL_DS_DROP_SCHEMA);
@@ -411,7 +411,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case SqlInfoOptions::SQL_DDL_TABLE: {
               bool supports_table_ddl =
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value;
               // This is a bitmask and we cannot describe all clauses.
               info_[SQL_CREATE_TABLE] = static_cast<uint32_t>(SQL_CT_CREATE_TABLE);
               info_[SQL_DROP_TABLE] = static_cast<uint32_t>(SQL_DT_DROP_TABLE);
@@ -427,7 +427,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case SqlInfoOptions::SQL_NULL_PLUS_NULL_IS_NULL: {
               info_[SQL_CONCAT_NULL_BEHAVIOR] = static_cast<uint16_t>(
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value
                       ? SQL_CB_NULL
                       : SQL_CB_NON_NULL);
               break;
@@ -437,7 +437,7 @@ bool GetInfoCache::LoadInfoFromServer() {
               // SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES since we need both
               // properties to determine the value for SQL_CORRELATION_NAME.
               supports_correlation_name =
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value;
               break;
             }
             case SqlInfoOptions::SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES: {
@@ -445,7 +445,7 @@ bool GetInfoCache::LoadInfoFromServer() {
               // SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES since we need both
               // properties to determine the value for SQL_CORRELATION_NAME.
               requires_different_correlation_name =
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value;
               break;
             }
             case SqlInfoOptions::SQL_SUPPORTS_EXPRESSIONS_IN_ORDER_BY: {
@@ -455,7 +455,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             case SqlInfoOptions::SQL_SUPPORTS_ORDER_BY_UNRELATED: {
               // Note: this is the negation of the Flight SQL property.
               info_[SQL_ORDER_BY_COLUMNS_IN_SELECT] =
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value
                       ? "N"
                       : "Y";
               break;
@@ -466,7 +466,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case SqlInfoOptions::SQL_SUPPORTS_NON_NULLABLE_COLUMNS: {
               info_[SQL_NON_NULLABLE_COLUMNS] = static_cast<uint16_t>(
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value
                       ? SQL_NNC_NON_NULL
                       : SQL_NNC_NULL);
               break;
@@ -477,7 +477,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case SqlInfoOptions::SQL_CATALOG_AT_START: {
               info_[SQL_CATALOG_LOCATION] = static_cast<uint16_t>(
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value
                       ? SQL_CL_START
                       : SQL_CL_END);
               break;
@@ -495,22 +495,22 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case SqlInfoOptions::SQL_TRANSACTIONS_SUPPORTED: {
               transactions_supported =
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value;
               break;
             }
             case SqlInfoOptions::SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT: {
               transaction_ddl_commit =
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value;
               break;
             }
             case SqlInfoOptions::SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED: {
               transaction_ddl_ignore =
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value;
               break;
             }
             case SqlInfoOptions::SQL_BATCH_UPDATES_SUPPORTED: {
               info_[SQL_BATCH_SUPPORT] = static_cast<uint32_t>(
-                  reinterpret_cast<arrow::BooleanScalar*>(scalar->value.get())->value
+                  reinterpret_cast<arrow::BooleanScalar*>(scalar->child_value().get())->value
                       ? SQL_BS_ROW_COUNT_EXPLICIT
                       : 0);
               break;
@@ -943,7 +943,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             // List<string> properties
             case ARROW_SQL_NUMERIC_FUNCTIONS: {
               std::shared_ptr<arrow::Array> list_value =
-                  reinterpret_cast<arrow::BaseListScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BaseListScalar*>(scalar->child_value().get())->value;
               uint32_t result_val = 0;
               for (int64_t list_index = 0; list_index < list_value->length();
                    ++list_index) {
@@ -960,7 +960,7 @@ bool GetInfoCache::LoadInfoFromServer() {
 
             case ARROW_SQL_STRING_FUNCTIONS: {
               std::shared_ptr<arrow::Array> list_value =
-                  reinterpret_cast<arrow::BaseListScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BaseListScalar*>(scalar->child_value().get())->value;
               uint32_t result_val = 0;
               for (int64_t list_index = 0; list_index < list_value->length();
                    ++list_index) {
@@ -976,7 +976,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case ARROW_SQL_SYSTEM_FUNCTIONS: {
               std::shared_ptr<arrow::Array> list_value =
-                  reinterpret_cast<arrow::BaseListScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BaseListScalar*>(scalar->child_value().get())->value;
               uint32_t sys_result = 0;
               uint32_t convert_result = 0;
               for (int64_t list_index = 0; list_index < list_value->length();
@@ -994,7 +994,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             }
             case SqlInfoOptions::SQL_DATETIME_FUNCTIONS: {
               std::shared_ptr<arrow::Array> list_value =
-                  reinterpret_cast<arrow::BaseListScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BaseListScalar*>(scalar->child_value().get())->value;
               uint32_t result_val = 0;
               for (int64_t list_index = 0; list_index < list_value->length();
                    ++list_index) {
@@ -1011,7 +1011,7 @@ bool GetInfoCache::LoadInfoFromServer() {
 
             case ARROW_SQL_KEYWORDS: {
               std::shared_ptr<arrow::Array> list_value =
-                  reinterpret_cast<arrow::BaseListScalar*>(scalar->value.get())->value;
+                  reinterpret_cast<arrow::BaseListScalar*>(scalar->child_value().get())->value;
               std::string result_str;
               for (int64_t list_index = 0; list_index < list_value->length();
                    ++list_index) {
@@ -1031,7 +1031,7 @@ bool GetInfoCache::LoadInfoFromServer() {
             // Map<int32, list<int32> properties
             case SqlInfoOptions::SQL_SUPPORTS_CONVERT: {
               arrow::MapScalar* map_scalar =
-                  reinterpret_cast<arrow::MapScalar*>(scalar->value.get());
+                  reinterpret_cast<arrow::MapScalar*>(scalar->child_value().get());
               auto data_array = map_scalar->value;
               arrow::StructArray* map_contents =
                   reinterpret_cast<arrow::StructArray*>(data_array.get());

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/get_info_cache.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/get_info_cache.h
@@ -17,20 +17,12 @@
 
 #pragma once
 
-#include <arrow/flight/api.h>
+#include <arrow/flight/sql/client.h>
 #include <arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/connection.h>
 #include <atomic>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
-
-namespace arrow {
-namespace flight {
-namespace sql {
-class FlightSqlClient;
-}
-}  // namespace flight
-}  // namespace arrow
 
 namespace driver {
 namespace flight_sql {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/custom_window.h"
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h"
+#include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/custom_window.h"
 
 namespace driver {
 namespace flight_sql {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/system_dsn.cc
@@ -15,24 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h"
 #include <winuser.h>
-#include <utility>
+#include "arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h"
 #include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/configuration.h"
 #include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/connection_string_parser.h"
-#include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h"
 #include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h"
-#include "arrow/flight/sql/odbc/flight_sqlflight_sql_connection.h"
+#include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h"
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/exceptions.h"
-#include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h"
+#include <utility>
 
 #include <odbcinst.h>
-#include <codecvt>
-#include <locale>
 #include <sstream>
+#include <locale>
+#include <codecvt>
 
-namespace std {
-namespace driver::flight_sql {
-namespace driver::flight_sql::config {
+using namespace std;
+using namespace driver::flight_sql;
+using namespace driver::flight_sql::config;
 
 BOOL CALLBACK ConfigDriver(HWND hwndParent, WORD fRequest, LPCSTR lpszDriver,
                            LPCSTR lpszArgs, LPSTR lpszMsg, WORD cbMsgMax,
@@ -170,7 +170,3 @@ BOOL INSTAPI ConfigDSN(HWND hwndParent, WORD req, LPCSTR driver, LPCSTR attribut
 
   return TRUE;
 }
-
-}  // namespace driver::flight_sql::config
-}  // namespace driver::flight_sql
-}  // namespace std

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/system_trust_store.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/system_trust_store.h
@@ -19,13 +19,13 @@
 
 #if defined _WIN32 || defined _WIN64
 
-#  include <bcrypt.h>
-#  include <cryptuiapi.h>
-#  include <tchar.h>
-#  include <wincrypt.h>
-#  include <windows.h>
-#  include <iostream>
-#  include <vector>
+#include <windows.h>
+#include <wincrypt.h>
+#include <bcrypt.h>
+#include <cryptuiapi.h>
+#include <iostream>
+#include <tchar.h>
+#include <vector>
 
 namespace driver {
 namespace flight_sql {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
@@ -17,14 +17,15 @@
 
 #include "ui/add_property_window.h"
 
-#include <Shlwapi.h>
 #include <Windowsx.h>
-#include <commctrl.h>
+#include <Shlwapi.h>
 #include <sstream>
+#include <commctrl.h>
 
-#include <arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/exceptions.h>
 #include "ui/custom_window.h"
 #include "ui/window.h"
+#include <arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/exceptions.h>
+
 
 namespace driver {
 namespace flight_sql {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
@@ -15,9 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// platform.h includes windows.h, so it needs to be included 
+// before Windowsx.h and commctrl.h
+#include <arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h>
 #include <Windowsx.h>
 #include <commctrl.h>
-#include <arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h>
+
 #include <wtypes.h>
 #include <sstream>
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
@@ -16,15 +16,15 @@
 // under the License.
 
 #include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h"
+#include "arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h"
 
 #include <Shlwapi.h>
 #include <Windowsx.h>
 #include <commctrl.h>
 #include <commdlg.h>
-#include <arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/utils.h>
 #include <sql.h>
 #include <sstream>
-#include "arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h"
+#include <arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/utils.h>
 
 #include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h"
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/window.cc
@@ -15,11 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// platform.h includes windows.h, so it needs to be included 
+// before Windowsx.h and commctrl.h
+#include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h"
+
 #include <Windowsx.h>
 #include <commctrl.h>
 #include <string>
 #include <winuser.h>
-#include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h"
 
 #include <boost/algorithm/string/trim.hpp>
 #include <sstream>

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/CMakeLists.txt
@@ -17,6 +17,8 @@
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+include_directories(include)
+
 # Ensure fmt is loaded as header only
 add_compile_definitions(FMT_HEADER_ONLY)
 
@@ -57,7 +59,7 @@ add_library(odbcabstraction
             odbc_impl/odbc_environment.cc
             odbc_impl/odbc_statement.cc)
 target_include_directories(odbcabstraction PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
-target_link_libraries(odbcabstraction PUBLIC ODBC::ODBC Boost::headers)
+target_link_libraries(odbcabstraction PUBLIC ${ODBC_LIBRARIES} Boost::headers)
 
 set_target_properties(odbcabstraction
                       PROPERTIES ARCHIVE_OUTPUT_DIRECTORY

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
@@ -52,8 +52,6 @@ const boost::xpressive::sregex CONNECTION_STR_REGEX(
 // entries in the properties.
 void loadPropertiesFromDSN(const std::string& dsn,
                            Connection::ConnPropertyMap& properties) {
-  // TODO - fix build errors with configuration window
-  /*
   const size_t BUFFER_SIZE = 1024 * 10;
   std::vector<char> outputBuffer;
   outputBuffer.resize(BUFFER_SIZE, '\0');
@@ -94,7 +92,6 @@ void loadPropertiesFromDSN(const std::string& dsn,
       properties.emplace(std::make_pair(std::move(key), std::move(value)));
     }
   }
-  */
 }
 
 }  // namespace


### PR DESCRIPTION
### Rationale for this change
Fix build failures, so files can be included in cmake lists

### What changes are included in this PR?
Fix build issues with config window, system trust store, and cache info, and unit test in `flightsql-odbc`

### Are these changes tested?
Tested locally

### Are there any user-facing changes?
No