### PR TITLE
Fix build issue from static flight sql driver

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -37,10 +37,8 @@ namespace arrow
         using ODBC::ODBCEnvironment;
         using driver::flight_sql::FlightSqlDriver;
         
-        static FlightSqlDriver* odbc_driver = new FlightSqlDriver();
-        static std::shared_ptr<FlightSqlDriver> driver_ptr =
-            std::make_shared<FlightSqlDriver>(odbc_driver);
-        *result = reinterpret_cast<SQLHENV>(new ODBCEnvironment(driver_ptr));
+        static std::shared_ptr<FlightSqlDriver> odbc_driver = std::make_shared<FlightSqlDriver>();
+        *result = reinterpret_cast<SQLHENV>(new ODBCEnvironment(odbc_driver));
 
         return SQL_SUCCESS;
       }


### PR DESCRIPTION
Fix build issue from static flight sql driver
Passing a static flight sql driver into the static shared pointer causes compilation error.  Changing to have the static shared pointer create the underlying referenced sql driver fixes the issue.
