### PR TITLE
Updates for SQLGetDiagFieldW

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -256,9 +256,46 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
       return SQL_ERROR;
     }
 
-    default: {
-      // TODO Return correct dummy values
+    // Return valid 1 based dummy variable for unimplemented field
+    case SQL_DIAG_COLUMN_NUMBER: {
+      if (diagInfoPtr) {
+        *static_cast<SQLINTEGER*>(diagInfoPtr) = 1;
+      }
+
+      if (stringLengthPtr) {
+        *stringLengthPtr = sizeof(SQLINTEGER);
+      }
+
       return SQL_SUCCESS;
+    }
+
+    // Return empty string dummy variable for unimplemented fields
+    case SQL_DIAG_CLASS_ORIGIN:
+    case SQL_DIAG_CONNECTION_NAME:
+    case SQL_DIAG_SUBCLASS_ORIGIN: {
+      if (diagInfoPtr || stringLengthPtr) {
+        return GetStringAttribute(isUnicode, "", false, diagInfoPtr, bufferLength,
+                                  stringLengthPtr, *diagnostics);
+      }
+
+      return SQL_ERROR;
+    }
+
+    // Return valid 1 based dummy variable for unimplemented field
+    case SQL_DIAG_ROW_NUMBER: {
+      if (diagInfoPtr) {
+        *static_cast<SQLLEN*>(diagInfoPtr) = 1;
+      }
+
+      if (stringLengthPtr) {
+        *stringLengthPtr = sizeof(SQLLEN);
+      }
+
+      return SQL_SUCCESS;
+    }
+
+    default: {
+      return SQL_ERROR;
     }
   }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -157,7 +157,6 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
   // Set character type to be Unicode by default
   const bool isUnicode = true;
   Diagnostics* diagnostics = nullptr;
