### PR TITLE
Remove reference of `Configuration` in odbc_connection.cc

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
@@ -85,7 +85,10 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
   inline bool IsOdbc2Connection() const { return m_is2xConnection; }
 
   /// @return the DSN or empty string if Driver was used.
-  static std::string getPropertiesFromConnString(
+  static std::string getDsnIfExists(const std::string& connStr);
+
+  /// Read properties from connection string, but does not read values from DSN
+  static void getPropertiesFromConnString(
       const std::string& connStr,
       driver::odbcabstraction::Connection::ConnPropertyMap& properties);
 


### PR DESCRIPTION
Remove reference of `Configuration` in odbc_connection.cc which is in library `odbcabstraction`. The reasoning is that `Configuration` is in `arrow_odbc_spi_impl` and this is a library that `odbcabstraction` depends on. I moved the logic for reading DSN values into `odbc_api.cc` instead, since that is a place that will result in no conflicts. The ODBC driver now does not save the DSN value in the connection string if the DSN value is put after Driver value. 