### PR TITLE
Add Descriptor support in SQLAllocHandle and SQLFreeHandle

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -107,8 +107,6 @@ SQLRETURN SQLAllocHandle(SQLSMALLINT type, SQLHANDLE parent, SQLHANDLE* result) 
       });
     }
 
-    // TODO -AL- Implement for case of descriptor, explicit descriptors are associated
-    // with connection handles.
     case SQL_HANDLE_DESC: {
       using ODBC::ODBCConnection;
       using ODBC::ODBCDescriptor;
@@ -184,7 +182,6 @@ SQLRETURN SQLFreeHandle(SQLSMALLINT type, SQLHANDLE handle) {
     }
 
     case SQL_HANDLE_DESC: {
-      // -AL- todo free Descriptor
       using ODBC::ODBCDescriptor;
 
       ODBCDescriptor* descriptor = reinterpret_cast<ODBCDescriptor*>(handle);
@@ -309,7 +306,6 @@ SQLRETURN SQLGetDiagField(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT 
     }
 
     case SQL_HANDLE_DESC: {
-      // -AL- todo add support here
       ODBCDescriptor* descriptor = reinterpret_cast<ODBCDescriptor*>(handle);
       diagnostics = &descriptor->GetDiagnostics();
       break;
@@ -440,7 +436,6 @@ SQLRETURN SQLGetDiagField(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT 
           }
 
           case SQL_HANDLE_DESC: {
-            // TODO -AL- Implement for case of descriptor
             ODBCDescriptor* descriptor = reinterpret_cast<ODBCDescriptor*>(handle);
             ODBCConnection* connection = &descriptor->GetConnection();
             std::string dsn = connection->GetDSN();
@@ -566,7 +561,6 @@ SQLRETURN SQLGetDiagRec(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT re
     }
 
     case SQL_HANDLE_DESC: {
-      // -AL- todo add support here. + tests (?)
       auto* descriptor = ODBCDescriptor::of(handle);
       diagnostics = &descriptor->GetDiagnostics();
       break;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -273,6 +273,7 @@ SQLRETURN SQLGetDiagField(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT 
   using driver::odbcabstraction::Diagnostics;
   using ODBC::GetStringAttribute;
   using ODBC::ODBCConnection;
+  using ODBC::ODBCDescriptor;
   using ODBC::ODBCEnvironment;
   using ODBC::ODBCStatement;
 
@@ -308,7 +309,10 @@ SQLRETURN SQLGetDiagField(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT 
     }
 
     case SQL_HANDLE_DESC: {
-      return SQL_ERROR;
+      // -AL- todo add support here
+      ODBCDescriptor* descriptor = reinterpret_cast<ODBCDescriptor*>(handle);
+      diagnostics = &descriptor->GetDiagnostics();
+      break;
     }
 
     case SQL_HANDLE_STMT: {
@@ -436,8 +440,13 @@ SQLRETURN SQLGetDiagField(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT 
           }
 
           case SQL_HANDLE_DESC: {
-            // TODO Implement for case of descriptor
-            return SQL_ERROR;
+            // TODO -AL- Implement for case of descriptor
+            ODBCDescriptor* descriptor = reinterpret_cast<ODBCDescriptor*>(handle);
+            ODBCConnection* connection = &descriptor->GetConnection();
+            std::string dsn = connection->GetDSN();
+            return GetStringAttribute(isUnicode, dsn, true, diagInfoPtr, bufferLength,
+                                      stringLengthPtr, *diagnostics);
+            break;
           }
 
           case SQL_HANDLE_STMT: {
@@ -526,6 +535,7 @@ SQLRETURN SQLGetDiagRec(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT re
   using driver::odbcabstraction::Diagnostics;
   using ODBC::GetStringAttribute;
   using ODBC::ODBCConnection;
+  using ODBC::ODBCDescriptor;
   using ODBC::ODBCEnvironment;
   using ODBC::ODBCStatement;
 
@@ -556,7 +566,10 @@ SQLRETURN SQLGetDiagRec(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT re
     }
 
     case SQL_HANDLE_DESC: {
-      return SQL_ERROR;
+      // -AL- todo add support here. + tests (?)
+      auto* descriptor = ODBCDescriptor::of(handle);
+      diagnostics = &descriptor->GetDiagnostics();
+      break;
     }
 
     case SQL_HANDLE_STMT: {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
@@ -77,6 +77,8 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   void SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value, SQLINTEGER bufferSize,
                    bool isUnicode);
 
+  // -AL- Add doc comments. bool is just to differentiate between apd and ard,
+  // not "yes -> revert" or "no -> don't revert"
   void RevertAppDescriptor(bool isApd);
 
   inline ODBCDescriptor* GetIRD() { return m_ird.get(); }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
@@ -77,8 +77,11 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   void SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value, SQLINTEGER bufferSize,
                    bool isUnicode);
 
-  // -AL- Add doc comments. bool is just to differentiate between apd and ard,
-  // not "yes -> revert" or "no -> don't revert"
+  /**
+   * @brief Revert back to implicitly allocated internal descriptors.
+   * isApd as True indicates APD descritor is to be reverted.
+   * isApd as False indicates ARD descritor is to be reverted.
+   */
   void RevertAppDescriptor(bool isApd);
 
   inline ODBCDescriptor* GetIRD() { return m_ird.get(); }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
@@ -462,6 +462,10 @@ void ODBCDescriptor::DetachFromStatement(ODBCStatement* statement, bool isApd) {
   }
 }
 
+// -AL- driver reverts back app descritor here.
+// all statement registered to this descriptor will have
+// their APD/ARD reverted.
+
 void ODBCDescriptor::ReleaseDescriptor() {
   for (ODBCStatement* stmt : m_registeredOnStatementsAsApd) {
     stmt->RevertAppDescriptor(true);

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
@@ -462,10 +462,6 @@ void ODBCDescriptor::DetachFromStatement(ODBCStatement* statement, bool isApd) {
   }
 }
 
-// -AL- driver reverts back app descritor here.
-// all statement registered to this descriptor will have
-// their APD/ARD reverted.
-
 void ODBCDescriptor::ReleaseDescriptor() {
   for (ODBCStatement* stmt : m_registeredOnStatementsAsApd) {
     stmt->RevertAppDescriptor(true);

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -1018,25 +1018,6 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrDescriptor) {
   this->disconnect();
 }
 
-// -AL- todo move this test to errors_test
-TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForDescriptorFailure) {
-  // -AL- todo work on this test next, need to generate an descriptor error
-  this->connect();
-  SQLHDESC descriptor;
-
-  // Allocate a descriptor using alloc handle
-  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor);
-
-  EXPECT_EQ(ret, SQL_SUCCESS);
-
-  // Free descriptor handle
-  ret = SQLFreeHandle(SQL_HANDLE_DESC, descriptor);
-
-  EXPECT_EQ(ret, SQL_SUCCESS);
-
-  this->disconnect();
-}
-
 }  // namespace arrow::flight::sql::odbc
 
 int main(int argc, char** argv) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -1018,6 +1018,25 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrDescriptor) {
   this->disconnect();
 }
 
+// -AL- todo move this test to errors_test
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForDescriptorFailure) {
+  // -AL- todo work on this test next, need to generate an descriptor error
+  this->connect();
+  SQLHDESC descriptor;
+
+  // Allocate a descriptor using alloc handle
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor);
+
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  // Free descriptor handle
+  ret = SQLFreeHandle(SQL_HANDLE_DESC, descriptor);
+
+  EXPECT_EQ(ret, SQL_SUCCESS);
+
+  this->disconnect();
+}
+
 }  // namespace arrow::flight::sql::odbc
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
* Add support for allocating and freeing descriptors.
* Add tests for retrieving descriptor handle errors from driver manager, as our driver doesn't have descriptor-specific APIs implemented. 