-  std::string dsn("");
 
   switch (handleType) {
     case SQL_HANDLE_ENV: {
@@ -168,7 +167,6 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
 
     case SQL_HANDLE_DBC: {
       ODBCConnection* connection = reinterpret_cast<ODBCConnection*>(handle);
-      dsn = connection->GetDSN();
       diagnostics = &connection->GetDiagnostics();
       break;
     }
@@ -242,8 +240,27 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
 
     case SQL_DIAG_SERVER_NAME: {
       if (diagInfoPtr || stringLengthPtr) {
-        return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
-                                  stringLengthPtr, *diagnostics);
+        switch (handleType) {
+          case SQL_HANDLE_DBC: {
+              ODBCConnection* connection = reinterpret_cast<ODBCConnection*>(handle);
+              std::string dsn = connection->GetDSN();
+              return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
+                                        stringLengthPtr, *diagnostics);
+          }
+
+          case SQL_HANDLE_DESC: {
+            // TODO Implement for case of descriptor
+            return SQL_ERROR;
+          }
+
+          case SQL_HANDLE_STMT: {
+            // TODO Implement for case of statement
+            return SQL_ERROR;
+          }
+
+          default:
+            return SQL_ERROR;
+        }
       }
 
       return SQL_ERROR;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -204,7 +204,7 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
 
       case SQL_DIAG_SERVER_NAME: {
         if (diagInfoPtr || stringLengthPtr) {
-          return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
+          return GetStringAttribute(isUnicode, dsn, false, diagInfoPtr, bufferLength,
                                     stringLengthPtr, *diagnostics);
         }
 
@@ -227,7 +227,7 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     case SQL_DIAG_MESSAGE_TEXT: {
       if (diagInfoPtr || stringLengthPtr) {
         const std::string& message = diagnostics->GetMessageText(recordIndex);
-        return GetStringAttribute(isUnicode, message, true, diagInfoPtr, bufferLength,
+        return GetStringAttribute(isUnicode, message, false, diagInfoPtr, bufferLength,
                                   stringLengthPtr, *diagnostics);
       }
 
@@ -249,7 +249,7 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     case SQL_DIAG_SQLSTATE: {
       if (diagInfoPtr || stringLengthPtr) {
         const std::string& state = diagnostics->GetSQLState(recordIndex);
-        return GetStringAttribute(isUnicode, state, true, diagInfoPtr, bufferLength,
+        return GetStringAttribute(isUnicode, state, false, diagInfoPtr, bufferLength,
                                   stringLengthPtr, *diagnostics);
       }
 
@@ -512,7 +512,7 @@ SQLRETURN SQLDriverConnectW(SQLHDBC conn, SQLHWND windowHandle,
     connection->connect(dsn, properties, missing_properties);
 #endif
     // Copy connection string to outConnectionString after connection attempt
-    return ODBC::GetStringAttribute(true, connection_string, true, outConnectionString,
+    return ODBC::GetStringAttribute(true, connection_string, false, outConnectionString,
                                     outConnectionStringBufferLen, outConnectionStringLen,
                                     connection->GetDiagnostics());
   });
@@ -576,7 +576,7 @@ SQLRETURN SQLGetInfoW(SQLHDBC conn, SQLUSMALLINT infoType, SQLPOINTER infoValueP
     if (infoType == SQL_DRIVER_ODBC_VER) {
       std::string_view ver("03.80");
 
-      return ODBC::GetStringAttribute(true, ver, true, infoValuePtr, bufLen, length,
+      return ODBC::GetStringAttribute(true, ver, false, infoValuePtr, bufLen, length,
                                       connection->GetDiagnostics());
     }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -154,7 +154,7 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     return SQL_ERROR;
   }
 
-  // Set character type to be Unicode by defualt (not Ansi)
+  // Set character type to be Unicode by default
   const bool isUnicode = true;
   Diagnostics* diagnostics = nullptr;
   std::string dsn("");
@@ -204,15 +204,6 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
         return SQL_SUCCESS;
       }
 
-      case SQL_DIAG_SERVER_NAME: {
-        if (diagInfoPtr || stringLengthPtr) {
-          return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
-                                    stringLengthPtr, *diagnostics);
-        }
-
-        return SQL_ERROR;
-      }
-
       default:
         return SQL_ERROR;
     }
@@ -246,6 +237,15 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
       }
 
       return SQL_SUCCESS;
+    }
+
+    case SQL_DIAG_SERVER_NAME: {
+      if (diagInfoPtr || stringLengthPtr) {
+        return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
+                                  stringLengthPtr, *diagnostics);
+      }
+
+      return SQL_ERROR;
     }
 
     case SQL_DIAG_SQLSTATE: {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -206,7 +206,7 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
 
       case SQL_DIAG_SERVER_NAME: {
         if (diagInfoPtr || stringLengthPtr) {
-          return GetStringAttribute(isUnicode, dsn, false, diagInfoPtr, bufferLength,
+          return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
                                     stringLengthPtr, *diagnostics);
         }
 
@@ -229,7 +229,7 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     case SQL_DIAG_MESSAGE_TEXT: {
       if (diagInfoPtr || stringLengthPtr) {
         const std::string& message = diagnostics->GetMessageText(recordIndex);
-        return GetStringAttribute(isUnicode, message, false, diagInfoPtr, bufferLength,
+        return GetStringAttribute(isUnicode, message, true, diagInfoPtr, bufferLength,
                                   stringLengthPtr, *diagnostics);
       }
 
@@ -251,14 +251,14 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     case SQL_DIAG_SQLSTATE: {
       if (diagInfoPtr || stringLengthPtr) {
         const std::string& state = diagnostics->GetSQLState(recordIndex);
-        return GetStringAttribute(isUnicode, state, false, diagInfoPtr, bufferLength,
+        return GetStringAttribute(isUnicode, state, true, diagInfoPtr, bufferLength,
                                   stringLengthPtr, *diagnostics);
       }
 
       return SQL_ERROR;
     }
 
-    // Return valid 1 based dummy variable for unimplemented field
+    // Return valid dummy variable for unimplemented field
     case SQL_DIAG_COLUMN_NUMBER: {
       if (diagInfoPtr) {
         *static_cast<SQLINTEGER*>(diagInfoPtr) = SQL_NO_COLUMN_NUMBER;
@@ -276,14 +276,14 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     case SQL_DIAG_CONNECTION_NAME:
     case SQL_DIAG_SUBCLASS_ORIGIN: {
       if (diagInfoPtr || stringLengthPtr) {
-        return GetStringAttribute(isUnicode, "", false, diagInfoPtr, bufferLength,
+        return GetStringAttribute(isUnicode, "", true, diagInfoPtr, bufferLength,
                                   stringLengthPtr, *diagnostics);
       }
 
       return SQL_ERROR;
     }
 
-    // Return valid 1 based dummy variable for unimplemented field
+    // Return valid dummy variable for unimplemented field
     case SQL_DIAG_ROW_NUMBER: {
       if (diagInfoPtr) {
         *static_cast<SQLLEN*>(diagInfoPtr) = SQL_NO_ROW_NUMBER;
@@ -615,7 +615,7 @@ SQLRETURN SQLGetInfoW(SQLHDBC conn, SQLUSMALLINT infoType, SQLPOINTER infoValueP
     if (infoType == SQL_DRIVER_ODBC_VER) {
       std::string_view ver("03.80");
 
-      return ODBC::GetStringAttribute(true, ver, false, infoValuePtr, bufLen, length,
+      return ODBC::GetStringAttribute(true, ver, true, infoValuePtr, bufLen, length,
                                       connection->GetDiagnostics());
     }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -139,6 +139,8 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
                            SQLSMALLINT recNumber, SQLSMALLINT diagIdentifier,
                            SQLPOINTER diagInfoPtr, SQLSMALLINT bufferLength,
                            SQLSMALLINT* stringLengthPtr) {
+  // TODO: Implement additional fields types
+  // https://github.com/apache/arrow/issues/46573
   using driver::odbcabstraction::Diagnostics;
   using ODBC::GetStringAttribute;
   using ODBC::ODBCConnection;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -261,7 +261,7 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     // Return valid 1 based dummy variable for unimplemented field
     case SQL_DIAG_COLUMN_NUMBER: {
       if (diagInfoPtr) {
-        *static_cast<SQLINTEGER*>(diagInfoPtr) = 1;
+        *static_cast<SQLINTEGER*>(diagInfoPtr) = SQL_NO_COLUMN_NUMBER;
       }
 
       if (stringLengthPtr) {
@@ -286,7 +286,7 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     // Return valid 1 based dummy variable for unimplemented field
     case SQL_DIAG_ROW_NUMBER: {
       if (diagInfoPtr) {
-        *static_cast<SQLLEN*>(diagInfoPtr) = 1;
+        *static_cast<SQLLEN*>(diagInfoPtr) = SQL_NO_ROW_NUMBER;
       }
 
       if (stringLengthPtr) {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -141,6 +141,7 @@ inline bool IsValidStringFieldArgs(SQLPOINTER diagInfoPtr, SQLSMALLINT bufferLen
   const bool hasValidBuffer =
       diagInfoPtr && bufferLength >= 0 && bufferLength % charSize == 0;
 
+  // regardless of capacity return false if invalid
   if (diagInfoPtr && !hasValidBuffer) {
     return false;
   }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -194,7 +194,8 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
     switch (diagIdentifier) {
       case SQL_DIAG_NUMBER: {
         if (diagInfoPtr) {
-          *static_cast<SQLINTEGER*>(diagInfoPtr) = static_cast<SQLINTEGER>(diagnostics->GetRecordCount());
+          *static_cast<SQLINTEGER*>(diagInfoPtr) =
+              static_cast<SQLINTEGER>(diagnostics->GetRecordCount());
         }
 
         if (stringLengthPtr) {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -242,10 +242,10 @@ SQLRETURN SQLGetDiagFieldW(SQLSMALLINT handleType, SQLHANDLE handle,
       if (diagInfoPtr || stringLengthPtr) {
         switch (handleType) {
           case SQL_HANDLE_DBC: {
-              ODBCConnection* connection = reinterpret_cast<ODBCConnection*>(handle);
-              std::string dsn = connection->GetDSN();
-              return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
-                                        stringLengthPtr, *diagnostics);
+            ODBCConnection* connection = reinterpret_cast<ODBCConnection*>(handle);
+            std::string dsn = connection->GetDSN();
+            return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
+                                      stringLengthPtr, *diagnostics);
           }
 
           case SQL_HANDLE_DESC: {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
@@ -79,15 +79,19 @@ template <typename O>
 inline SQLRETURN GetAttributeSQLWCHAR(const std::string_view& attributeValue,
                                       bool isLengthInBytes, SQLPOINTER output,
                                       O outputSize, O* outputLenPtr) {
-  size_t result =
+  size_t length =
       ConvertToSqlWChar(attributeValue, reinterpret_cast<SQLWCHAR*>(output),
                         isLengthInBytes ? outputSize : outputSize * GetSqlWCharSize());
 
-  if (outputLenPtr) {
-    *outputLenPtr = static_cast<O>(isLengthInBytes ? result : result / GetSqlWCharSize());
+  if (!isLengthInBytes) {
+    length = length / GetSqlWCharSize();
   }
 
-  if (output && outputSize < result + (isLengthInBytes ? GetSqlWCharSize() : 1)) {
+  if (outputLenPtr) {
+    *outputLenPtr = static_cast<O>(length);
+  }
+
+  if (output && outputSize < length + (isLengthInBytes ? GetSqlWCharSize() : 1)) {
     return SQL_SUCCESS_WITH_INFO;
   }
   return SQL_SUCCESS;

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -798,7 +798,7 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
 
   EXPECT_TRUE(ret == SQL_SUCCESS);
 
-  EXPECT_TRUE(diag_number == 1);
+  EXPECT_EQ(diag_number, 1);
 
   // SQL_DIAG_SERVER_NAME
   SQLWCHAR server_name[ODBC_BUFFER_SIZE];
@@ -818,7 +818,7 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
 
   EXPECT_TRUE(ret == SQL_SUCCESS);
 
-  EXPECT_TRUE(message_text_length > 100);
+  EXPECT_GT(message_text_length, 100);
 
   // SQL_DIAG_NATIVE
   SQLINTEGER diag_native;
@@ -829,7 +829,7 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
 
   EXPECT_TRUE(ret == SQL_SUCCESS);
 
-  EXPECT_TRUE(diag_native == 200);
+  EXPECT_EQ(diag_native, 200);
 
   // SQL_DIAG_SQLSTATE
   const SQLSMALLINT sql_state_size = 6;
@@ -842,11 +842,11 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
   EXPECT_TRUE(ret == SQL_SUCCESS);
 
   // 28000
-  EXPECT_TRUE(sql_state[0] == '2');
-  EXPECT_TRUE(sql_state[1] == '8');
-  EXPECT_TRUE(sql_state[2] == '0');
-  EXPECT_TRUE(sql_state[3] == '0');
-  EXPECT_TRUE(sql_state[4] == '0');
+  EXPECT_EQ(sql_state[0], '2');
+  EXPECT_EQ(sql_state[1], '8');
+  EXPECT_EQ(sql_state[2], '0');
+  EXPECT_EQ(sql_state[3], '0');
+  EXPECT_EQ(sql_state[4], '0');
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
@@ -908,16 +908,16 @@ TEST(SQLGetDiagRec, TestSQLGetDiagRecForConnectFailure) {
 
   EXPECT_TRUE(ret == SQL_SUCCESS);
 
-  EXPECT_TRUE(message_length > 200);
+  EXPECT_GT(message_length, 200);
 
-  EXPECT_TRUE(native_error == 200);
+  EXPECT_EQ(native_error, 200);
 
   // 28000
-  EXPECT_TRUE(sql_state[0] == '2');
-  EXPECT_TRUE(sql_state[1] == '8');
-  EXPECT_TRUE(sql_state[2] == '0');
-  EXPECT_TRUE(sql_state[3] == '0');
-  EXPECT_TRUE(sql_state[4] == '0');
+  EXPECT_EQ(sql_state[0], '2');
+  EXPECT_EQ(sql_state[1], '8');
+  EXPECT_EQ(sql_state[2], '0');
+  EXPECT_EQ(sql_state[3], '0');
+  EXPECT_EQ(sql_state[4], '0');
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -746,7 +746,7 @@ TEST(SQLDisconnect, TestSQLDisconnectWithoutConnection) {
   EXPECT_TRUE(ret == SQL_SUCCESS);
 }
 
-TEST(SQLGetDiagRec, TestSQLGetDiagRecForConnectFailure) {
+TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
   //  ODBC Environment
   SQLHENV env;
   SQLHDBC conn;
@@ -785,9 +785,123 @@ TEST(SQLGetDiagRec, TestSQLGetDiagRecForConnectFailure) {
 
   EXPECT_TRUE(ret == SQL_ERROR);
 
-  if (ret != SQL_SUCCESS) {
-    std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
-  }
+  // Retrieve all supported header level and record level data
+  SQLSMALLINT HEADER_LEVEL = 0;
+  SQLSMALLINT RECORD_1 = 1;
+
+  //
+  // SQL_DIAG_NUMBER
+  //
+  SQLINTEGER diag_number;
+  SQLSMALLINT diag_number_length;
+
+  ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, HEADER_LEVEL, SQL_DIAG_NUMBER, &diag_number,
+                        sizeof(SQLINTEGER), &diag_number_length);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  EXPECT_TRUE(diag_number == 1);
+
+  // SQL_DIAG_SERVER_NAME
+  //
+  SQLWCHAR server_name[ODBC_BUFFER_SIZE];
+  SQLSMALLINT server_name_length;
+
+  ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_SERVER_NAME, server_name,
+                        ODBC_BUFFER_SIZE, &server_name_length);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  // SQL_DIAG_MESSAGE_TEXT
+  //
+  SQLWCHAR message_text[ODBC_BUFFER_SIZE];
+  SQLSMALLINT message_text_length;
+
+  ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
+                        message_text, ODBC_BUFFER_SIZE, &message_text_length);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  EXPECT_TRUE(message_text_length > 100);
+
+  // SQL_DIAG_NATIVE
+  //
+  SQLINTEGER diag_native;
+  SQLSMALLINT diag_native_length;
+
+  ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_NATIVE, &diag_native,
+                        sizeof(diag_native), &diag_native_length);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  EXPECT_TRUE(diag_native == 200);
+
+  // SQL_DIAG_SQLSTATE
+  //
+  const SQLSMALLINT sql_state_size = 6;
+  SQLWCHAR sql_state[sql_state_size];
+  SQLSMALLINT sql_state_length;
+  ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_SQLSTATE, sql_state,
+                        sql_state_size * 2, &sql_state_length);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  // 28000
+  EXPECT_TRUE(sql_state[0] == '2');
+  EXPECT_TRUE(sql_state[1] == '8');
+  EXPECT_TRUE(sql_state[2] == '0');
+  EXPECT_TRUE(sql_state[3] == '0');
+  EXPECT_TRUE(sql_state[4] == '0');
+
+  // Free connection handle
+  ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  // Free environment handle
+  ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+}
+
+TEST(SQLGetDiagRec, TestSQLGetDiagRecForConnectFailure) {
+  //  ODBC Environment
+  SQLHENV env;
+  SQLHDBC conn;
+
+  // Allocate an environment handle
+  SQLRETURN ret = SQLAllocEnv(&env);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  // Allocate a connection using alloc handle
+  ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
+
+  EXPECT_TRUE(ret == SQL_SUCCESS);
+
+  // Connect string
+  ASSERT_OK_AND_ASSIGN(std::string connect_str,
+                       arrow::internal::GetEnvVar(TEST_CONNECT_STR));
+  // Append invalid uid to connection string
+  connect_str += std::string("uid=non_existent_id;");
+
+  ASSERT_OK_AND_ASSIGN(std::wstring wconnect_str,
+                       arrow::util::UTF8ToWideString(connect_str));
+  std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
+
+  SQLWCHAR outstr[ODBC_BUFFER_SIZE];
+  SQLSMALLINT outstrlen;
+
+  // Connecting to ODBC server.
+  ret = SQLDriverConnect(conn, NULL, &connect_str0[0],
+                         static_cast<SQLSMALLINT>(connect_str0.size()), outstr,
+                         ODBC_BUFFER_SIZE, &outstrlen, SQL_DRIVER_NOPROMPT);
+
+  EXPECT_TRUE(ret == SQL_ERROR);
 
   SQLWCHAR sql_state[6];
   SQLINTEGER native_error;

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -789,9 +789,7 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
   SQLSMALLINT HEADER_LEVEL = 0;
   SQLSMALLINT RECORD_1 = 1;
 
-  //
   // SQL_DIAG_NUMBER
-  //
   SQLINTEGER diag_number;
   SQLSMALLINT diag_number_length;
 
@@ -803,7 +801,6 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
   EXPECT_TRUE(diag_number == 1);
 
   // SQL_DIAG_SERVER_NAME
-  //
   SQLWCHAR server_name[ODBC_BUFFER_SIZE];
   SQLSMALLINT server_name_length;
 
@@ -813,7 +810,6 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
   EXPECT_TRUE(ret == SQL_SUCCESS);
 
   // SQL_DIAG_MESSAGE_TEXT
-  //
   SQLWCHAR message_text[ODBC_BUFFER_SIZE];
   SQLSMALLINT message_text_length;
 
@@ -825,7 +821,6 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
   EXPECT_TRUE(message_text_length > 100);
 
   // SQL_DIAG_NATIVE
-  //
   SQLINTEGER diag_native;
   SQLSMALLINT diag_native_length;
 
@@ -837,12 +832,12 @@ TEST(SQLGetDiagFieldW, TestSQLGetDiagFieldWForConnectFailure) {
   EXPECT_TRUE(diag_native == 200);
 
   // SQL_DIAG_SQLSTATE
-  //
   const SQLSMALLINT sql_state_size = 6;
   SQLWCHAR sql_state[sql_state_size];
   SQLSMALLINT sql_state_length;
   ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_SQLSTATE, sql_state,
-                        sql_state_size * 2, &sql_state_length);
+                        sql_state_size * driver::odbcabstraction::GetSqlWCharSize(),
+                        &sql_state_length);
 
   EXPECT_TRUE(ret == SQL_SUCCESS);
 


### PR DESCRIPTION
Updates for SQLGetDiagFieldW coming from comments to initial merged [PR](https://github.com/Bit-Quill/arrow/pull/33).

Addresses the following issues:

- Add statement and descriptor cases now so we don't forget.
- Use const std::string& to use copy by reference semantics to avoid copy.
- Change to use dsn value retrieved from connection for SQL_DIAG_SERVER_NAME
- Allow passing of diagInfoPtr if they just want the length
- For GetStringAttribute calls set isLengthInBytes to true for calls with SQLPOINTER and to false for calls with SQLWCHAR
- Return dummy values for unimplemented field types

Fixed bug in attribute_utils.h for GetAttributeSQLWCHAR to determine when truncation has been applied.
