### PR TITLE
Register ODBC Driver on Windows 

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
@@ -122,6 +122,7 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
             PATTERN "gmock.dll" EXCLUDE
             PATTERN "gtest.dll" EXCLUDE
             PATTERN "gtest_main.dll" EXCLUDE)
+    set(CPACK_WIX_EXTRA_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/install/arrow-flight-sql-odbc.wxs")
   endif()
 
   get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)

--- a/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
@@ -99,9 +99,10 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
 
   set(CPACK_RESOURCE_FILE_LICENSE
       "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../LICENSE.txt")
-  # Tentative version 1.0.0 (patch version is not set)
+  # Tentative version 1.0.0
   set(CPACK_PACKAGE_VERSION_MAJOR "1")
   set(CPACK_PACKAGE_VERSION_MINOR "0")
+  set(CPACK_PACKAGE_VERSION_PATCH "0")
 
   set(CPACK_PACKAGE_NAME "Apache Arrow Flight SQL ODBC")
   set(CPACK_PACKAGE_VENDOR "Apache Arrow")

--- a/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
@@ -123,6 +123,7 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
             PATTERN "gtest.dll" EXCLUDE
             PATTERN "gtest_main.dll" EXCLUDE)
     set(CPACK_WIX_EXTRA_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/install/arrow-flight-sql-odbc.wxs")
+    set(CPACK_WIX_PATCH_FILE "${CMAKE_CURRENT_SOURCE_DIR}/install/arrow-flight-sql-odbc-patch.xml")
   endif()
 
   get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)

--- a/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
@@ -115,15 +115,28 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
             DESTINATION bin
             COMPONENT flight_sql_odbc_lib
             FILES_MATCHING
-            PATTERN "*.dll"
-            PATTERN "arrow_flight_testing.dll" EXCLUDE
-            PATTERN "arrow_testing.dll" EXCLUDE
-            PATTERN "gflags.dll" EXCLUDE
-            PATTERN "gmock.dll" EXCLUDE
-            PATTERN "gtest.dll" EXCLUDE
-            PATTERN "gtest_main.dll" EXCLUDE)
-    set(CPACK_WIX_EXTRA_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/install/arrow-flight-sql-odbc.wxs")
-    set(CPACK_WIX_PATCH_FILE "${CMAKE_CURRENT_SOURCE_DIR}/install/arrow-flight-sql-odbc-patch.xml")
+            # Use regex for dll name patterns with versions
+            PATTERN "abseil_dll.dll"
+            PATTERN "arrow.dll"
+            PATTERN "arrow_compute.dll"
+            PATTERN "arrow_flight.dll"
+            PATTERN "arrow_flight_sql.dll"
+            PATTERN "arrow_flight_sql_odbc.dll"
+            PATTERN "boost_filesystem*.dll"
+            PATTERN "boost_locale*.dll"
+            PATTERN "cares.dll"
+            PATTERN "libcrypto*.dll"
+            PATTERN "libprotobuf.dll"
+            PATTERN "libssl*.dll"
+            PATTERN "re2.dll"
+            PATTERN "sqlite3.dll"
+            PATTERN "utf8proc.dll"
+            PATTERN "zlib1.dll")
+
+    set(CPACK_WIX_EXTRA_SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/install/arrow-flight-sql-odbc.wxs")
+    set(CPACK_WIX_PATCH_FILE
+        "${CMAKE_CURRENT_SOURCE_DIR}/install/arrow-flight-sql-odbc-patch.xml")
   endif()
 
   get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)

--- a/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
@@ -122,14 +122,12 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
             PATTERN "arrow_flight.dll"
             PATTERN "arrow_flight_sql.dll"
             PATTERN "arrow_flight_sql_odbc.dll"
-            PATTERN "boost_filesystem*.dll"
             PATTERN "boost_locale*.dll"
             PATTERN "cares.dll"
             PATTERN "libcrypto*.dll"
             PATTERN "libprotobuf.dll"
             PATTERN "libssl*.dll"
             PATTERN "re2.dll"
-            PATTERN "sqlite3.dll"
             PATTERN "utf8proc.dll"
             PATTERN "zlib1.dll")
 

--- a/cpp/src/arrow/flight/sql/odbc/README
+++ b/cpp/src/arrow/flight/sql/odbc/README
@@ -17,3 +17,10 @@ After the build succeeds, the ODBC DLL will be located in
 
 If the registration is successful, then Apache Arrow Flight SQL ODBC Driver 
 should show as an available ODBC driver in the x64 ODBC Driver Manager.
