### PR TITLE
Fix build warnings treated as error

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -2333,7 +2333,8 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColValidateInput) {
   SQLUSMALLINT outOfRangeColumn = 4;
   SQLUSMALLINT negativeColumn = -1;
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT dataType = 0;
   SQLULEN columnSize = 0;
@@ -2378,7 +2379,8 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
   this->connect();
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;
@@ -2454,7 +2456,8 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
   this->connect();
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;
@@ -2537,7 +2540,8 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadata) {
   this->connect();
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;
@@ -2599,7 +2603,8 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadataODBC2) {
   this->connect(SQL_OV_ODBC2);
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;
@@ -2661,7 +2666,8 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColAllTypesTableMetadata) {
   this->CreateTableAllDataType();
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;
@@ -2717,7 +2723,8 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColUnicodeTableMetadata) {
   this->CreateUnicodeTable();
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;
@@ -2761,7 +2768,8 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeCol) {
   this->connect();
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;
@@ -2821,7 +2829,8 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeColODBC2) {
   this->connect(SQL_OV_ODBC2);
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;

--- a/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
@@ -579,7 +579,8 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesGetMetadataBySQLDescribeCol) {
   this->connect();
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;
@@ -630,7 +631,8 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesGetMetadataBySQLDescribeColODBC2) {
   this->connect(SQL_OV_ODBC2);
 
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -37,7 +37,8 @@ void checkSQLDescribeCol(SQLHSTMT stmt, const SQLUSMALLINT columnIndex,
                          const SQLSMALLINT& expectedDecimalDigits,
                          const SQLSMALLINT& expectedNullable) {
   SQLWCHAR columnName[1024];
-  SQLINTEGER bufCharLen = sizeof(columnName) / ODBC::GetSqlWCharSize();
+  SQLSMALLINT bufCharLen =
+      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
   SQLSMALLINT nameLength = 0;
   SQLSMALLINT columnDataType = 0;
   SQLULEN columnSize = 0;


### PR DESCRIPTION
SQLDescribeCol expects `bufCharLen` to be of type `SQLSMALLINT`, so build warnings occur when `bufCharLen` is set to `SQLINTEGER`. This error did not occur on my local environment before, so I am fixing it as it occurs. 