### PR TITLE
SQLFetchScroll Implementation

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/entry_points.cc
+++ b/cpp/src/arrow/flight/sql/odbc/entry_points.cc
@@ -137,6 +137,11 @@ SQLRETURN SQL_API SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* queryText,
 
 SQLRETURN SQL_API SQLFetch(SQLHSTMT stmt) { return arrow::SQLFetch(stmt); }
 
+SQLRETURN SQL_API SQLFetchScroll(SQLHSTMT stmt, SQLSMALLINT fetchOrientation,
+                                 SQLLEN fetchOffset) {
+  return arrow::SQLFetchScroll(stmt, fetchOrientation, fetchOffset);
+}
+
 SQLRETURN SQL_API SQLGetData(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
                              SQLPOINTER dataPtr, SQLLEN bufferLength,
                              SQLLEN* indicatorPtr) {

--- a/cpp/src/arrow/flight/sql/odbc/entry_points.cc
+++ b/cpp/src/arrow/flight/sql/odbc/entry_points.cc
@@ -150,15 +150,11 @@ SQLRETURN SQL_API SQLPrepare(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER text
 
 SQLRETURN SQL_API SQLExecute(SQLHSTMT stmt) { return arrow::SQLExecute(stmt); }
 
-SQLRETURN SQL_API SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT columnNumber,
-                             SQLSMALLINT targetType, SQLPOINTER targetValuePtr,
-                             SQLLEN bufferLength, SQLLEN* strLen_or_IndPtr) {
-  LOG_DEBUG(
-      "SQLBindCol called with stmt: {}, columnNumber: {}, targetType: {}, "
-      "targetValuePtr: {}, bufferLength: {}, strLen_or_IndPtr: {}",
-      stmt, columnNumber, targetType, targetValuePtr, bufferLength,
-      fmt::ptr(strLen_or_IndPtr));
-  return SQL_ERROR;
+SQLRETURN SQL_API SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
+                             SQLPOINTER dataPtr, SQLLEN bufferLength,
+                             SQLLEN* indicatorPtr) {
+  return arrow::SQLBindCol(stmt, recordNumber, cType, dataPtr, bufferLength,
+                           indicatorPtr);
 }
 
 SQLRETURN SQL_API SQLCancel(SQLHSTMT stmt) {

--- a/cpp/src/arrow/flight/sql/odbc/odbc.def
+++ b/cpp/src/arrow/flight/sql/odbc/odbc.def
@@ -34,6 +34,7 @@ EXPORTS
 	SQLExecDirectW
 	SQLExecute
 	SQLFetch
+	SQLFetchScroll
 	SQLForeignKeysW
 	SQLFreeEnv
 	SQLFreeConnect

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -982,8 +982,14 @@ SQLRETURN SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType
       "SQLBindCol called with stmt: {}, recordNumber: {}, cType: {}, "
       "dataPtr: {}, bufferLength: {}, strLen_or_IndPtr: {}",
       stmt, recordNumber, cType, dataPtr, bufferLength, fmt::ptr(indicatorPtr));
-  return SQL_ERROR;
-  //-AL - TODO: implement SQLBindCol functionality
+  using ODBC::ODBCDescriptor;
+  using ODBC::ODBCStatement;
+  return ODBCStatement::ExecuteWithDiagnostics(stmt, SQL_ERROR, [=]() {
+    ODBCStatement* statement = reinterpret_cast<ODBCStatement*>(stmt);
+    ODBCDescriptor* ard = statement->GetARD();
+    ard->BindCol(recordNumber, cType, dataPtr, bufferLength, indicatorPtr);
+    return SQL_SUCCESS;
+  });
 }
 
 SQLRETURN SQLGetData(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -197,8 +197,6 @@ SQLRETURN SQLFreeStmt(SQLHSTMT handle, SQLUSMALLINT option) {
       return SQLFreeHandle(SQL_HANDLE_STMT, handle);
     }
 
-    // TODO Implement SQLBindCol -AL-
-    // Implement SQL_UNBIND in SQLFreeStmt
     case SQL_UNBIND: {
       using ODBC::ODBCDescriptor;
       using ODBC::ODBCStatement;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -976,6 +976,16 @@ SQLRETURN SQLFetch(SQLHSTMT stmt) {
   });
 }
 