+
+Steps to Generate Windows Installer
+1. Build with  `ARROW_FLIGHT_SQL_ODBC=ON` and `ARROW_FLIGHT_SQL_ODBC_INSTALLER=ON`.
+2. `cd` to `build` folder.
+3. Run `cpack`. 
+
+If the generation is successful, you will find `Apache Arrow Flight SQL ODBC-<version>-win64.msi` generated under the `build` folder.

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc-patch.xml
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc-patch.xml
@@ -1,0 +1,5 @@
+<CPackWiXPatch>
+    <CPackWiXFragment Id="#PRODUCTFEATURE">
+        <ComponentRef Id="MyRegistryEntries"/>
+    </CPackWiXFragment>
+</CPackWiXPatch>

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc-patch.xml
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc-patch.xml
@@ -1,3 +1,20 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 <CPackWiXPatch>
     <CPackWiXFragment Id="#PRODUCTFEATURE">
         <ComponentRef Id="ODBCRegistryEntries"/>

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc-patch.xml
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc-patch.xml
@@ -1,5 +1,5 @@
 <CPackWiXPatch>
     <CPackWiXFragment Id="#PRODUCTFEATURE">
-        <ComponentRef Id="MyRegistryEntries"/>
+        <ComponentRef Id="ODBCRegistryEntries"/>
     </CPackWiXFragment>
 </CPackWiXPatch>

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
@@ -22,12 +22,22 @@
   <DirectoryRef Id="TARGETDIR">
   <!-- -AL- Registers Computer\HKEY_CURRENT_USER\Software\MyCompany\MyApplicationName -->
       <Component Id="MyRegistryEntries" Guid="C348B9F7-5E8D-415D-A001-D92F2D4EA013">
-          <RegistryKey Root="HKCU"
-                      Key="Software\MyCompany\MyApplicationName">
+          <!-- <File Id="ArrowFlightSqlOdbcDll" Name="arrow_flight_sql_odbc.dll" DiskId="1" Source="./bin/arrow_flight_sql_odbc.dll" KeyPath="yes"/> -AL- doesn't work -->
+          <!-- <File Id="ArrowFlightSqlOdbcDll" Name="arrow_flight_sql_odbc.dll" DiskId="1" Source="./release/Release/arrow_flight_sql_odbc.dll" KeyPath="yes"/> -->
+          
+          <!-- <File Id="ArrowFlightSqlOdbcDll" Name="arrow_flight_sql_odbc.dll" DiskId="1" Source="bin\arrow_flight_sql_odbc.dll" /> -AL- doesn't compile -->
+          
+          <RegistryValue Root='HKLM' Key='Software\ODBC\ODBCINST.INI\ODBC Drivers' Name='Apache Arrow Flight SQL ODBC Driver' Type='string' Value='Installed'/>
+
+          <RegistryKey Root="HKLM"
+                      Key="Software\ODBC\ODBCINST.INI\Apache Arrow Flight SQL ODBC Driver">
                       <!-- -AL- `action=` is removed, since it is WiX 3 ONLY -->
                 <!-- -AL- here we can have multiple key-value pairs as needed -->
-              <RegistryValue Type="integer" Name="SomeIntegerValue" Value="1" KeyPath="yes"/>
-              <RegistryValue Type="string" Value="Default Value"/>
+                <!-- -AL- CM_FP_flight_sql_odbc_lib.bin.arrow_flight_sql_odbc.dll is a generated file value from release-build\_CPack_Packages\win64\WIX\files.wxs -->
+                <RegistryValue Type="string" Name="DriverODBCVer" Value="03.00"/>
+                <RegistryValue Type="string" Name="Driver" Value="[#CM_FP_flight_sql_odbc_lib.bin.arrow_flight_sql_odbc.dll]"/>
+                <RegistryValue Type="string" Name="Setup" Value="[#CM_FP_flight_sql_odbc_lib.bin.arrow_flight_sql_odbc.dll]"/>
+                <RegistryValue Type="integer" Name="UsageCount" Value="1"/>
           </RegistryKey>
       </Component>
   </DirectoryRef>

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
@@ -20,20 +20,12 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Fragment>
   <DirectoryRef Id="TARGETDIR">
-  <!-- -AL- Registers Computer\HKEY_CURRENT_USER\Software\MyCompany\MyApplicationName -->
       <Component Id="MyRegistryEntries" Guid="C348B9F7-5E8D-415D-A001-D92F2D4EA013">
-          <!-- <File Id="ArrowFlightSqlOdbcDll" Name="arrow_flight_sql_odbc.dll" DiskId="1" Source="./bin/arrow_flight_sql_odbc.dll" KeyPath="yes"/> -AL- doesn't work -->
-          <!-- <File Id="ArrowFlightSqlOdbcDll" Name="arrow_flight_sql_odbc.dll" DiskId="1" Source="./release/Release/arrow_flight_sql_odbc.dll" KeyPath="yes"/> -->
-          
-          <!-- <File Id="ArrowFlightSqlOdbcDll" Name="arrow_flight_sql_odbc.dll" DiskId="1" Source="bin\arrow_flight_sql_odbc.dll" /> -AL- doesn't compile -->
-          
           <RegistryValue Root='HKLM' Key='Software\ODBC\ODBCINST.INI\ODBC Drivers' Name='Apache Arrow Flight SQL ODBC Driver' Type='string' Value='Installed'/>
 
           <RegistryKey Root="HKLM"
                       Key="Software\ODBC\ODBCINST.INI\Apache Arrow Flight SQL ODBC Driver">
