### PR TITLE
Fix connection issues servers that require data in handshake

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
@@ -58,9 +58,9 @@ class NoOpClientAuthHandler : public arrow::flight::ClientAuthHandler {
 
   arrow::Status Authenticate(arrow::flight::ClientAuthSender* outgoing,
                              arrow::flight::ClientAuthReader* incoming) override {
-    // Return OK Status. The server should ignore this and just accept any Handshake
-    // request.
-    return arrow::Status::OK();
+    // The server should ignore this and just accept any Handshake
+    // request. Some servers do not allow authentication with no handshakes.
+    return outgoing->Write(std::string());
   }
 
   arrow::Status GetToken(std::string* token) override {


### PR DESCRIPTION
We changed `outgoing->Write(std::string())` to `arrow::Status::OK()` in #63, but it turns out some servers actually require an empty handshake in order to properly validate the authentication. For example, without `Write`, some servers can return `Invalid handshake. No payload provided` errors. 