+SQLRETURN SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
+                     SQLPOINTER dataPtr, SQLLEN bufferLength, SQLLEN* indicatorPtr) {
+  LOG_DEBUG(
+      "SQLBindCol called with stmt: {}, recordNumber: {}, cType: {}, "
+      "dataPtr: {}, bufferLength: {}, strLen_or_IndPtr: {}",
+      stmt, recordNumber, cType, dataPtr, bufferLength, fmt::ptr(indicatorPtr));
+  return SQL_ERROR;
+  //-AL - TODO: implement SQLBindCol functionality
+}
+
 SQLRETURN SQLGetData(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
                      SQLPOINTER dataPtr, SQLLEN bufferLength, SQLLEN* indicatorPtr) {
   // GH-46979: support SQL_C_GUID data type

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -983,6 +983,33 @@ SQLRETURN SQLFetch(SQLHSTMT stmt) {
   });
 }
 
+SQLRETURN SQLFetchScroll(SQLHSTMT stmt, SQLSMALLINT fetchOrientation,
+                         SQLLEN fetchOffset) {
+  LOG_DEBUG("SQLFetchScroll called with stmt: {}, fetchOrientation: {}, fetchOffset: {}",
+            stmt, fetchOrientation, fetchOffset);
+  using ODBC::ODBCDescriptor;
+  using ODBC::ODBCStatement;
+  return ODBCStatement::ExecuteWithDiagnostics(stmt, SQL_ERROR, [=]() {
+    if (fetchOrientation != SQL_FETCH_NEXT) {
+      throw DriverException("Optional feature not supported.", "HYC00");
+    }
+    // fetchOffset is ignored as only SQL_FETCH_NEXT is supported
+
+    ODBCStatement* statement = reinterpret_cast<ODBCStatement*>(stmt);
+
+    // The SQL_ATTR_ROW_ARRAY_SIZE statement attribute specifies the number of rows in the
+    // rowset.
+    ODBCDescriptor* ard = statement->GetARD();
+    size_t rows = static_cast<size_t>(ard->GetArraySize());
+    if (statement->Fetch(rows)) {
+      return SQL_SUCCESS;
+    } else {
+      // Reached the end of rowset
+      return SQL_NO_DATA;
+    }
+  });
+}
+
 SQLRETURN SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
                      SQLPOINTER dataPtr, SQLLEN bufferLength, SQLLEN* indicatorPtr) {
   LOG_DEBUG(

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -1068,7 +1068,7 @@ SQLRETURN SQLNumResultCols(SQLHSTMT stmt, SQLSMALLINT* columnCountPtr) {
   });
 }
 
-SQLRETURN SQL_API SQLRowCount(SQLHSTMT stmt, SQLLEN* rowCountPtr) {
+SQLRETURN SQLRowCount(SQLHSTMT stmt, SQLLEN* rowCountPtr) {
   LOG_DEBUG("SQLRowCount called with stmt: {}, columnCountPtr: {}", stmt,
             fmt::ptr(rowCountPtr));
   // TODO: write tests for SQLRowCount

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.h
@@ -68,6 +68,8 @@ SQLRETURN SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER textLengt
 SQLRETURN SQLPrepare(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER textLength);
 SQLRETURN SQLExecute(SQLHSTMT stmt);
 SQLRETURN SQLFetch(SQLHSTMT stmt);
+SQLRETURN SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
+                     SQLPOINTER dataPtr, SQLLEN bufferLength, SQLLEN* indicatorPtr);
 SQLRETURN SQLGetData(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
                      SQLPOINTER dataPtr, SQLLEN bufferLength, SQLLEN* indicatorPtr);
 SQLRETURN SQLMoreResults(SQLHSTMT stmt);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.h
@@ -68,6 +68,7 @@ SQLRETURN SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER textLengt
 SQLRETURN SQLPrepare(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER textLength);
 SQLRETURN SQLExecute(SQLHSTMT stmt);
 SQLRETURN SQLFetch(SQLHSTMT stmt);
+SQLRETURN SQLFetchScroll(SQLHSTMT stmt, SQLSMALLINT fetchOrientation, SQLLEN fetchOffset);
 SQLRETURN SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
                      SQLPOINTER dataPtr, SQLLEN bufferLength, SQLLEN* indicatorPtr);
 SQLRETURN SQLGetData(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -167,6 +167,7 @@ static constexpr std::string_view error_state_HY010 = "HY010";
 static constexpr std::string_view error_state_HY024 = "HY024";
 static constexpr std::string_view error_state_HY092 = "HY092";
 static constexpr std::string_view error_state_HYC00 = "HYC00";
+static constexpr std::string_view error_state_HY106 = "HY106";
 static constexpr std::string_view error_state_HY114 = "HY114";
 static constexpr std::string_view error_state_HY017 = "HY017";
 static constexpr std::string_view error_state_HY118 = "HY118";

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -1432,9 +1432,325 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
   this->disconnect();
 }
 
