### PR TITLE
Change SQLDescribeCol to return nameLengthPtr value as length in char…

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -1435,7 +1435,8 @@ SQLRETURN SQLDescribeCol(SQLHSTMT stmt, SQLUSMALLINT columnNumber, SQLWCHAR* col
       ird->GetField(columnNumber, SQL_DESC_NAME, columnName, bufferLength,
                     &outputLengthInt);
       if (nameLengthPtr) {
-        *nameLengthPtr = static_cast<SQLSMALLINT>(outputLengthInt);
+        // returned length should be in characters
+        *nameLengthPtr = static_cast<SQLSMALLINT>(outputLengthInt / GetSqlWCharSize());
       }
     }
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -2431,11 +2431,9 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, 1024);
@@ -2515,11 +2513,9 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, columnSizes[i]);
@@ -2579,11 +2575,9 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadata) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, columnSizes[i]);
@@ -2643,11 +2637,9 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadataODBC2) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, columnSizes[i]);
@@ -2701,11 +2693,9 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColAllTypesTableMetadata) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, columnSizes[i]);
@@ -2755,11 +2745,9 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColUnicodeTableMetadata) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_GT(nameLength, 0);
+  EXPECT_EQ(nameLength, wcslen(expectedColumnName));
 
-  // Returned nameLength is in bytes so convert to length in characters
-  size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-  std::wstring returned(columnName, columnName + charCount);
+  std::wstring returned(columnName, columnName + nameLength);
   EXPECT_EQ(returned, expectedColumnName);
   EXPECT_EQ(columnDataType, expectedColumnDataType);
   EXPECT_EQ(columnSize, expectedColumnSize);
@@ -2810,11 +2798,9 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeCol) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, columnSizes[i]);
@@ -2880,11 +2866,9 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeColODBC2) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, columnSizes[i]);

--- a/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
@@ -607,11 +607,9 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesGetMetadataBySQLDescribeCol) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, columnSizes[i]);
@@ -660,11 +658,9 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesGetMetadataBySQLDescribeColODBC2) {
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_GT(nameLength, 0);
+    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
 
-    // Returned nameLength is in bytes so convert to length in characters
-    size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-    std::wstring returned(columnName, columnName + charCount);
+    std::wstring returned(columnName, columnName + nameLength);
     EXPECT_EQ(returned, columnNames[i]);
     EXPECT_EQ(columnDataType, columnDataTypes[i]);
     EXPECT_EQ(columnSize, columnSizes[i]);

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -49,11 +49,9 @@ void checkSQLDescribeCol(SQLHSTMT stmt, const SQLUSMALLINT columnIndex,
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_GT(nameLength, 0);
+  EXPECT_EQ(nameLength, expectedName.size());
 
-  // returned nameLength is in bytes so convert to length in characters
-  size_t charCount = static_cast<size_t>(nameLength) / ODBC::GetSqlWCharSize();
-  std::wstring returned(columnName, columnName + charCount);
+  std::wstring returned(columnName, columnName + nameLength);
   EXPECT_EQ(returned, expectedName);
   EXPECT_EQ(columnDataType, expectedDataType);
   EXPECT_EQ(columnSize, expectedColumnSize);


### PR DESCRIPTION
The SQLDescribeCol was incorrectly returning the length of the column name in bytes.  The PR changes to return the length in characters for the nameLengthPtr value.