### PR TITLE
Enable TestCloseConnectionWithOpenStatement test case

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -1016,9 +1016,6 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLAllocFreeStmt) {
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestCloseConnectionWithOpenStatement) {
-  // Test is disabled as disconnecting without closing statement fails on Windows.
-  // This test case can be potentially used on macOS/Linux.
-  GTEST_SKIP();
   // ODBC Environment
   SQLHENV env;
   SQLHDBC conn;


### PR DESCRIPTION
Enable TestCloseConnectionWithOpenStatement test case as with merge of the GetStmtAttr/SetStmtAttr functionality, the connection can be successfully closed with an open statement.
