### PR TITLE
Initialize Kernel Library

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/CMakeLists.txt
@@ -102,7 +102,7 @@ if(WIN32)
 endif()
 
 target_link_libraries(arrow_odbc_spi_impl PUBLIC odbcabstraction arrow_flight_sql_shared
-                                                 Boost::locale)
+                                                 arrow_compute_shared Boost::locale)
 
 # Link libraries on MINGW64 only
 if(MINGW AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_driver.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_driver.cc
@@ -16,7 +16,9 @@
 // under the License.
 
 #include "arrow/flight/sql/odbc/flight_sql/include/flight_sql/flight_sql_driver.h"
+#include "arrow/compute/api.h"
 #include "arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h"
+#include "arrow/flight/sql/odbc/flight_sql/utils.h"
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h"
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spd_logger.h"
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/utils.h"
@@ -56,6 +58,8 @@ LogLevel ToLogLevel(int64_t level) {
 FlightSqlDriver::FlightSqlDriver()
     : diagnostics_("Apache Arrow", "Flight SQL", OdbcVersion::V_3), version_("0.9.0.0") {
   RegisterLog();
+  // Register Kernel functions to library
+  ThrowIfNotOK(arrow::compute::Initialize());
 }
 
 std::shared_ptr<Connection> FlightSqlDriver::CreateConnection(OdbcVersion odbc_version) {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/utils_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/utils_test.cc
@@ -19,6 +19,7 @@
 
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/calendar_utils.h"
 
+#include "arrow/compute/initialize.h"
 #include "arrow/testing/builder.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
@@ -26,6 +27,13 @@
 
 namespace driver {
 namespace flight_sql {
+
+class UtilTestsWithCompute : public ::testing::Test {
+ public:
+  // This must be done before using the compute kernels in order to
+  // register them to the FunctionRegistry.
+  void SetUp() override { ASSERT_OK(arrow::compute::Initialize()); }
+};
 
 void AssertConvertedArray(const std::shared_ptr<arrow::Array>& expected_array,
                           const std::shared_ptr<arrow::Array>& converted_array,
@@ -80,7 +88,7 @@ void TestTime64ArrayConversion(const std::vector<int64_t>& input,
   AssertConvertedArray(expected_array, converted_array, input.size(), arrow_type);
 }
 
-TEST(Utils, Time32ToTimeStampArray) {
+TEST_F(UtilTestsWithCompute, Time32ToTimeStampArray) {
   std::vector<int32_t> input_data = {14896, 17820};
 
   const auto seconds_from_epoch = odbcabstraction::GetTodayTimeFromEpoch();
@@ -100,7 +108,7 @@ TEST(Utils, Time32ToTimeStampArray) {
                             arrow::Type::TIMESTAMP);
 }
 
-TEST(Utils, Time64ToTimeStampArray) {
+TEST_F(UtilTestsWithCompute, Time64ToTimeStampArray) {
   std::vector<int64_t> input_data = {1579489200000, 1646881200000};
 
   const auto seconds_from_epoch = odbcabstraction::GetTodayTimeFromEpoch();
@@ -120,7 +128,7 @@ TEST(Utils, Time64ToTimeStampArray) {
                             arrow::Type::TIMESTAMP);
 }
 
-TEST(Utils, StringToDateArray) {
+TEST_F(UtilTestsWithCompute, StringToDateArray) {
   std::shared_ptr<arrow::Array> expected;
   arrow::ArrayFromVector<arrow::Date64Type, int64_t>({1579489200000, 1646881200000},
                                                      &expected);
@@ -129,7 +137,7 @@ TEST(Utils, StringToDateArray) {
                       odbcabstraction::CDataType_DATE, arrow::Type::DATE64);
 }
 
-TEST(Utils, StringToTimeArray) {
+TEST_F(UtilTestsWithCompute, StringToTimeArray) {
   std::shared_ptr<arrow::Array> expected;
   arrow::ArrayFromVector<arrow::Time64Type, int64_t>(
       time64(arrow::TimeUnit::MICRO), {36000000000, 43200000000}, &expected);


### PR DESCRIPTION
As per changes from https://github.com/apache/arrow/issues/46261, we need to initialize Kernel library explicitly to get the functions registered.
Same as #50 except I wanted to fix the branch names. 