-                      <!-- -AL- `action=` is removed, since it is WiX 3 ONLY -->
-                <!-- -AL- here we can have multiple key-value pairs as needed -->
-                <!-- -AL- CM_FP_flight_sql_odbc_lib.bin.arrow_flight_sql_odbc.dll is a generated file value from release-build\_CPack_Packages\win64\WIX\files.wxs -->
+                <!-- CM_FP_flight_sql_odbc_lib.bin.arrow_flight_sql_odbc.dll is a generated variable value from build\_CPack_Packages\win64\WIX\files.wxs -->
                 <RegistryValue Type="string" Name="DriverODBCVer" Value="03.00"/>
                 <RegistryValue Type="string" Name="Driver" Value="[#CM_FP_flight_sql_odbc_lib.bin.arrow_flight_sql_odbc.dll]"/>
                 <RegistryValue Type="string" Name="Setup" Value="[#CM_FP_flight_sql_odbc_lib.bin.arrow_flight_sql_odbc.dll]"/>

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="windows-1252"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+  <DirectoryRef Id="TARGETDIR">
+      <Component Id="MyRegistryEntries" Guid="C348B9F7-5E8D-415D-A001-D92F2D4EA013">
+          <RegistryKey Root="HKCU"
+                      Key="Software\MyCompany\MyApplicationName">
+                      <!-- -AL- `action=` is removed, since it is WiX 3 ONLY -->
+                <!-- -AL- here we can have multiple key-value pairs as needed -->
+              <RegistryValue Type="integer" Name="SomeIntegerValue" Value="1" KeyPath="yes"/>
+              <RegistryValue Type="string" Value="Default Value"/>
+          </RegistryKey>
+      </Component>
+  </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
+    <Feature Id="Complete" Title="My ODBC Driver" Description="My description" Level="1"
+        ConfigurableDirectory="INSTALLDIR" AllowAbsent="no" AllowAdvertise="no" InstallDefault="local">
+        <ComponentRef Id="MyRegistryEntries" />
+    </Feature>
+  </Fragment>
+</Wix>

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
@@ -20,6 +20,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Fragment>
   <DirectoryRef Id="TARGETDIR">
+  <!-- -AL- Registers Computer\HKEY_CURRENT_USER\Software\MyCompany\MyApplicationName -->
       <Component Id="MyRegistryEntries" Guid="C348B9F7-5E8D-415D-A001-D92F2D4EA013">
           <RegistryKey Root="HKCU"
                       Key="Software\MyCompany\MyApplicationName">
@@ -30,15 +31,5 @@
           </RegistryKey>
       </Component>
   </DirectoryRef>
-  </Fragment>
-
-  <Fragment>
-    <ComponentGroup Id="ComponentsGroup">
-      <ComponentRef Id="MyRegistryEntries"/>
-    </ComponentGroup>
-    <!-- <Feature Id="Complete" Title="My ODBC Driver" Description="My description" Level="1"
-        ConfigurableDirectory="INSTALLDIR" AllowAbsent="no" AllowAdvertise="no" InstallDefault="local">
-        <ComponentRef Id="MyRegistryEntries" />
-    </Feature> -->
   </Fragment>
 </Wix>

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
@@ -33,9 +33,12 @@
   </Fragment>
 
   <Fragment>
-    <Feature Id="Complete" Title="My ODBC Driver" Description="My description" Level="1"
+    <ComponentGroup Id="ComponentsGroup">
+      <ComponentRef Id="MyRegistryEntries"/>
+    </ComponentGroup>
+    <!-- <Feature Id="Complete" Title="My ODBC Driver" Description="My description" Level="1"
         ConfigurableDirectory="INSTALLDIR" AllowAbsent="no" AllowAdvertise="no" InstallDefault="local">
         <ComponentRef Id="MyRegistryEntries" />
-    </Feature>
+    </Feature> -->
   </Fragment>
 </Wix>

--- a/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
+++ b/cpp/src/arrow/flight/sql/odbc/install/arrow-flight-sql-odbc.wxs
@@ -20,7 +20,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Fragment>
   <DirectoryRef Id="TARGETDIR">
-      <Component Id="MyRegistryEntries" Guid="C348B9F7-5E8D-415D-A001-D92F2D4EA013">
+      <Component Id="ODBCRegistryEntries" Guid="C348B9F7-5E8D-415D-A001-D92F2D4EA013">
           <RegistryValue Root='HKLM' Key='Software\ODBC\ODBCINST.INI\ODBC Drivers' Name='Apache Arrow Flight SQL ODBC Driver' Type='string' Value='Installed'/>
 
           <RegistryKey Root="HKLM"


### PR DESCRIPTION
* This PR enables the ODBC installer to register the ODBC driver on Windows, so user doesn't need to run any script to make the driver manager recognize the driver. 