-//-AL- TODO: add tests that use SQLBindCol to fetch all data <TestSQLExecDirectDataQuery>.
+//-AL- TODOs for tests
 // TODO: add tests that replicate queries for 1) varibinary (mock server)
 // <TestSQLExecDirectVarbinaryQuery>
 //  and 2) time (remote server) <TestSQLExecDirectTimeQuery>
+// TODO: add tests for indicator pointer for null data etc <TestSQLExecDirectNullQuery>
+// TODO: add SQLBindCol tests for row fetching <TestSQLExecDirectRowFetching>
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColSimpleQuery) {
+  // -AL- TODO can perhaps delete this test later after TestSQLBindColDataQuery is done,
+  // this is just proof of concept
+  this->connect();
+
+  // Numeric Types
+
+  // Signed Tiny Int
+  int8_t stiny_int_val;
+  SQLLEN buf_len = sizeof(stiny_int_val);
+  SQLLEN ind;
+
+  SQLRETURN ret =
+      SQLBindCol(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind);
+
+  std::wstring wsql = L"SELECT 1;";
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  ret =
+      SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLFetch(this->stmt);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Check that 1 is fetched
+  EXPECT_EQ(stiny_int_val, 1);
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColDataQuery) {
+  this->connect();
+
+  // Numeric Types
+
+  // Signed Tiny Int
+  int8_t stiny_int_val_min;
+  int8_t stiny_int_val_max;
+  SQLLEN buf_len = 0;
+  SQLLEN ind;
+
+  SQLRETURN ret =
+      SQLBindCol(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+  
+  ret = SQLBindCol(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Unsigned Tiny Int
+  uint8_t utiny_int_val_min;
+  uint8_t utiny_int_val_max;
+
+  ret = SQLBindCol(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Signed Small Int
+  int16_t ssmall_int_val_min;
+  int16_t ssmall_int_val_max;
+
+  ret = SQLBindCol(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Unsigned Small Int
+  uint16_t usmall_int_val_min;
+  uint16_t usmall_int_val_max;
+
+  ret = SQLBindCol(this->stmt, 7, SQL_C_USHORT, &usmall_int_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 8, SQL_C_USHORT, &usmall_int_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Signed Integer
+  SQLINTEGER slong_val_min;
+  SQLINTEGER slong_val_max;
+
+  ret = SQLBindCol(this->stmt, 9, SQL_C_SLONG, &slong_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 10, SQL_C_SLONG, &slong_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Unsigned Integer
+  SQLUINTEGER ulong_val_min;
+  SQLUINTEGER ulong_val_max;
+
+  ret = SQLBindCol(this->stmt, 11, SQL_C_ULONG, &ulong_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 12, SQL_C_ULONG, &ulong_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Signed Big Int
+  SQLBIGINT sbig_int_val_min;
+  SQLBIGINT sbig_int_val_max;
+
+  ret = SQLBindCol(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Unsigned Big Int
+  SQLUBIGINT ubig_int_val_min;
+  SQLUBIGINT ubig_int_val_max;
+
+  ret = SQLBindCol(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Decimal
+  SQL_NUMERIC_STRUCT decimal_val_neg;
+  SQL_NUMERIC_STRUCT decimal_val_pos;
+  memset(&decimal_val_neg, 0, sizeof(decimal_val_neg));
+  memset(&decimal_val_pos, 0, sizeof(decimal_val_pos));
+
+  ret = SQLBindCol(this->stmt, 17, SQL_C_NUMERIC, &decimal_val_neg, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 18, SQL_C_NUMERIC, &decimal_val_pos, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Float
+  float float_val_min;
+  float float_val_max;
+
+  ret = SQLBindCol(this->stmt, 19, SQL_C_FLOAT, &float_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 20, SQL_C_FLOAT, &float_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Double
+  SQLDOUBLE double_val_min;
+  SQLDOUBLE double_val_max;
+
+  ret = SQLBindCol(this->stmt, 21, SQL_C_DOUBLE, &double_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 22, SQL_C_DOUBLE, &double_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Bit
+  bool bit_val_false;
+  bool bit_val_true;
+
+  ret = SQLBindCol(this->stmt, 23, SQL_C_BIT, &bit_val_false, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 24, SQL_C_BIT, &bit_val_true, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Characters
+  SQLCHAR char_val[2];
+  buf_len = sizeof(SQLCHAR) * 2;
+
+  ret = SQLBindCol(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  SQLWCHAR wchar_val[2];
+  constexpr size_t wchar_size = driver::odbcabstraction::GetSqlWCharSize();
+  buf_len = wchar_size * 2;
+
+  ret = SQLBindCol(this->stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  SQLWCHAR wvarchar_val[3];
+  buf_len = wchar_size * 3;
+
+  ret = SQLBindCol(this->stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  SQLCHAR varchar_val[4];
+  buf_len = sizeof(SQLCHAR) * 4;
+
+  ret = SQLBindCol(this->stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Date and Timestamp
+  SQL_DATE_STRUCT date_val_min{}, date_val_max{};
+  buf_len = 0;
+
+  ret = SQLBindCol(this->stmt, 29, SQL_C_TYPE_DATE, &date_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLBindCol(this->stmt, 30, SQL_C_TYPE_DATE, &date_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  SQL_TIMESTAMP_STRUCT timestamp_val_min{}, timestamp_val_max{};
+
+  ret =
+      SQLBindCol(this->stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_val_min, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret =
+      SQLBindCol(this->stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_val_max, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Execute query and fetch data once since there is only 1 row.
+  std::wstring wsql = this->getQueryAllDataTypes();
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  ret =
+      SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLFetch(this->stmt);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Data verification
+
+  // Signed Tiny Int
+  EXPECT_EQ(stiny_int_val_min, std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(stiny_int_val_max, std::numeric_limits<int8_t>::max());
+
+  // Unsigned Tiny Int
+  EXPECT_EQ(utiny_int_val_min, std::numeric_limits<uint8_t>::min());
+  EXPECT_EQ(utiny_int_val_max, std::numeric_limits<uint8_t>::max());
+
+  // Signed Small Int
+  EXPECT_EQ(ssmall_int_val_min, std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(ssmall_int_val_max, std::numeric_limits<int16_t>::max());
+
+  // Unsigned Small Int
+  EXPECT_EQ(usmall_int_val_min, std::numeric_limits<uint16_t>::min());
+  EXPECT_EQ(usmall_int_val_max, std::numeric_limits<uint16_t>::max());
+
+  // Signed Long
+  EXPECT_EQ(slong_val_min, std::numeric_limits<SQLINTEGER>::min());
+  EXPECT_EQ(slong_val_max, std::numeric_limits<SQLINTEGER>::max());
+
+  // Unsigned Long
+  EXPECT_EQ(ulong_val_min, std::numeric_limits<SQLUINTEGER>::min());
+  EXPECT_EQ(ulong_val_max, std::numeric_limits<SQLUINTEGER>::max());
+
+  // Signed Big Int
+  EXPECT_EQ(sbig_int_val_min, std::numeric_limits<SQLBIGINT>::min());
+  EXPECT_EQ(sbig_int_val_max, std::numeric_limits<SQLBIGINT>::max());
+
+  // Unsigned Big Int
+  EXPECT_EQ(ubig_int_val_min, std::numeric_limits<SQLUBIGINT>::min());
+  EXPECT_EQ(ubig_int_val_max, std::numeric_limits<SQLUBIGINT>::max());
+
+  // Decimal
+  EXPECT_EQ(decimal_val_neg.sign, 0);
+  EXPECT_EQ(decimal_val_neg.scale, 0);
+  EXPECT_EQ(decimal_val_neg.precision, 38);
+  EXPECT_THAT(decimal_val_neg.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0,
+                                                          0, 0, 0, 0, 0, 0, 0, 0, 0));
+
+  EXPECT_EQ(decimal_val_pos.sign, 1);
+  EXPECT_EQ(decimal_val_pos.scale, 0);
+  EXPECT_EQ(decimal_val_pos.precision, 38);
+  EXPECT_THAT(decimal_val_pos.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0,
+                                                          0, 0, 0, 0, 0, 0, 0, 0, 0));
+
+  // Float
+  EXPECT_EQ(float_val_min, -std::numeric_limits<float>::max());
+  EXPECT_EQ(float_val_max, std::numeric_limits<float>::max());
+
+  // Double
+  EXPECT_EQ(double_val_min, -std::numeric_limits<SQLDOUBLE>::max());
+  EXPECT_EQ(double_val_max, std::numeric_limits<SQLDOUBLE>::max());
+
+  // Bit
+  EXPECT_EQ(bit_val_false, false);
+  EXPECT_EQ(bit_val_true, true);
+
+  // Characters
+  EXPECT_EQ(char_val[0], 'Z');
+  EXPECT_EQ(wchar_val[0], L'你');
+  EXPECT_EQ(wvarchar_val[0], L'你');
+  EXPECT_EQ(wvarchar_val[1], L'好');
+
+  EXPECT_EQ(varchar_val[0], 'X');
+  EXPECT_EQ(varchar_val[1], 'Y');
+  EXPECT_EQ(varchar_val[2], 'Z');
+
+  // Date
+  EXPECT_EQ(date_val_min.day, 1);
+  EXPECT_EQ(date_val_min.month, 1);
+  EXPECT_EQ(date_val_min.year, 1400);
+
+  EXPECT_EQ(date_val_max.day, 31);
+  EXPECT_EQ(date_val_max.month, 12);
+  EXPECT_EQ(date_val_max.year, 9999);
+
+  // Timestamp
+  EXPECT_EQ(timestamp_val_min.day, 1);
+  EXPECT_EQ(timestamp_val_min.month, 1);
+  EXPECT_EQ(timestamp_val_min.year, 1400);
+  EXPECT_EQ(timestamp_val_min.hour, 0);
+  EXPECT_EQ(timestamp_val_min.minute, 0);
+  EXPECT_EQ(timestamp_val_min.second, 0);
+  EXPECT_EQ(timestamp_val_min.fraction, 0);
+
+  EXPECT_EQ(timestamp_val_max.day, 31);
+  EXPECT_EQ(timestamp_val_max.month, 12);
+  EXPECT_EQ(timestamp_val_max.year, 9999);
+  EXPECT_EQ(timestamp_val_max.hour, 23);
+  EXPECT_EQ(timestamp_val_max.minute, 59);
+  EXPECT_EQ(timestamp_val_max.second, 59);
+  EXPECT_EQ(timestamp_val_max.fraction, 0);
+
+  this->disconnect();
+}
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -1432,4 +1432,9 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
   this->disconnect();
 }
 
+//-AL- TODO: add tests that use SQLBindCol to fetch all data <TestSQLExecDirectDataQuery>.
+// TODO: add tests that replicate queries for 1) varibinary (mock server)
+// <TestSQLExecDirectVarbinaryQuery>
+//  and 2) time (remote server) <TestSQLExecDirectTimeQuery>
+
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -832,24 +832,28 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectRowFetching) {
   SQLLEN ind;
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
-
   EXPECT_EQ(ret, SQL_SUCCESS);
+
   // Verify 1 is returned
   EXPECT_EQ(val, 1);
 
   // Fetch row 2
   ret = SQLFetch(this->stmt);
-  ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
-
   EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
   // Verify 2 is returned
   EXPECT_EQ(val, 2);
 
   // Fetch row 3
   ret = SQLFetch(this->stmt);
-  ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
-
   EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
   // Verify 3 is returned
   EXPECT_EQ(val, 3);
 
@@ -858,10 +862,121 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectRowFetching) {
   EXPECT_EQ(ret, SQL_NO_DATA);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind);
+  EXPECT_EQ(ret, SQL_ERROR);
+
+  // Invalid cursor state
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
+
+  this->disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
+  this->connect();
+
+  std::wstring wsql =
+      LR"(
+    SELECT 1 AS small_table
+    UNION ALL
+    SELECT 2
+    UNION ALL
+    SELECT 3;
+  )";
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  SQLRETURN ret =
+      SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Fetch row 1
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  SQLINTEGER val;
+  SQLLEN buf_len = sizeof(val);
+  SQLLEN ind;
+
+  ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
+
+  EXPECT_EQ(ret, SQL_SUCCESS);
+  // Verify 1 is returned
+  EXPECT_EQ(val, 1);
+
+  // Fetch row 2
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Verify 2 is returned
+  EXPECT_EQ(val, 2);
+
+  // Fetch row 3
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Verify 3 is returned
+  EXPECT_EQ(val, 3);
+
+  // Verify result set has no more data beyond row 3
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
+  EXPECT_EQ(ret, SQL_NO_DATA);
+
+  ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind);
 
   EXPECT_EQ(ret, SQL_ERROR);
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
+
+  this->disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollUnsupportedOrientation) {
+  // SQL_FETCH_PRIOR is the only supported fetch orientation.
+  this->connect();
+
+  std::wstring wsql = L"SELECT 1;";
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  SQLRETURN ret =
+      SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_PRIOR, 0);
+  EXPECT_EQ(ret, SQL_ERROR);
+
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
+
+  SQLLEN fetch_offset = 1;
+
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_RELATIVE, fetch_offset);
+  EXPECT_EQ(ret, SQL_ERROR);
+
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
+
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_ABSOLUTE, fetch_offset);
+  EXPECT_EQ(ret, SQL_ERROR);
+
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
+
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_FIRST, 0);
+  EXPECT_EQ(ret, SQL_ERROR);
+
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
+
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_LAST, 0);
+  EXPECT_EQ(ret, SQL_ERROR);
+
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
+
+  ret = SQLFetchScroll(this->stmt, SQL_FETCH_BOOKMARK, fetch_offset);
+  EXPECT_EQ(ret, SQL_ERROR);
+
+  // DM returns state HY106 for SQL_FETCH_BOOKMARK
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY106);
 
   this->disconnect();
 }

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -873,9 +873,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectRowFetching) {
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
   this->connect();
 
-  // -AL- todo uncomment out after SQLSetStmtAttr is finished
-  // SQLLEN rows_fetched;
-  // ret = SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
+  SQLLEN rows_fetched;
+  SQLRETURN ret = SQLSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
 
   std::wstring wsql =
       LR"(
@@ -887,8 +886,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
   )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
-  SQLRETURN ret =
-      SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
+  ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Fetch row 1
@@ -904,16 +902,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   // Verify 1 is returned
   EXPECT_EQ(val, 1);
-
-  // -AL- todo uncomment out after SQLSetStmtAttr is finished
   // Verify 1 row is fetched
-  // EXPECT_EQ(rows_fetched, 1);
-
-  // TODO: -AL- for SQLFetchScroll,
-  // add tests for SQL_ATTR_ROWS_FETCHED_PTR using SQLGetStmtAttr;
-  // can also modify existing test. Value should be 1,
-  // but the value should increase as more rows are fetched
-  // -AL- I should add more checks, like = 2 and 3 after fetch is called more times.
+  EXPECT_EQ(rows_fetched, 1);
 
   // Fetch row 2
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
@@ -924,6 +914,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
 
   // Verify 2 is returned
   EXPECT_EQ(val, 2);
+  // Verify 1 row is fetched in the last SQLFetchScroll call
+  EXPECT_EQ(rows_fetched, 1);
 
   // Fetch row 3
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
@@ -934,6 +926,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
 
   // Verify 3 is returned
   EXPECT_EQ(val, 3);
+  // Verify 1 row is fetched in the last SQLFetchScroll call
+  EXPECT_EQ(rows_fetched, 1);
 
   // Verify result set has no more data beyond row 3
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -873,6 +873,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectRowFetching) {
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
   this->connect();
 
+  // -AL- todo uncomment out after SQLSetStmtAttr is finished
+  // SQLLEN rows_fetched;
+  // ret = SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
+
   std::wstring wsql =
       LR"(
     SELECT 1 AS small_table
@@ -900,6 +904,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   // Verify 1 is returned
   EXPECT_EQ(val, 1);
+
+  // -AL- todo uncomment out after SQLSetStmtAttr is finished
+  // Verify 1 row is fetched
+  // EXPECT_EQ(rows_fetched, 1);
+
+  // TODO: -AL- for SQLFetchScroll,
+  // add tests for SQL_ATTR_ROWS_FETCHED_PTR using SQLGetStmtAttr;
+  // can also modify existing test. Value should be 1,
+  // but the value should increase as more rows are fetched
+  // -AL- I should add more checks, like = 2 and 3 after fetch is called more times.
 
   // Fetch row 2
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);


### PR DESCRIPTION
Only fetch orientation `SQL_FETCH_NEXT` is supported by the driver. 