### PR TITLE
Fix Function & Variable Naming

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/entry_points.cc
+++ b/cpp/src/arrow/flight/sql/odbc/entry_points.cc
@@ -69,112 +69,118 @@ SQLRETURN SQL_API SQLFreeStmt(SQLHSTMT stmt, SQLUSMALLINT option) {
   return arrow::SQLFreeStmt(stmt, option);
 }
 
-SQLRETURN SQL_API SQLGetDiagField(SQLSMALLINT handleType, SQLHANDLE handle,
-                                  SQLSMALLINT recNumber, SQLSMALLINT diagIdentifier,
-                                  SQLPOINTER diagInfoPtr, SQLSMALLINT bufferLength,
-                                  SQLSMALLINT* stringLengthPtr) {
-  return arrow::SQLGetDiagField(handleType, handle, recNumber, diagIdentifier,
-                                diagInfoPtr, bufferLength, stringLengthPtr);
+SQLRETURN SQL_API SQLGetDiagField(SQLSMALLINT handle_type, SQLHANDLE handle,
+                                  SQLSMALLINT rec_number, SQLSMALLINT diag_identifier,
+                                  SQLPOINTER diag_info_ptr, SQLSMALLINT buffer_length,
+                                  SQLSMALLINT* string_length_ptr) {
+  return arrow::SQLGetDiagField(handle_type, handle, rec_number, diag_identifier,
+                                diag_info_ptr, buffer_length, string_length_ptr);
 }
 
-SQLRETURN SQL_API SQLGetDiagRec(SQLSMALLINT handleType, SQLHANDLE handle,
-                                SQLSMALLINT recNumber, SQLWCHAR* sqlState,
-                                SQLINTEGER* nativeErrorPtr, SQLWCHAR* messageText,
-                                SQLSMALLINT bufferLength, SQLSMALLINT* textLengthPtr) {
-  return arrow::SQLGetDiagRec(handleType, handle, recNumber, sqlState, nativeErrorPtr,
-                              messageText, bufferLength, textLengthPtr);
+SQLRETURN SQL_API SQLGetDiagRec(SQLSMALLINT handle_type, SQLHANDLE handle,
+                                SQLSMALLINT rec_number, SQLWCHAR* sql_state,
+                                SQLINTEGER* native_error_ptr, SQLWCHAR* message_text,
+                                SQLSMALLINT buffer_length, SQLSMALLINT* text_length_ptr) {
+  return arrow::SQLGetDiagRec(handle_type, handle, rec_number, sql_state,
+                              native_error_ptr, message_text, buffer_length,
+                              text_length_ptr);
 }
 
-SQLRETURN SQL_API SQLGetEnvAttr(SQLHENV env, SQLINTEGER attr, SQLPOINTER valuePtr,
-                                SQLINTEGER bufferLen, SQLINTEGER* strLenPtr) {
-  return arrow::SQLGetEnvAttr(env, attr, valuePtr, bufferLen, strLenPtr);
+SQLRETURN SQL_API SQLGetEnvAttr(SQLHENV env, SQLINTEGER attr, SQLPOINTER value_ptr,
+                                SQLINTEGER buffer_len, SQLINTEGER* str_len_ptr) {
+  return arrow::SQLGetEnvAttr(env, attr, value_ptr, buffer_len, str_len_ptr);
 }
 
-SQLRETURN SQL_API SQLSetEnvAttr(SQLHENV env, SQLINTEGER attr, SQLPOINTER valuePtr,
-                                SQLINTEGER strLen) {
-  return arrow::SQLSetEnvAttr(env, attr, valuePtr, strLen);
+SQLRETURN SQL_API SQLSetEnvAttr(SQLHENV env, SQLINTEGER attr, SQLPOINTER value_ptr,
+                                SQLINTEGER str_len) {
+  return arrow::SQLSetEnvAttr(env, attr, value_ptr, str_len);
 }
 
 SQLRETURN SQL_API SQLGetConnectAttr(SQLHDBC conn, SQLINTEGER attribute,
-                                    SQLPOINTER valuePtr, SQLINTEGER bufferLength,
-                                    SQLINTEGER* stringLengthPtr) {
-  return arrow::SQLGetConnectAttr(conn, attribute, valuePtr, bufferLength,
-                                  stringLengthPtr);
+                                    SQLPOINTER value_ptr, SQLINTEGER buffer_length,
+                                    SQLINTEGER* string_length_ptr) {
+  return arrow::SQLGetConnectAttr(conn, attribute, value_ptr, buffer_length,
+                                  string_length_ptr);
 }
 
 SQLRETURN SQL_API SQLSetConnectAttr(SQLHDBC conn, SQLINTEGER attr, SQLPOINTER value,
-                                    SQLINTEGER valueLen) {
-  return arrow::SQLSetConnectAttr(conn, attr, value, valueLen);
+                                    SQLINTEGER value_len) {
+  return arrow::SQLSetConnectAttr(conn, attr, value, value_len);
 }
 
-SQLRETURN SQL_API SQLGetInfo(SQLHDBC conn, SQLUSMALLINT infoType, SQLPOINTER infoValuePtr,
-                             SQLSMALLINT bufLen, SQLSMALLINT* length) {
-  return arrow::SQLGetInfo(conn, infoType, infoValuePtr, bufLen, length);
+SQLRETURN SQL_API SQLGetInfo(SQLHDBC conn, SQLUSMALLINT info_type,
+                             SQLPOINTER info_value_ptr, SQLSMALLINT buf_len,
+                             SQLSMALLINT* length) {
+  return arrow::SQLGetInfo(conn, info_type, info_value_ptr, buf_len, length);
 }
 
-SQLRETURN SQL_API SQLDriverConnect(SQLHDBC conn, SQLHWND windowHandle,
-                                   SQLWCHAR* inConnectionString,
-                                   SQLSMALLINT inConnectionStringLen,
-                                   SQLWCHAR* outConnectionString,
-                                   SQLSMALLINT outConnectionStringBufferLen,
-                                   SQLSMALLINT* outConnectionStringLen,
-                                   SQLUSMALLINT driverCompletion) {
-  return arrow::SQLDriverConnect(
-      conn, windowHandle, inConnectionString, inConnectionStringLen, outConnectionString,
-      outConnectionStringBufferLen, outConnectionStringLen, driverCompletion);
+SQLRETURN SQL_API SQLDriverConnect(SQLHDBC conn, SQLHWND window_handle,
+                                   SQLWCHAR* in_connection_string,
+                                   SQLSMALLINT in_connection_stringLen,
+                                   SQLWCHAR* out_connection_string,
+                                   SQLSMALLINT out_connection_string_buffer_len,
+                                   SQLSMALLINT* out_connection_string_len,
+                                   SQLUSMALLINT driver_completion) {
+  return arrow::SQLDriverConnect(conn, window_handle, in_connection_string,
+                                 in_connection_stringLen, out_connection_string,
+                                 out_connection_string_buffer_len,
+                                 out_connection_string_len, driver_completion);
 }
 
-SQLRETURN SQL_API SQLConnect(SQLHDBC conn, SQLWCHAR* dsnName, SQLSMALLINT dsnNameLen,
-                             SQLWCHAR* userName, SQLSMALLINT userNameLen,
-                             SQLWCHAR* password, SQLSMALLINT passwordLen) {
-  return arrow::SQLConnect(conn, dsnName, dsnNameLen, userName, userNameLen, password,
-                           passwordLen);
+SQLRETURN SQL_API SQLConnect(SQLHDBC conn, SQLWCHAR* dsn_name, SQLSMALLINT dsn_name_len,
+                             SQLWCHAR* user_name, SQLSMALLINT user_name_len,
+                             SQLWCHAR* password, SQLSMALLINT password_len) {
+  return arrow::SQLConnect(conn, dsn_name, dsn_name_len, user_name, user_name_len,
+                           password, password_len);
 }
 
 SQLRETURN SQL_API SQLDisconnect(SQLHDBC conn) { return arrow::SQLDisconnect(conn); }
 
-SQLRETURN SQL_API SQLGetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER valuePtr,
-                                 SQLINTEGER bufferLength, SQLINTEGER* stringLengthPtr) {
-  return arrow::SQLGetStmtAttr(stmt, attribute, valuePtr, bufferLength, stringLengthPtr);
+SQLRETURN SQL_API SQLGetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute,
+                                 SQLPOINTER value_ptr, SQLINTEGER buffer_length,
+                                 SQLINTEGER* string_length_ptr) {
+  return arrow::SQLGetStmtAttr(stmt, attribute, value_ptr, buffer_length,
+                               string_length_ptr);
 }
 
-SQLRETURN SQL_API SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* queryText,
-                                SQLINTEGER textLength) {
-  return arrow::SQLExecDirect(stmt, queryText, textLength);
+SQLRETURN SQL_API SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* query_text,
+                                SQLINTEGER text_length) {
+  return arrow::SQLExecDirect(stmt, query_text, text_length);
 }
 
 SQLRETURN SQL_API SQLFetch(SQLHSTMT stmt) { return arrow::SQLFetch(stmt); }
 
-SQLRETURN SQL_API SQLExtendedFetch(SQLHSTMT stmt, SQLUSMALLINT fetchOrientation,
-                                   SQLLEN fetchOffset, SQLULEN* rowCountPtr,
-                                   SQLUSMALLINT* rowStatusArray) {
-  return arrow::SQLExtendedFetch(stmt, fetchOrientation, fetchOffset, rowCountPtr,
-                                 rowStatusArray);
+SQLRETURN SQL_API SQLExtendedFetch(SQLHSTMT stmt, SQLUSMALLINT fetch_orientation,
+                                   SQLLEN fetch_offset, SQLULEN* row_count_ptr,
+                                   SQLUSMALLINT* row_status_array) {
+  return arrow::SQLExtendedFetch(stmt, fetch_orientation, fetch_offset, row_count_ptr,
+                                 row_status_array);
 }
 
-SQLRETURN SQL_API SQLFetchScroll(SQLHSTMT stmt, SQLSMALLINT fetchOrientation,
-                                 SQLLEN fetchOffset) {
-  return arrow::SQLFetchScroll(stmt, fetchOrientation, fetchOffset);
+SQLRETURN SQL_API SQLFetchScroll(SQLHSTMT stmt, SQLSMALLINT fetch_orientation,
+                                 SQLLEN fetch_offset) {
+  return arrow::SQLFetchScroll(stmt, fetch_orientation, fetch_offset);
 }
 
-SQLRETURN SQL_API SQLGetData(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
-                             SQLPOINTER dataPtr, SQLLEN bufferLength,
-                             SQLLEN* indicatorPtr) {
-  return arrow::SQLGetData(stmt, recordNumber, cType, dataPtr, bufferLength,
-                           indicatorPtr);
+SQLRETURN SQL_API SQLGetData(SQLHSTMT stmt, SQLUSMALLINT record_number,
+                             SQLSMALLINT c_type, SQLPOINTER data_ptr,
+                             SQLLEN buffer_length, SQLLEN* indicator_ptr) {
+  return arrow::SQLGetData(stmt, record_number, c_type, data_ptr, buffer_length,
+                           indicator_ptr);
 }
 
-SQLRETURN SQL_API SQLPrepare(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER textLength) {
-  return arrow::SQLPrepare(stmt, queryText, textLength);
+SQLRETURN SQL_API SQLPrepare(SQLHSTMT stmt, SQLWCHAR* query_text,
+                             SQLINTEGER text_length) {
+  return arrow::SQLPrepare(stmt, query_text, text_length);
 }
 
 SQLRETURN SQL_API SQLExecute(SQLHSTMT stmt) { return arrow::SQLExecute(stmt); }
 
-SQLRETURN SQL_API SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
-                             SQLPOINTER dataPtr, SQLLEN bufferLength,
-                             SQLLEN* indicatorPtr) {
-  return arrow::SQLBindCol(stmt, recordNumber, cType, dataPtr, bufferLength,
-                           indicatorPtr);
+SQLRETURN SQL_API SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT record_number,
+                             SQLSMALLINT c_type, SQLPOINTER data_ptr,
+                             SQLLEN buffer_length, SQLLEN* indicator_ptr) {
+  return arrow::SQLBindCol(stmt, record_number, c_type, data_ptr, buffer_length,
+                           indicator_ptr);
 }
 
 SQLRETURN SQL_API SQLCancel(SQLHSTMT stmt) {
@@ -188,56 +194,56 @@ SQLRETURN SQL_API SQLCancel(SQLHSTMT stmt) {
 
 SQLRETURN SQL_API SQLCloseCursor(SQLHSTMT stmt) { return arrow::SQLCloseCursor(stmt); }
 
-SQLRETURN SQL_API SQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT recordNumber,
-                                  SQLUSMALLINT fieldIdentifier,
-                                  SQLPOINTER characterAttributePtr,
-                                  SQLSMALLINT bufferLength, SQLSMALLINT* outputLength,
-                                  SQLLEN* numericAttributePtr) {
-  return arrow::SQLColAttribute(stmt, recordNumber, fieldIdentifier,
-                                characterAttributePtr, bufferLength, outputLength,
-                                numericAttributePtr);
+SQLRETURN SQL_API SQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT record_number,
+                                  SQLUSMALLINT field_identifier,
+                                  SQLPOINTER character_attribute_ptr,
+                                  SQLSMALLINT buffer_length, SQLSMALLINT* output_length,
+                                  SQLLEN* numeric_attribute_ptr) {
+  return arrow::SQLColAttribute(stmt, record_number, field_identifier,
+                                character_attribute_ptr, buffer_length, output_length,
+                                numeric_attribute_ptr);
 }
 
-SQLRETURN SQL_API SQLTables(SQLHSTMT stmt, SQLWCHAR* catalogName,
-                            SQLSMALLINT catalogNameLength, SQLWCHAR* schemaName,
-                            SQLSMALLINT schemaNameLength, SQLWCHAR* tableName,
-                            SQLSMALLINT tableNameLength, SQLWCHAR* tableType,
-                            SQLSMALLINT tableTypeLength) {
-  return arrow::SQLTables(stmt, catalogName, catalogNameLength, schemaName,
-                          schemaNameLength, tableName, tableNameLength, tableType,
-                          tableTypeLength);
+SQLRETURN SQL_API SQLTables(SQLHSTMT stmt, SQLWCHAR* catalog_name,
+                            SQLSMALLINT catalog_name_length, SQLWCHAR* schema_name,
+                            SQLSMALLINT schema_name_length, SQLWCHAR* table_name,
+                            SQLSMALLINT table_name_length, SQLWCHAR* table_type,
+                            SQLSMALLINT table_type_length) {
+  return arrow::SQLTables(stmt, catalog_name, catalog_name_length, schema_name,
+                          schema_name_length, table_name, table_name_length, table_type,
+                          table_type_length);
 }
 
-SQLRETURN SQL_API SQLColumns(SQLHSTMT stmt, SQLWCHAR* catalogName,
-                             SQLSMALLINT catalogNameLength, SQLWCHAR* schemaName,
-                             SQLSMALLINT schemaNameLength, SQLWCHAR* tableName,
-                             SQLSMALLINT tableNameLength, SQLWCHAR* columnName,
-                             SQLSMALLINT columnNameLength) {
-  return arrow::SQLColumns(stmt, catalogName, catalogNameLength, schemaName,
-                           schemaNameLength, tableName, tableNameLength, columnName,
-                           columnNameLength);
+SQLRETURN SQL_API SQLColumns(SQLHSTMT stmt, SQLWCHAR* catalog_name,
+                             SQLSMALLINT catalog_name_length, SQLWCHAR* schema_name,
+                             SQLSMALLINT schema_name_length, SQLWCHAR* table_name,
+                             SQLSMALLINT table_name_length, SQLWCHAR* columnName,
+                             SQLSMALLINT column_name_length) {
+  return arrow::SQLColumns(stmt, catalog_name, catalog_name_length, schema_name,
+                           schema_name_length, table_name, table_name_length, columnName,
+                           column_name_length);
 }
 
-SQLRETURN SQL_API SQLForeignKeys(SQLHSTMT stmt, SQLWCHAR* pKCatalogName,
-                                 SQLSMALLINT pKCatalogNameLength, SQLWCHAR* pKSchemaName,
-                                 SQLSMALLINT pKSchemaNameLength, SQLWCHAR* pKTableName,
-                                 SQLSMALLINT pKTableNameLength, SQLWCHAR* fKCatalogName,
-                                 SQLSMALLINT fKCatalogNameLength, SQLWCHAR* fKSchemaName,
-                                 SQLSMALLINT fKSchemaNameLength, SQLWCHAR* fKTableName,
-                                 SQLSMALLINT fKTableNameLength) {
+SQLRETURN SQL_API SQLForeignKeys(
+    SQLHSTMT stmt, SQLWCHAR* pk_catalog_name, SQLSMALLINT pk_catalog_name_length,
+    SQLWCHAR* pk_schema_name, SQLSMALLINT pk_schema_name_length, SQLWCHAR* pk_table_name,
+    SQLSMALLINT pk_table_name_length, SQLWCHAR* fk_catalog_name,
+    SQLSMALLINT fk_catalog_name_length, SQLWCHAR* fk_schema_name,
+    SQLSMALLINT fk_schema_name_length, SQLWCHAR* fk_table_name,
+    SQLSMALLINT fk_table_name_length) {
   ARROW_LOG(DEBUG) << "SQLForeignKeysW called with stmt: " << stmt
-                   << ", pKCatalogName: " << static_cast<const void*>(pKCatalogName)
-                   << ", pKCatalogNameLength: " << pKCatalogNameLength
-                   << ", pKSchemaName: " << static_cast<const void*>(pKSchemaName)
-                   << ", pKSchemaNameLength: " << pKSchemaNameLength
-                   << ", pKTableName: " << static_cast<const void*>(pKTableName)
-                   << ", pKTableNameLength: " << pKTableNameLength
-                   << ", fKCatalogName: " << static_cast<const void*>(fKCatalogName)
-                   << ", fKCatalogNameLength: " << fKCatalogNameLength
-                   << ", fKSchemaName: " << static_cast<const void*>(fKSchemaName)
-                   << ", fKSchemaNameLength: " << fKSchemaNameLength
-                   << ", fKTableName: " << static_cast<const void*>(fKTableName)
-                   << ", fKTableNameLength: " << fKTableNameLength;
+                   << ", pk_catalog_name: " << static_cast<const void*>(pk_catalog_name)
+                   << ", pk_catalog_name_length: " << pk_catalog_name_length
+                   << ", pk_schema_name: " << static_cast<const void*>(pk_schema_name)
+                   << ", pk_schema_name_length: " << pk_schema_name_length
+                   << ", pk_table_name: " << static_cast<const void*>(pk_table_name)
+                   << ", pk_table_name_length: " << pk_table_name_length
+                   << ", fk_catalog_name: " << static_cast<const void*>(fk_catalog_name)
+                   << ", fk_catalog_name_length: " << fk_catalog_name_length
+                   << ", fk_schema_name: " << static_cast<const void*>(fk_schema_name)
+                   << ", fk_schema_name_length: " << fk_schema_name_length
+                   << ", fk_table_name: " << static_cast<const void*>(fk_table_name)
+                   << ", fk_table_name_length: " << fk_table_name_length;
   return ODBC::ODBCStatement::ExecuteWithDiagnostics(stmt, SQL_ERROR, [=]() {
     throw driver::odbcabstraction::DriverException("SQLForeignKeysW is not implemented",
                                                    "IM001");
@@ -245,39 +251,40 @@ SQLRETURN SQL_API SQLForeignKeys(SQLHSTMT stmt, SQLWCHAR* pKCatalogName,
   });
 }
 
-SQLRETURN SQL_API SQLGetTypeInfo(SQLHSTMT stmt, SQLSMALLINT dataType) {
-  return arrow::SQLGetTypeInfo(stmt, dataType);
+SQLRETURN SQL_API SQLGetTypeInfo(SQLHSTMT stmt, SQLSMALLINT data_type) {
+  return arrow::SQLGetTypeInfo(stmt, data_type);
 }
 
 SQLRETURN SQL_API SQLMoreResults(SQLHSTMT stmt) { return arrow::SQLMoreResults(stmt); }
 
-SQLRETURN SQL_API SQLNativeSql(SQLHDBC connectionHandle, SQLWCHAR* inStatementText,
-                               SQLINTEGER inStatementTextLength,
-                               SQLWCHAR* outStatementText, SQLINTEGER bufferLength,
-                               SQLINTEGER* outStatementTextLength) {
-  return arrow::SQLNativeSql(connectionHandle, inStatementText, inStatementTextLength,
-                             outStatementText, bufferLength, outStatementTextLength);
+SQLRETURN SQL_API SQLNativeSql(SQLHDBC conn, SQLWCHAR* in_statement_text,
+                               SQLINTEGER in_statement_text_length,
+                               SQLWCHAR* out_statement_text, SQLINTEGER buffer_length,
+                               SQLINTEGER* out_statement_text_length) {
+  return arrow::SQLNativeSql(conn, in_statement_text, in_statement_text_length,
+                             out_statement_text, buffer_length,
+                             out_statement_text_length);
 }
 
-SQLRETURN SQL_API SQLNumResultCols(SQLHSTMT stmt, SQLSMALLINT* columnCountPtr) {
-  return arrow::SQLNumResultCols(stmt, columnCountPtr);
+SQLRETURN SQL_API SQLNumResultCols(SQLHSTMT stmt, SQLSMALLINT* column_count_ptr) {
+  return arrow::SQLNumResultCols(stmt, column_count_ptr);
 }
 
-SQLRETURN SQL_API SQLRowCount(SQLHSTMT stmt, SQLLEN* rowCountPtr) {
-  return arrow::SQLRowCount(stmt, rowCountPtr);
+SQLRETURN SQL_API SQLRowCount(SQLHSTMT stmt, SQLLEN* row_count_ptr) {
+  return arrow::SQLRowCount(stmt, row_count_ptr);
 }
 
-SQLRETURN SQL_API SQLPrimaryKeys(SQLHSTMT stmt, SQLWCHAR* catalogName,
-                                 SQLSMALLINT catalogNameLength, SQLWCHAR* schemaName,
-                                 SQLSMALLINT schemaNameLength, SQLWCHAR* tableName,
-                                 SQLSMALLINT tableNameLength) {
+SQLRETURN SQL_API SQLPrimaryKeys(SQLHSTMT stmt, SQLWCHAR* catalog_name,
+                                 SQLSMALLINT catalog_name_length, SQLWCHAR* schema_name,
+                                 SQLSMALLINT schema_name_length, SQLWCHAR* table_name,
+                                 SQLSMALLINT table_name_length) {
   ARROW_LOG(DEBUG) << "SQLPrimaryKeysW called with stmt: " << stmt
-                   << ", catalogName: " << static_cast<const void*>(catalogName)
-                   << ", catalogNameLength: " << catalogNameLength
-                   << ", schemaName: " << static_cast<const void*>(schemaName)
-                   << ", schemaNameLength: " << schemaNameLength
-                   << ", tableName: " << static_cast<const void*>(tableName)
-                   << ", tableNameLength: " << tableNameLength;
+                   << ", catalog_name: " << static_cast<const void*>(catalog_name)
+                   << ", catalog_name_length: " << catalog_name_length
+                   << ", schema_name: " << static_cast<const void*>(schema_name)
+                   << ", schema_name_length: " << schema_name_length
+                   << ", table_name: " << static_cast<const void*>(table_name)
+                   << ", table_name_length: " << table_name_length;
   return ODBC::ODBCStatement::ExecuteWithDiagnostics(stmt, SQL_ERROR, [=]() {
     throw driver::odbcabstraction::DriverException("SQLPrimaryKeysW is not implemented",
                                                    "IM001");
@@ -285,17 +292,18 @@ SQLRETURN SQL_API SQLPrimaryKeys(SQLHSTMT stmt, SQLWCHAR* catalogName,
   });
 }
 
-SQLRETURN SQL_API SQLSetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER valuePtr,
-                                 SQLINTEGER stringLength) {
-  return arrow::SQLSetStmtAttr(stmt, attribute, valuePtr, stringLength);
+SQLRETURN SQL_API SQLSetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute,
+                                 SQLPOINTER value_ptr, SQLINTEGER stringLength) {
+  return arrow::SQLSetStmtAttr(stmt, attribute, value_ptr, stringLength);
 }
 
-SQLRETURN SQL_API SQLDescribeCol(SQLHSTMT statementHandle, SQLUSMALLINT columnNumber,
-                                 SQLWCHAR* columnName, SQLSMALLINT bufferLength,
-                                 SQLSMALLINT* nameLengthPtr, SQLSMALLINT* dataTypePtr,
-                                 SQLULEN* columnSizePtr, SQLSMALLINT* decimalDigitsPtr,
-                                 SQLSMALLINT* nullablePtr) {
-  return arrow::SQLDescribeCol(statementHandle, columnNumber, columnName, bufferLength,
-                               nameLengthPtr, dataTypePtr, columnSizePtr,
-                               decimalDigitsPtr, nullablePtr);
+SQLRETURN SQL_API SQLDescribeCol(SQLHSTMT stmt, SQLUSMALLINT column_number,
+                                 SQLWCHAR* column_name, SQLSMALLINT buffer_length,
+                                 SQLSMALLINT* name_length_ptr, SQLSMALLINT* data_type_ptr,
+                                 SQLULEN* column_size_ptr,
+                                 SQLSMALLINT* decimal_digits_ptr,
+                                 SQLSMALLINT* nullable_ptr) {
+  return arrow::SQLDescribeCol(stmt, column_number, column_name, buffer_length,
+                               name_length_ptr, data_type_ptr, column_size_ptr,
+                               decimal_digits_ptr, nullable_ptr);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.cc
@@ -56,8 +56,8 @@ inline RowStatus MoveSingleCellToBinaryBuffer(ColumnBinding* binding, BinaryArra
     value_offset = -1;
   }
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[i] = static_cast<ssize_t>(remaining_length);
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[i] = static_cast<ssize_t>(remaining_length);
   }
 
   return result;
@@ -72,7 +72,7 @@ BinaryArrayFlightSqlAccessor<TARGET_TYPE>::BinaryArrayFlightSqlAccessor(Array* a
 
 template <>
 RowStatus
-BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY>::MoveSingleCell_impl(
+BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t i, int64_t& value_offset,
     bool update_value_offset, odbcabstraction::Diagnostics& diagnostics) {
   return MoveSingleCellToBinaryBuffer(binding, this->GetArray(), arrow_row, i,
@@ -80,7 +80,7 @@ BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY>::MoveSingleCell_
 }
 
 template <CDataType TARGET_TYPE>
-size_t BinaryArrayFlightSqlAccessor<TARGET_TYPE>::GetCellLength_impl(
+size_t BinaryArrayFlightSqlAccessor<TARGET_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return binding->buffer_length;
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.h
@@ -34,11 +34,11 @@ class BinaryArrayFlightSqlAccessor
  public:
   explicit BinaryArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                                int64_t& value_offset, bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                               int64_t& value_offset, bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor_test.cc
@@ -35,12 +35,12 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Basic) {
 
   BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY> accessor(array.get());
 
-  size_t max_strlen = 64;
-  std::vector<char> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 64;
+  std::vector<char> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_BINARY, 0, 0, buffer.data(),
-                        max_strlen, strlen_buffer.data());
+                        max_str_len, str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -49,12 +49,13 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Basic) {
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(values[i].length(), strlen_buffer[i]);
+    ASSERT_EQ(values[i].length(), str_len_buffer[i]);
     // Beware that CDataType_BINARY values are not null terminated.
     // It's safe to create a std::string from this data because we know it's
     // ASCII, this doesn't work with arbitrary binary data.
-    ASSERT_EQ(values[i], std::string(buffer.data() + i * max_strlen,
-                                     buffer.data() + i * max_strlen + strlen_buffer[i]));
+    ASSERT_EQ(values[i],
+              std::string(buffer.data() + i * max_str_len,
+                          buffer.data() + i * max_str_len + str_len_buffer[i]));
   }
 }
 
@@ -65,12 +66,12 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Truncation) {
 
   BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY> accessor(array.get());
 
-  size_t max_strlen = 8;
-  std::vector<char> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 8;
+  std::vector<char> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_BINARY, 0, 0, buffer.data(),
-                        max_strlen, strlen_buffer.data());
+                        max_str_len, str_len_buffer.data());
 
   std::stringstream ss;
   int64_t value_offset = 0;
@@ -83,13 +84,13 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Truncation) {
     int64_t original_value_offset = value_offset;
     ASSERT_EQ(1, accessor.GetColumnarData(&binding, 0, 1, value_offset, true, diagnostics,
                                           nullptr));
-    ASSERT_EQ(values[0].length() - original_value_offset, strlen_buffer[0]);
+    ASSERT_EQ(values[0].length() - original_value_offset, str_len_buffer[0]);
 
     int64_t chunk_length = 0;
     if (value_offset == -1) {
-      chunk_length = strlen_buffer[0];
+      chunk_length = str_len_buffer[0];
     } else {
-      chunk_length = max_strlen;
+      chunk_length = max_str_len;
     }
 
     // Beware that CDataType_BINARY values are not null terminated.

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor.cc
@@ -29,7 +29,7 @@ BooleanArrayFlightSqlAccessor<TARGET_TYPE>::BooleanArrayFlightSqlAccessor(Array*
                         BooleanArrayFlightSqlAccessor<TARGET_TYPE>>(array) {}
 
 template <CDataType TARGET_TYPE>
-RowStatus BooleanArrayFlightSqlAccessor<TARGET_TYPE>::MoveSingleCell_impl(
+RowStatus BooleanArrayFlightSqlAccessor<TARGET_TYPE>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t i, int64_t& value_offset,
     bool update_value_offset, odbcabstraction::Diagnostics& diagnostics) {
   typedef unsigned char c_type;
@@ -38,15 +38,15 @@ RowStatus BooleanArrayFlightSqlAccessor<TARGET_TYPE>::MoveSingleCell_impl(
   auto* buffer = static_cast<c_type*>(binding->buffer);
   buffer[i] = value ? 1 : 0;
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[i] = static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[i] = static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
 
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <CDataType TARGET_TYPE>
-size_t BooleanArrayFlightSqlAccessor<TARGET_TYPE>::GetCellLength_impl(
+size_t BooleanArrayFlightSqlAccessor<TARGET_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(unsigned char);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor.h
@@ -35,11 +35,11 @@ class BooleanArrayFlightSqlAccessor
  public:
   explicit BooleanArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                                int64_t& value_offset, bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                               int64_t& value_offset, bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor_test.cc
@@ -35,10 +35,10 @@ TEST(BooleanArrayFlightSqlAccessor, Test_BooleanArray_CDataType_BIT) {
   BooleanArrayFlightSqlAccessor<odbcabstraction::CDataType_BIT> accessor(array.get());
 
   std::vector<char> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_BIT, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -47,7 +47,7 @@ TEST(BooleanArrayFlightSqlAccessor, Test_BooleanArray_CDataType_BIT) {
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(unsigned char), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(unsigned char), str_len_buffer[i]);
     ASSERT_EQ(values[i] ? 1 : 0, buffer[i]);
   }
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
@@ -33,13 +33,13 @@ inline size_t CopyFromArrayValuesToBinding(ARRAY_TYPE* array, ColumnBinding* bin
                                            int64_t starting_row, int64_t cells) {
   constexpr ssize_t element_size = sizeof(typename ARRAY_TYPE::value_type);
 
-  if (binding->strlen_buffer) {
+  if (binding->str_len_buffer) {
     for (int64_t i = 0; i < cells; ++i) {
       int64_t current_row = starting_row + i;
       if (array->IsNull(current_row)) {
-        binding->strlen_buffer[i] = odbcabstraction::NULL_DATA;
+        binding->str_len_buffer[i] = odbcabstraction::NULL_DATA;
       } else {
-        binding->strlen_buffer[i] = element_size;
+        binding->str_len_buffer[i] = element_size;
       }
     }
   } else {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor.cc
@@ -60,7 +60,7 @@ DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::DateArrayFlightSqlAccessor
                         DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>>(array) {}
 
 template <CDataType TARGET_TYPE, typename ARROW_ARRAY>
-RowStatus DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::MoveSingleCell_impl(
+RowStatus DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t cell_counter,
     int64_t& value_offset, bool update_value_offset,
     odbcabstraction::Diagnostics& diagnostics) {
@@ -74,16 +74,16 @@ RowStatus DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::MoveSingleCell_i
   buffer[cell_counter].month = date.tm_mon + 1;
   buffer[cell_counter].day = date.tm_mday;
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[cell_counter] =
-        static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[cell_counter] =
+        static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
 
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <CDataType TARGET_TYPE, typename ARROW_ARRAY>
-size_t DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::GetCellLength_impl(
+size_t DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(DATE_STRUCT);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor.h
@@ -34,12 +34,12 @@ class DateArrayFlightSqlAccessor
  public:
   explicit DateArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row,
-                                int64_t cell_counter, int64_t& value_offset,
-                                bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row,
+                               int64_t cell_counter, int64_t& value_offset,
+                               bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor_test.cc
@@ -51,10 +51,10 @@ TEST(DateArrayAccessor, Test_Date32Array_CDataType_DATE) {
       dynamic_cast<NumericArray<Date32Type>*>(array.get()));
 
   std::vector<tagDATE_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_DATE, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -63,7 +63,7 @@ TEST(DateArrayAccessor, Test_Date32Array_CDataType_DATE) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(DATE_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(DATE_STRUCT), str_len_buffer[i]);
 
     ASSERT_EQ(expected[i].year, buffer[i].year);
     ASSERT_EQ(expected[i].month, buffer[i].month);
@@ -89,10 +89,10 @@ TEST(DateArrayAccessor, Test_Date64Array_CDataType_DATE) {
       dynamic_cast<NumericArray<Date64Type>*>(array.get()));
 
   std::vector<tagDATE_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_DATE, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -101,7 +101,7 @@ TEST(DateArrayAccessor, Test_Date64Array_CDataType_DATE) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(DATE_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(DATE_STRUCT), str_len_buffer[i]);
     ASSERT_EQ(expected[i].year, buffer[i].year);
     ASSERT_EQ(expected[i].month, buffer[i].month);
     ASSERT_EQ(expected[i].day, buffer[i].day);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor.cc
@@ -42,9 +42,9 @@ DecimalArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::DecimalArrayFlightSqlAc
 template <>
 RowStatus
 DecimalArrayFlightSqlAccessor<Decimal128Array, odbcabstraction::CDataType_NUMERIC>::
-    MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                        int64_t& value_offset, bool update_value_offset,
-                        odbcabstraction::Diagnostics& diagnostics) {
+    MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                       int64_t& value_offset, bool update_value_offset,
+                       odbcabstraction::Diagnostics& diagnostics) {
   auto result = &(static_cast<NUMERIC_STRUCT*>(binding->buffer)[i]);
   int32_t original_scale = data_type_->scale();
 
@@ -74,15 +74,15 @@ DecimalArrayFlightSqlAccessor<Decimal128Array, odbcabstraction::CDataType_NUMERI
 
   result->precision = data_type_->precision();
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[i] = static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[i] = static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
 
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <typename ARROW_ARRAY, CDataType TARGET_TYPE>
-size_t DecimalArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetCellLength_impl(
+size_t DecimalArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(NUMERIC_STRUCT);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor.h
@@ -37,11 +37,11 @@ class DecimalArrayFlightSqlAccessor
  public:
   explicit DecimalArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                                int64_t& value_offset, bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                               int64_t& value_offset, bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 
  private:
   Decimal128Type* data_type_;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor_test.cc
@@ -84,10 +84,10 @@ void AssertNumericOutput(int input_precision, int input_scale,
       accessor(array.get());
 
   std::vector<NUMERIC_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_NUMERIC, output_precision,
-                        output_scale, buffer.data(), 0, strlen_buffer.data());
+                        output_scale, buffer.data(), 0, str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -96,7 +96,7 @@ void AssertNumericOutput(int input_precision, int input_scale,
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(NUMERIC_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(NUMERIC_STRUCT), str_len_buffer[i]);
 
     ASSERT_EQ(output_precision, buffer[i].precision);
     ASSERT_EQ(output_scale, buffer[i].scale);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor.cc
@@ -39,7 +39,7 @@ PrimitiveArrayFlightSqlAccessor<
           array) {}
 
 template <typename ARROW_ARRAY, CDataType TARGET_TYPE>
-size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetColumnarData_impl(
+size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetColumnarDataImpl(
     ColumnBinding* binding, int64_t starting_row, int64_t cells, int64_t& value_offset,
     bool update_value_offset, odbcabstraction::Diagnostics& diagnostics,
     uint16_t* row_status_array) {
@@ -48,7 +48,7 @@ size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetColumnarDat
 }
 
 template <typename ARROW_ARRAY, CDataType TARGET_TYPE>
-size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetCellLength_impl(
+size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(typename ARROW_ARRAY::TypeClass::c_type);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor.h
@@ -35,12 +35,12 @@ class PrimitiveArrayFlightSqlAccessor
  public:
   explicit PrimitiveArrayFlightSqlAccessor(Array* array);
 
-  size_t GetColumnarData_impl(ColumnBinding* binding, int64_t starting_row, int64_t cells,
-                              int64_t& value_offset, bool update_value_offset,
-                              odbcabstraction::Diagnostics& diagnostics,
-                              uint16_t* row_status_array);
+  size_t GetColumnarDataImpl(ColumnBinding* binding, int64_t starting_row, int64_t cells,
+                             int64_t& value_offset, bool update_value_offset,
+                             odbcabstraction::Diagnostics& diagnostics,
+                             uint16_t* row_status_array);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor_test.cc
@@ -48,10 +48,10 @@ void TestPrimitiveArraySqlAccessor() {
   PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE> accessor(array.get());
 
   std::vector<c_type> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(TARGET_TYPE, 0, 0, buffer.data(), values.size(),
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   driver::odbcabstraction::Diagnostics diagnostics("Dummy", "Dummy",
@@ -61,7 +61,7 @@ void TestPrimitiveArraySqlAccessor() {
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(c_type), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(c_type), str_len_buffer[i]);
     ASSERT_EQ(values[i], buffer[i]);
   }
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.cc
@@ -31,11 +31,11 @@ using odbcabstraction::RowStatus;
 namespace {
 
 #if defined _WIN32 || defined _WIN64
-std::string utf8_to_clocale(const char* utf8str, int len) {
+std::string Utf8ToCLocale(const char* utf8_str, int len) {
   thread_local boost::locale::generator g;
   g.locale_cache_enabled(true);
   std::locale loc = g(boost::locale::util::get_system_locale());
-  return boost::locale::conv::from_utf<char>(utf8str, utf8str + len, loc);
+  return boost::locale::conv::from_utf<char>(utf8_str, utf8_str + len, loc);
 }
 #endif
 
@@ -69,7 +69,7 @@ inline RowStatus MoveSingleCellToCharBuffer(std::vector<uint8_t>& buffer,
 #if defined _WIN32 || defined _WIN64
     // Convert to C locale string
     if (last_retrieved_arrow_row != arrow_row) {
-      clocale_str = utf8_to_clocale(raw_value, raw_value_length);
+      clocale_str = Utf8ToCLocale(raw_value, raw_value_length);
       last_retrieved_arrow_row = arrow_row;
     }
     const char* clocale_data = clocale_str.data();
@@ -112,8 +112,8 @@ inline RowStatus MoveSingleCellToCharBuffer(std::vector<uint8_t>& buffer,
     }
   }
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[i] = static_cast<ssize_t>(remaining_length);
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[i] = static_cast<ssize_t>(remaining_length);
   }
 
   return result;
@@ -129,7 +129,7 @@ StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::StringArrayFlightSqlAccess
       last_arrow_row_(-1) {}
 
 template <CDataType TARGET_TYPE, typename CHAR_TYPE>
-RowStatus StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::MoveSingleCell_impl(
+RowStatus StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t i, int64_t& value_offset,
     bool update_value_offset, odbcabstraction::Diagnostics& diagnostics) {
   return MoveSingleCellToCharBuffer<CHAR_TYPE>(buffer_, last_arrow_row_,
@@ -142,7 +142,7 @@ RowStatus StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::MoveSingleCell_i
 }
 
 template <CDataType TARGET_TYPE, typename CHAR_TYPE>
-size_t StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::GetCellLength_impl(
+size_t StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return binding->buffer_length;
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.h
@@ -41,11 +41,11 @@ class StringArrayFlightSqlAccessor
  public:
   explicit StringArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                                int64_t& value_offset, bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                               int64_t& value_offset, bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 
  private:
   std::vector<uint8_t> buffer_;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor_test.cc
@@ -37,12 +37,12 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Basic) {
   StringArrayFlightSqlAccessor<odbcabstraction::CDataType_CHAR, char> accessor(
       array.get());
 
-  size_t max_strlen = 64;
-  std::vector<char> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 64;
+  std::vector<char> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
-  ColumnBinding binding(odbcabstraction::CDataType_CHAR, 0, 0, buffer.data(), max_strlen,
-                        strlen_buffer.data());
+  ColumnBinding binding(odbcabstraction::CDataType_CHAR, 0, 0, buffer.data(), max_str_len,
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -51,8 +51,8 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Basic) {
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(values[i].length(), strlen_buffer[i]);
-    ASSERT_EQ(values[i], std::string(buffer.data() + i * max_strlen));
+    ASSERT_EQ(values[i].length(), str_len_buffer[i]);
+    ASSERT_EQ(values[i], std::string(buffer.data() + i * max_str_len));
   }
 }
 
@@ -64,12 +64,12 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Truncation) {
   StringArrayFlightSqlAccessor<odbcabstraction::CDataType_CHAR, char> accessor(
       array.get());
 
-  size_t max_strlen = 8;
-  std::vector<char> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 8;
+  std::vector<char> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
-  ColumnBinding binding(odbcabstraction::CDataType_CHAR, 0, 0, buffer.data(), max_strlen,
-                        strlen_buffer.data());
+  ColumnBinding binding(odbcabstraction::CDataType_CHAR, 0, 0, buffer.data(), max_str_len,
+                        str_len_buffer.data());
 
   std::stringstream ss;
   int64_t value_offset = 0;
@@ -82,7 +82,7 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Truncation) {
     int64_t original_value_offset = value_offset;
     ASSERT_EQ(1, accessor.GetColumnarData(&binding, 0, 1, value_offset, true, diagnostics,
                                           nullptr));
-    ASSERT_EQ(values[0].length() - original_value_offset, strlen_buffer[0]);
+    ASSERT_EQ(values[0].length() - original_value_offset, str_len_buffer[0]);
 
     ss << buffer.data();
   } while (value_offset < static_cast<int64_t>(values[0].length()) && value_offset != -1);
@@ -97,12 +97,12 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Basic) {
 
   auto accessor = CreateWCharStringArrayAccessor(array.get());
 
-  size_t max_strlen = 64;
-  std::vector<uint8_t> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 64;
+  std::vector<uint8_t> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
-  ColumnBinding binding(odbcabstraction::CDataType_WCHAR, 0, 0, buffer.data(), max_strlen,
-                        strlen_buffer.data());
+  ColumnBinding binding(odbcabstraction::CDataType_WCHAR, 0, 0, buffer.data(),
+                        max_str_len, str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -111,11 +111,11 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Basic) {
                                       diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(values[i].length() * GetSqlWCharSize(), strlen_buffer[i]);
+    ASSERT_EQ(values[i].length() * GetSqlWCharSize(), str_len_buffer[i]);
     std::vector<uint8_t> expected;
     Utf8ToWcs(values[i].c_str(), &expected);
-    uint8_t* start = buffer.data() + i * max_strlen;
-    auto actual = std::vector<uint8_t>(start, start + strlen_buffer[i]);
+    uint8_t* start = buffer.data() + i * max_str_len;
+    auto actual = std::vector<uint8_t>(start, start + str_len_buffer[i]);
     ASSERT_EQ(expected, actual);
   }
 }
@@ -127,12 +127,12 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Truncation) {
 
   auto accessor = CreateWCharStringArrayAccessor(array.get());
 
-  size_t max_strlen = 8;
-  std::vector<uint8_t> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 8;
+  std::vector<uint8_t> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
-  ColumnBinding binding(odbcabstraction::CDataType_WCHAR, 0, 0, buffer.data(), max_strlen,
-                        strlen_buffer.data());
+  ColumnBinding binding(odbcabstraction::CDataType_WCHAR, 0, 0, buffer.data(),
+                        max_str_len, str_len_buffer.data());
 
   int64_t value_offset = 0;
 
@@ -146,7 +146,7 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Truncation) {
     ASSERT_EQ(1, accessor->GetColumnarData(&binding, 0, 1, value_offset, true,
                                            diagnostics, nullptr));
     ASSERT_EQ(values[0].length() * GetSqlWCharSize() - original_value_offset,
-              strlen_buffer[0]);
+              str_len_buffer[0]);
 
     size_t length = value_offset - original_value_offset;
     if (value_offset == -1) {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor.cc
@@ -97,7 +97,7 @@ TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::TimeArrayFlightSqlAc
           array) {}
 
 template <CDataType TARGET_TYPE, typename ARROW_ARRAY, TimeUnit::type UNIT>
-RowStatus TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::MoveSingleCell_impl(
+RowStatus TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t cell_counter,
     int64_t& value_offset, bool update_value_offset,
     odbcabstraction::Diagnostics& diagnostic) {
@@ -114,15 +114,15 @@ RowStatus TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::MoveSingle
   buffer[cell_counter].minute = time.tm_min;
   buffer[cell_counter].second = time.tm_sec;
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[cell_counter] =
-        static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[cell_counter] =
+        static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <CDataType TARGET_TYPE, typename ARROW_ARRAY, TimeUnit::type UNIT>
-size_t TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::GetCellLength_impl(
+size_t TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(TIME_STRUCT);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor.h
@@ -37,12 +37,12 @@ class TimeArrayFlightSqlAccessor
  public:
   explicit TimeArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row,
-                                int64_t cell_counter, int64_t& value_offset,
-                                bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostic);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row,
+                               int64_t cell_counter, int64_t& value_offset,
+                               bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostic);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor_test.cc
@@ -50,10 +50,10 @@ TEST(TEST_TIME32, TIME_WITH_SECONDS) {
       accessor(time32_array.get());
 
   std::vector<TIME_STRUCT> buffer(t32_values.size());
-  std::vector<ssize_t> strlen_buffer(t32_values.size());
+  std::vector<ssize_t> str_len_buffer(t32_values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_TIME, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -62,7 +62,7 @@ TEST(TEST_TIME32, TIME_WITH_SECONDS) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < t32_values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIME_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIME_STRUCT), str_len_buffer[i]);
 
     tm time{};
 
@@ -86,10 +86,10 @@ TEST(TEST_TIME32, TIME_WITH_MILLI) {
       accessor(time32_array.get());
 
   std::vector<TIME_STRUCT> buffer(t32_values.size());
-  std::vector<ssize_t> strlen_buffer(t32_values.size());
+  std::vector<ssize_t> str_len_buffer(t32_values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_TIME, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -98,12 +98,12 @@ TEST(TEST_TIME32, TIME_WITH_MILLI) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < t32_values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIME_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIME_STRUCT), str_len_buffer[i]);
 
     tm time{};
 
-    auto convertedValue = t32_values[i] / odbcabstraction::MILLI_TO_SECONDS_DIVISOR;
-    GetTimeForSecondsSinceEpoch(convertedValue, time);
+    auto converted_value = t32_values[i] / odbcabstraction::MILLI_TO_SECONDS_DIVISOR;
+    GetTimeForSecondsSinceEpoch(converted_value, time);
 
     ASSERT_EQ(buffer[i].hour, time.tm_hour);
     ASSERT_EQ(buffer[i].minute, time.tm_min);
@@ -125,10 +125,10 @@ TEST(TEST_TIME64, TIME_WITH_MICRO) {
       accessor(time64_array.get());
 
   std::vector<TIME_STRUCT> buffer(t64_values.size());
-  std::vector<ssize_t> strlen_buffer(t64_values.size());
+  std::vector<ssize_t> str_len_buffer(t64_values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_TIME, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -137,7 +137,7 @@ TEST(TEST_TIME64, TIME_WITH_MICRO) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < t64_values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIME_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIME_STRUCT), str_len_buffer[i]);
 
     tm time{};
 
@@ -162,10 +162,10 @@ TEST(TEST_TIME64, TIME_WITH_NANO) {
       accessor(time64_array.get());
 
   std::vector<TIME_STRUCT> buffer(t64_values.size());
-  std::vector<ssize_t> strlen_buffer(t64_values.size());
+  std::vector<ssize_t> str_len_buffer(t64_values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_TIME, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -174,12 +174,12 @@ TEST(TEST_TIME64, TIME_WITH_NANO) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < t64_values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIME_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIME_STRUCT), str_len_buffer[i]);
 
     tm time{};
 
-    const auto convertedValue = t64_values[i] / odbcabstraction::NANO_TO_SECONDS_DIVISOR;
-    GetTimeForSecondsSinceEpoch(convertedValue, time);
+    const auto converted_value = t64_values[i] / odbcabstraction::NANO_TO_SECONDS_DIVISOR;
+    GetTimeForSecondsSinceEpoch(converted_value, time);
 
     ASSERT_EQ(buffer[i].hour, time.tm_hour);
     ASSERT_EQ(buffer[i].minute, time.tm_min);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.cc
@@ -84,7 +84,7 @@ TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::TimestampArrayFlightSqlAcces
                         TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>>(array) {}
 
 template <CDataType TARGET_TYPE, TimeUnit::type UNIT>
-RowStatus TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::MoveSingleCell_impl(
+RowStatus TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t cell_counter,
     int64_t& value_offset, bool update_value_offset,
     odbcabstraction::Diagnostics& diagnostics) {
@@ -120,16 +120,16 @@ RowStatus TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::MoveSingleCell_imp
   buffer[cell_counter].second = timestamp.tm_sec;
   buffer[cell_counter].fraction = CalculateFraction(UNIT, value);
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[cell_counter] =
-        static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[cell_counter] =
+        static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
 
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <CDataType TARGET_TYPE, TimeUnit::type UNIT>
-size_t TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::GetCellLength_impl(
+size_t TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(TIMESTAMP_STRUCT);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.h
@@ -36,12 +36,12 @@ class TimestampArrayFlightSqlAccessor
  public:
   explicit TimestampArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row,
-                                int64_t cell_counter, int64_t& value_offset,
-                                bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row,
+                               int64_t cell_counter, int64_t& value_offset,
+                               bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor_test.cc
@@ -74,18 +74,18 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MILLI) {
       accessor(timestamp_array.get());
 
   std::vector<TIMESTAMP_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   int64_t value_offset = 0;
   ColumnBinding binding(odbcabstraction::CDataType_TIMESTAMP, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
   ASSERT_EQ(values.size(),
             accessor.GetColumnarData(&binding, 0, values.size(), value_offset, false,
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), str_len_buffer[i]);
 
     ASSERT_EQ(buffer[i].year, expected[i].year);
     ASSERT_EQ(buffer[i].month, expected[i].month);
@@ -111,11 +111,11 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_SECONDS) {
       accessor(timestamp_array.get());
 
   std::vector<TIMESTAMP_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   int64_t value_offset = 0;
   ColumnBinding binding(odbcabstraction::CDataType_TIMESTAMP, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
 
   ASSERT_EQ(values.size(),
@@ -123,7 +123,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_SECONDS) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), str_len_buffer[i]);
     tm date{};
 
     auto converted_time = values[i];
@@ -152,11 +152,11 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MICRO) {
       accessor(timestamp_array.get());
 
   std::vector<TIMESTAMP_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   int64_t value_offset = 0;
   ColumnBinding binding(odbcabstraction::CDataType_TIMESTAMP, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
 
   ASSERT_EQ(values.size(),
@@ -164,7 +164,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MICRO) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), str_len_buffer[i]);
 
     tm date{};
 
@@ -196,11 +196,11 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_NANO) {
       accessor(timestamp_array.get());
 
   std::vector<TIMESTAMP_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   int64_t value_offset = 0;
   ColumnBinding binding(odbcabstraction::CDataType_TIMESTAMP, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
   ASSERT_EQ(values.size(),
@@ -208,7 +208,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_NANO) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), str_len_buffer[i]);
     tm date{};
 
     auto converted_time = values[i] / odbcabstraction::NANO_TO_SECONDS_DIVISOR;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/types.h
@@ -37,7 +37,7 @@ class FlightSqlResultSet;
 
 struct ColumnBinding {
   void* buffer;
-  ssize_t* strlen_buffer;
+  ssize_t* str_len_buffer;
   size_t buffer_length;
   CDataType target_type;
   int precision;
@@ -46,13 +46,13 @@ struct ColumnBinding {
   ColumnBinding() = default;
 
   ColumnBinding(CDataType target_type, int precision, int scale, void* buffer,
-                size_t buffer_length, ssize_t* strlen_buffer)
+                size_t buffer_length, ssize_t* str_len_buffer)
       : target_type(target_type),
         precision(precision),
         scale(scale),
         buffer(buffer),
         buffer_length(buffer_length),
-        strlen_buffer(strlen_buffer) {}
+        str_len_buffer(str_len_buffer) {}
 };
 
 /// \brief Accessor interface meant to provide a way of populating data of a
@@ -86,31 +86,31 @@ class FlightSqlAccessor : public Accessor {
                          int64_t& value_offset, bool update_value_offset,
                          odbcabstraction::Diagnostics& diagnostics,
                          uint16_t* row_status_array) override {
-    return static_cast<DERIVED*>(this)->GetColumnarData_impl(
+    return static_cast<DERIVED*>(this)->GetColumnarDataImpl(
         binding, starting_row, cells, value_offset, update_value_offset, diagnostics,
         row_status_array);
   }
 
   size_t GetCellLength(ColumnBinding* binding) const override {
-    return static_cast<const DERIVED*>(this)->GetCellLength_impl(binding);
+    return static_cast<const DERIVED*>(this)->GetCellLengthImpl(binding);
   }
 
  protected:
-  size_t GetColumnarData_impl(ColumnBinding* binding, int64_t starting_row, int64_t cells,
-                              int64_t& value_offset, bool update_value_offset,
-                              odbcabstraction::Diagnostics& diagnostics,
-                              uint16_t* row_status_array) {
+  size_t GetColumnarDataImpl(ColumnBinding* binding, int64_t starting_row, int64_t cells,
+                             int64_t& value_offset, bool update_value_offset,
+                             odbcabstraction::Diagnostics& diagnostics,
+                             uint16_t* row_status_array) {
     for (int64_t i = 0; i < cells; ++i) {
       int64_t current_arrow_row = starting_row + i;
       if (array_->IsNull(current_arrow_row)) {
-        if (binding->strlen_buffer) {
-          binding->strlen_buffer[i] = odbcabstraction::NULL_DATA;
+        if (binding->str_len_buffer) {
+          binding->str_len_buffer[i] = odbcabstraction::NULL_DATA;
         } else {
           throw odbcabstraction::NullWithoutIndicatorException();
         }
       } else {
         // TODO: Optimize this by creating different versions of MoveSingleCell
-        // depending on if strlen_buffer is null.
+        // depending on if str_len_buffer is null.
         auto row_status = MoveSingleCell(binding, current_arrow_row, i, value_offset,
                                          update_value_offset, diagnostics);
         if (row_status_array) {
@@ -131,11 +131,11 @@ class FlightSqlAccessor : public Accessor {
                                             int64_t i, int64_t& value_offset,
                                             bool update_value_offset,
                                             odbcabstraction::Diagnostics& diagnostics) {
-    return static_cast<DERIVED*>(this)->MoveSingleCell_impl(
+    return static_cast<DERIVED*>(this)->MoveSingleCellImpl(
         binding, arrow_row, i, value_offset, update_value_offset, diagnostics);
   }
 
-  odbcabstraction::RowStatus MoveSingleCell_impl(
+  odbcabstraction::RowStatus MoveSingleCellImpl(
       ColumnBinding* binding, int64_t arrow_row, int64_t i, int64_t& value_offset,
       bool update_value_offset, odbcabstraction::Diagnostics& diagnostics) {
     std::stringstream ss;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
@@ -37,26 +37,26 @@ static const char DEFAULT_DISABLE_CERT_VERIFICATION[] = FALSE_STR;
 namespace {
 std::string ReadDsnString(const std::string& dsn, const std::string_view& key,
                           const std::string& dflt = "") {
-  std::wstring wDsn = arrow::util::UTF8ToWideString(dsn).ValueOr(L"");
-  std::wstring wKey = arrow::util::UTF8ToWideString(key).ValueOr(L"");
-  std::wstring wDflt = arrow::util::UTF8ToWideString(dflt).ValueOr(L"");
+  std::wstring wdsn = arrow::util::UTF8ToWideString(dsn).ValueOr(L"");
+  std::wstring wkey = arrow::util::UTF8ToWideString(key).ValueOr(L"");
+  std::wstring wdflt = arrow::util::UTF8ToWideString(dflt).ValueOr(L"");
 
 #define BUFFER_SIZE (1024)
   std::vector<wchar_t> buf(BUFFER_SIZE);
   int ret =
-      SQLGetPrivateProfileString(wDsn.c_str(), wKey.c_str(), wDflt.c_str(), buf.data(),
+      SQLGetPrivateProfileString(wdsn.c_str(), wkey.c_str(), wdflt.c_str(), buf.data(),
                                  static_cast<int>(buf.size()), L"ODBC.INI");
 
   if (ret > BUFFER_SIZE) {
     // If there wasn't enough space, try again with the right size buffer.
     buf.resize(ret + 1);
     ret =
-        SQLGetPrivateProfileString(wDsn.c_str(), wKey.c_str(), wDflt.c_str(), buf.data(),
+        SQLGetPrivateProfileString(wdsn.c_str(), wkey.c_str(), wdflt.c_str(), buf.data(),
                                    static_cast<int>(buf.size()), L"ODBC.INI");
   }
 
-  std::wstring wResult = std::wstring(buf.data(), ret);
-  std::string result = arrow::util::WideStringToUTF8(wResult).ValueOr("");
+  std::wstring wresult = std::wstring(buf.data(), ret);
+  std::string result = arrow::util::WideStringToUTF8(wresult).ValueOr("");
   return result;
 }
 
@@ -189,12 +189,12 @@ const driver::odbcabstraction::Connection::ConnPropertyMap& Configuration::GetPr
 }
 
 std::vector<std::string> Configuration::GetCustomKeys() const {
-  driver::odbcabstraction::Connection::ConnPropertyMap copyProps(properties);
+  driver::odbcabstraction::Connection::ConnPropertyMap copy_props(properties);
   for (auto& key : FlightSqlConnection::ALL_KEYS) {
-    copyProps.erase(std::string(key));
+    copy_props.erase(std::string(key));
   }
   std::vector<std::string> keys;
-  boost::copy(copyProps | boost::adaptors::map_keys, std::back_inserter(keys));
+  boost::copy(copy_props | boost::adaptors::map_keys, std::back_inserter(keys));
   return keys;
 }
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
@@ -92,14 +92,15 @@ class UserPasswordAuthMethod : public FlightSqlAuthMethod {
         client_.AuthenticateBasicToken(auth_call_options, user_, password_);
 
     if (!bearer_result.ok()) {
-      const auto& flightStatus =
+      const auto& flight_status =
           arrow::flight::FlightStatusDetail::UnwrapStatus(bearer_result.status());
-      if (flightStatus != nullptr) {
-        if (flightStatus->code() == arrow::flight::FlightStatusCode::Unauthenticated) {
+      if (flight_status != nullptr) {
+        if (flight_status->code() == arrow::flight::FlightStatusCode::Unauthenticated) {
           throw AuthenticationException(
               "Failed to authenticate with user and password: " +
               bearer_result.status().ToString());
-        } else if (flightStatus->code() == arrow::flight::FlightStatusCode::Unavailable) {
+        } else if (flight_status->code() ==
+                   arrow::flight::FlightStatusCode::Unavailable) {
           throw CommunicationException(bearer_result.status().message());
         }
       }
@@ -141,12 +142,13 @@ class TokenAuthMethod : public FlightSqlAuthMethod {
         call_options,
         std::unique_ptr<arrow::flight::ClientAuthHandler>(new NoOpClientAuthHandler()));
     if (!status.ok()) {
-      const auto& flightStatus = arrow::flight::FlightStatusDetail::UnwrapStatus(status);
-      if (flightStatus != nullptr) {
-        if (flightStatus->code() == arrow::flight::FlightStatusCode::Unauthenticated) {
+      const auto& flight_status = arrow::flight::FlightStatusDetail::UnwrapStatus(status);
+      if (flight_status != nullptr) {
+        if (flight_status->code() == arrow::flight::FlightStatusCode::Unauthenticated) {
           throw AuthenticationException("Failed to authenticate with token: " + token_ +
                                         " Message: " + status.message());
-        } else if (flightStatus->code() == arrow::flight::FlightStatusCode::Unavailable) {
+        } else if (flight_status->code() ==
+                   arrow::flight::FlightStatusCode::Unavailable) {
           throw CommunicationException(status.message());
         }
       }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
@@ -141,20 +141,20 @@ Connection::ConnPropertyMap::const_iterator TrackMissingRequiredProperty(
 }  // namespace
 
 std::shared_ptr<FlightSqlSslConfig> LoadFlightSslConfigs(
-    const Connection::ConnPropertyMap& connPropertyMap) {
+    const Connection::ConnPropertyMap& conn_property_map) {
   bool use_encryption =
-      AsBool(connPropertyMap, FlightSqlConnection::USE_ENCRYPTION).value_or(true);
+      AsBool(conn_property_map, FlightSqlConnection::USE_ENCRYPTION).value_or(true);
   bool disable_cert =
-      AsBool(connPropertyMap, FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION)
+      AsBool(conn_property_map, FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION)
           .value_or(false);
   bool use_system_trusted =
-      AsBool(connPropertyMap, FlightSqlConnection::USE_SYSTEM_TRUST_STORE)
+      AsBool(conn_property_map, FlightSqlConnection::USE_SYSTEM_TRUST_STORE)
           .value_or(SYSTEM_TRUST_STORE_DEFAULT);
 
   // GH-47630: find co-located TLS certificate if `trusted certs` path is not specified
   auto trusted_certs_iterator =
-      connPropertyMap.find(std::string(FlightSqlConnection::TRUSTED_CERTS));
-  auto trusted_certs = trusted_certs_iterator != connPropertyMap.end()
+      conn_property_map.find(std::string(FlightSqlConnection::TRUSTED_CERTS));
+  auto trusted_certs = trusted_certs_iterator != conn_property_map.end()
                            ? trusted_certs_iterator->second
                            : "";
 
@@ -227,7 +227,7 @@ boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(
   return boost::none;
 }
 
-bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap& connPropertyMap) {
+bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap& conn_property_map) {
 #if defined _WIN32 || defined _WIN64
   // Windows should use wide chars by default
   bool default_value = true;
@@ -235,15 +235,15 @@ bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap& connPropertyMap)
   // Mac and Linux should not use wide chars by default
   bool default_value = false;
 #endif
-  return AsBool(connPropertyMap, FlightSqlConnection::USE_WIDE_CHAR)
+  return AsBool(conn_property_map, FlightSqlConnection::USE_WIDE_CHAR)
       .value_or(default_value);
 }
 
 size_t FlightSqlConnection::GetChunkBufferCapacity(
-    const ConnPropertyMap& connPropertyMap) {
+    const ConnPropertyMap& conn_property_map) {
   size_t default_value = 5;
   try {
-    return AsInt32(1, connPropertyMap, FlightSqlConnection::CHUNK_BUFFER_CAPACITY)
+    return AsInt32(1, conn_property_map, FlightSqlConnection::CHUNK_BUFFER_CAPACITY)
         .value_or(default_value);
   } catch (const std::exception& e) {
     diagnostics_.AddWarning(
@@ -299,18 +299,18 @@ FlightClientOptions FlightSqlConnection::BuildFlightClientOptions(
   // Persist state information using cookies if the FlightProducer supports it.
   options.middleware.push_back(arrow::flight::GetCookieFactory());
 
-  if (ssl_config->useEncryption()) {
-    if (ssl_config->shouldDisableCertificateVerification()) {
+  if (ssl_config->UseEncryption()) {
+    if (ssl_config->ShouldDisableCertificateVerification()) {
       options.disable_server_verification =
-          ssl_config->shouldDisableCertificateVerification();
+          ssl_config->ShouldDisableCertificateVerification();
     } else {
-      if (ssl_config->useSystemTrustStore()) {
+      if (ssl_config->UseSystemTrustStore()) {
         const std::string certs = GetCerts();
 
         options.tls_root_certs = certs;
-      } else if (!ssl_config->getTrustedCerts().empty()) {
+      } else if (!ssl_config->GetTrustedCerts().empty()) {
         arrow::flight::CertKeyPair cert_key_pair;
-        ssl_config->populateOptionsWithCerts(&cert_key_pair);
+        ssl_config->PopulateOptionsWithCerts(&cert_key_pair);
         options.tls_root_certs = cert_key_pair.pem_cert;
       }
     }
@@ -338,7 +338,7 @@ Location FlightSqlConnection::BuildLocation(
   const int& port = boost::lexical_cast<int>(port_iter->second);
 
   Location location;
-  if (ssl_config->useEncryption()) {
+  if (ssl_config->UseEncryption()) {
     AddressInfo address_info;
     char host_name_info[NI_MAXHOST] = "";
     bool operation_result = false;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
@@ -43,7 +43,7 @@ class FlightSqlSslConfig;
 /// \param connPropertyMap the map with the Connection properties.
 /// \return                An instance of the FlightSqlSslConfig.
 std::shared_ptr<FlightSqlSslConfig> LoadFlightSslConfigs(
-    const odbcabstraction::Connection::ConnPropertyMap& connPropertyMap);
+    const odbcabstraction::Connection::ConnPropertyMap& conn_property_map);
 
 class FlightSqlConnection : public odbcabstraction::Connection {
  private:
@@ -57,7 +57,7 @@ class FlightSqlConnection : public odbcabstraction::Connection {
   odbcabstraction::OdbcVersion odbc_version_;
   bool closed_;
 
-  void PopulateMetadataSettings(const Connection::ConnPropertyMap& connPropertyMap);
+  void PopulateMetadataSettings(const Connection::ConnPropertyMap& conn_property_map);
 
  public:
   static const std::vector<std::string_view> ALL_KEYS;
@@ -120,11 +120,12 @@ class FlightSqlConnection : public odbcabstraction::Connection {
   /// \note Visible for testing
   void SetClosed(bool is_closed);
 
-  boost::optional<int32_t> GetStringColumnLength(const ConnPropertyMap& connPropertyMap);
+  boost::optional<int32_t> GetStringColumnLength(
+      const ConnPropertyMap& conn_property_map);
 
-  bool GetUseWideChar(const ConnPropertyMap& connPropertyMap);
+  bool GetUseWideChar(const ConnPropertyMap& conn_property_map);
 
-  size_t GetChunkBufferCapacity(const ConnPropertyMap& connPropertyMap);
+  size_t GetChunkBufferCapacity(const ConnPropertyMap& conn_property_map);
 };
 }  // namespace flight_sql
 }  // namespace driver

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
@@ -32,20 +32,20 @@ TEST(AttributeTests, SetAndGetAttribute) {
   connection.SetClosed(false);
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(200));
-  const boost::optional<Connection::Attribute> firstValue =
+  const boost::optional<Connection::Attribute> first_value =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
-  EXPECT_TRUE(firstValue);
+  EXPECT_TRUE(first_value);
 
-  EXPECT_EQ(boost::get<uint32_t>(*firstValue), static_cast<uint32_t>(200));
+  EXPECT_EQ(boost::get<uint32_t>(*first_value), static_cast<uint32_t>(200));
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(300));
 
-  const boost::optional<Connection::Attribute> changeValue =
+  const boost::optional<Connection::Attribute> change_value =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
-  EXPECT_TRUE(changeValue);
-  EXPECT_EQ(boost::get<uint32_t>(*changeValue), static_cast<uint32_t>(300));
+  EXPECT_TRUE(change_value);
+  EXPECT_EQ(boost::get<uint32_t>(*change_value), static_cast<uint32_t>(300));
 
   connection.Close();
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.cc
@@ -146,9 +146,10 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
                 accessor->GetCellLength(&shifted_binding) * fetched_rows + bind_offset;
           }
 
-          if (shifted_binding.strlen_buffer) {
-            shifted_binding.strlen_buffer = reinterpret_cast<ssize_t*>(
-                reinterpret_cast<uint8_t*>(&shifted_binding.strlen_buffer[fetched_rows]) +
+          if (shifted_binding.str_len_buffer) {
+            shifted_binding.str_len_buffer = reinterpret_cast<ssize_t*>(
+                reinterpret_cast<uint8_t*>(
+                    &shifted_binding.str_len_buffer[fetched_rows]) +
                 bind_offset);
           }
 
@@ -165,9 +166,9 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
                                      bind_offset + bind_type * fetched_rows;
           }
 
-          if (shifted_binding.strlen_buffer) {
-            shifted_binding.strlen_buffer = reinterpret_cast<ssize_t*>(
-                reinterpret_cast<uint8_t*>(shifted_binding.strlen_buffer) + bind_offset +
+          if (shifted_binding.str_len_buffer) {
+            shifted_binding.str_len_buffer = reinterpret_cast<ssize_t*>(
+                reinterpret_cast<uint8_t*>(shifted_binding.str_len_buffer) + bind_offset +
                 bind_type * fetched_rows);
           }
 
@@ -185,9 +186,9 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
                   static_cast<uint8_t*>(shifted_binding.buffer) + bind_type;
             }
 
-            if (shifted_binding.strlen_buffer) {
-              shifted_binding.strlen_buffer = reinterpret_cast<ssize_t*>(
-                  reinterpret_cast<uint8_t*>(shifted_binding.strlen_buffer) + bind_type);
+            if (shifted_binding.str_len_buffer) {
+              shifted_binding.str_len_buffer = reinterpret_cast<ssize_t*>(
+                  reinterpret_cast<uint8_t*>(shifted_binding.str_len_buffer) + bind_type);
             }
 
             if (shifted_row_status_array) {
@@ -231,7 +232,7 @@ void FlightSqlResultSet::Cancel() {
 
 SQLRETURN FlightSqlResultSet::GetData(int column_n, int16_t target_type, int precision,
                                       int scale, void* buffer, size_t buffer_length,
-                                      ssize_t* strlen_buffer) {
+                                      ssize_t* str_len_buffer) {
   reset_get_data_ = true;
   // Check if the offset is already at the end.
   int64_t& value_offset = get_data_offsets_[column_n - 1];
@@ -240,7 +241,7 @@ SQLRETURN FlightSqlResultSet::GetData(int column_n, int16_t target_type, int pre
   }
 
   ColumnBinding binding(ConvertCDataTypeFromV2ToV3(target_type), precision, scale, buffer,
-                        buffer_length, strlen_buffer);
+                        buffer_length, str_len_buffer);
 
   auto& column = columns_[column_n - 1];
   Accessor* accessor = column.GetAccessorForGetData(binding.target_type);
@@ -263,7 +264,7 @@ std::shared_ptr<ResultSetMetadata> FlightSqlResultSet::GetMetadata() { return me
 
 void FlightSqlResultSet::BindColumn(int column_n, int16_t target_type, int precision,
                                     int scale, void* buffer, size_t buffer_length,
-                                    ssize_t* strlen_buffer) {
+                                    ssize_t* str_len_buffer) {
   auto& column = columns_[column_n - 1];
   if (buffer == nullptr) {
     if (column.is_bound_) {
@@ -278,7 +279,7 @@ void FlightSqlResultSet::BindColumn(int column_n, int16_t target_type, int preci
   }
 
   ColumnBinding binding(ConvertCDataTypeFromV2ToV3(target_type), precision, scale, buffer,
-                        buffer_length, strlen_buffer);
+                        buffer_length, str_len_buffer);
   column.SetBinding(binding, schema_->field(column_n - 1)->type()->id());
 }
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.h
@@ -75,7 +75,7 @@ class FlightSqlResultSet : public ResultSet {
   void Cancel() override;
 
   SQLRETURN GetData(int column_n, int16_t target_type, int precision, int scale,
-                    void* buffer, size_t buffer_length, ssize_t* strlen_buffer) override;
+                    void* buffer, size_t buffer_length, ssize_t* str_len_buffer) override;
 
   size_t Move(size_t rows, size_t bind_offset, size_t bind_type,
               uint16_t* row_status_array) override;
@@ -83,7 +83,7 @@ class FlightSqlResultSet : public ResultSet {
   std::shared_ptr<ResultSetMetadata> GetMetadata() override;
 
   void BindColumn(int column_n, int16_t target_type, int precision, int scale,
-                  void* buffer, size_t buffer_length, ssize_t* strlen_buffer) override;
+                  void* buffer, size_t buffer_length, ssize_t* str_len_buffer) override;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_metadata.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_metadata.cc
@@ -68,7 +68,7 @@ size_t FlightSqlResultSetMetadata::GetPrecision(int column_position) {
 
   int32_t column_size = GetFieldPrecision(field).ValueOrElse([] { return 0; });
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return GetColumnSize(data_type_v3, column_size).value_or(0);
 }
@@ -79,16 +79,16 @@ size_t FlightSqlResultSetMetadata::GetScale(int column_position) {
 
   int32_t type_scale = metadata.GetScale().ValueOrElse([] { return 0; });
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return GetTypeScale(data_type_v3, type_scale).value_or(0);
 }
 
 uint16_t FlightSqlResultSetMetadata::GetDataType(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
-  const SqlDataType conciseType =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
-  return GetNonConciseDataType(conciseType);
+  const SqlDataType concise_type =
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+  return GetNonConciseDataType(concise_type);
 }
 
 driver::odbcabstraction::Nullability FlightSqlResultSetMetadata::IsNullable(
@@ -129,7 +129,7 @@ size_t FlightSqlResultSetMetadata::GetColumnDisplaySize(int column_position) {
   int32_t column_size = metadata_settings_.string_column_length_.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return GetDisplaySize(data_type_v3, column_size).value_or(odbcabstraction::NO_TOTAL);
 }
@@ -148,7 +148,7 @@ uint16_t FlightSqlResultSetMetadata::GetConciseType(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
 
   const SqlDataType sqlColumnType =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
   return sqlColumnType;
 }
 
@@ -158,7 +158,7 @@ size_t FlightSqlResultSetMetadata::GetLength(int column_position) {
   int32_t column_size = metadata_settings_.string_column_length_.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return flight_sql::GetLength(data_type_v3, column_size)
       .value_or(DefaultLengthForVariableLengthColumns);
@@ -185,7 +185,7 @@ std::string FlightSqlResultSetMetadata::GetLocalTypeName(int column_position) {
 size_t FlightSqlResultSetMetadata::GetNumPrecRadix(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return GetRadixFromSqlDataType(data_type_v3).value_or(odbcabstraction::NO_TOTAL);
 }
@@ -197,7 +197,7 @@ size_t FlightSqlResultSetMetadata::GetOctetLength(int column_position) {
   int32_t column_size = metadata_settings_.string_column_length_.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   // Workaround to get the precision for Decimal and Numeric types, since server doesn't
   // return it currently.

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_ssl_config.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_ssl_config.cc
@@ -24,30 +24,30 @@
 namespace driver {
 namespace flight_sql {
 
-FlightSqlSslConfig::FlightSqlSslConfig(bool disableCertificateVerification,
-                                       const std::string& trustedCerts,
-                                       bool systemTrustStore, bool useEncryption)
-    : trustedCerts_(trustedCerts),
-      useEncryption_(useEncryption),
-      disableCertificateVerification_(disableCertificateVerification),
-      systemTrustStore_(systemTrustStore) {}
+FlightSqlSslConfig::FlightSqlSslConfig(bool disable_certificate_verification,
+                                       const std::string& trusted_certs,
+                                       bool system_trust_store, bool use_encryption)
+    : trusted_certs_(trusted_certs),
+      use_encryption_(use_encryption),
+      disable_certificate_verification_(disable_certificate_verification),
+      system_trust_store_(system_trust_store) {}
 
-bool FlightSqlSslConfig::useEncryption() const { return useEncryption_; }
+bool FlightSqlSslConfig::UseEncryption() const { return use_encryption_; }
 
-bool FlightSqlSslConfig::shouldDisableCertificateVerification() const {
-  return disableCertificateVerification_;
+bool FlightSqlSslConfig::ShouldDisableCertificateVerification() const {
+  return disable_certificate_verification_;
 }
 
-const std::string& FlightSqlSslConfig::getTrustedCerts() const { return trustedCerts_; }
+const std::string& FlightSqlSslConfig::GetTrustedCerts() const { return trusted_certs_; }
 
-bool FlightSqlSslConfig::useSystemTrustStore() const { return systemTrustStore_; }
+bool FlightSqlSslConfig::UseSystemTrustStore() const { return system_trust_store_; }
 
-void FlightSqlSslConfig::populateOptionsWithCerts(arrow::flight::CertKeyPair* out) {
+void FlightSqlSslConfig::PopulateOptionsWithCerts(arrow::flight::CertKeyPair* out) {
   try {
-    std::ifstream cert_file(trustedCerts_);
+    std::ifstream cert_file(trusted_certs_);
     if (!cert_file) {
       throw odbcabstraction::DriverException("Could not open certificate: " +
-                                             trustedCerts_);
+                                             trusted_certs_);
     }
     std::stringstream cert;
     cert << cert_file.rdbuf();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_ssl_config.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_ssl_config.h
@@ -28,35 +28,36 @@ namespace flight_sql {
 ///        a SSL connection.
 class FlightSqlSslConfig {
  public:
-  FlightSqlSslConfig(bool disableCertificateVerification, const std::string& trustedCerts,
-                     bool systemTrustStore, bool useEncryption);
+  FlightSqlSslConfig(bool disable_certificate_verification,
+                     const std::string& trusted_certs, bool system_trust_store,
+                     bool use_encryption);
 
   /// \brief  Tells if ssl is enabled. By default it will be true.
   /// \return Whether ssl is enabled.
-  bool useEncryption() const;
+  bool UseEncryption() const;
 
   /// \brief  Tells if disable certificate verification is enabled.
   /// \return Whether disable certificate verification is enabled.
-  bool shouldDisableCertificateVerification() const;
+  bool ShouldDisableCertificateVerification() const;
 
   /// \brief  The path to the trusted certificate.
   /// \return Certificate path.
-  const std::string& getTrustedCerts() const;
+  const std::string& GetTrustedCerts() const;
 
   /// \brief  Tells if we need to check if the certificate is in the system trust store.
   /// \return Whether to use the system trust store.
-  bool useSystemTrustStore() const;
+  bool UseSystemTrustStore() const;
 
   /// \brief Loads the certificate file and extract the certificate file from it
   ///        and create the object CertKeyPair with it on.
   /// \param out A CertKeyPair with the cert on it.
-  void populateOptionsWithCerts(arrow::flight::CertKeyPair* out);
+  void PopulateOptionsWithCerts(arrow::flight::CertKeyPair* out);
 
  private:
-  const std::string trustedCerts_;
-  const bool useEncryption_;
-  const bool disableCertificateVerification_;
-  const bool systemTrustStore_;
+  const std::string trusted_certs_;
+  const bool use_encryption_;
+  const bool disable_certificate_verification_;
+  const bool system_trust_store_;
 };
 }  // namespace flight_sql
 }  // namespace driver

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
@@ -267,7 +267,7 @@ std::shared_ptr<ResultSet> FlightSqlStatement::GetTypeInfo_V2(int16_t data_type)
 
   auto flight_info = result.ValueOrDie();
 
-  auto transformer = std::make_shared<GetTypeInfo_Transformer>(
+  auto transformer = std::make_shared<GetTypeInfoTransformer>(
       metadata_settings_, odbcabstraction::V_2, data_type);
 
   current_result_set_ = std::make_shared<FlightSqlResultSet>(
@@ -285,7 +285,7 @@ std::shared_ptr<ResultSet> FlightSqlStatement::GetTypeInfo_V3(int16_t data_type)
 
   auto flight_info = result.ValueOrDie();
 
-  auto transformer = std::make_shared<GetTypeInfo_Transformer>(
+  auto transformer = std::make_shared<GetTypeInfoTransformer>(
       metadata_settings_, odbcabstraction::V_3, data_type);
 
   current_result_set_ = std::make_shared<FlightSqlResultSet>(

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_columns.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_columns.cc
@@ -78,7 +78,7 @@ std::shared_ptr<Schema> GetColumns_V2_Schema() {
   });
 }
 
-Result<std::shared_ptr<RecordBatch>> Transform_inner(
+Result<std::shared_ptr<RecordBatch>> TransformInner(
     const odbcabstraction::OdbcVersion odbc_version,
     const std::shared_ptr<RecordBatch>& original,
     const optional<std::string>& column_name_pattern,
@@ -113,7 +113,7 @@ Result<std::shared_ptr<RecordBatch>> Transform_inner(
       }
 
       odbcabstraction::SqlDataType data_type_v3 =
-          GetDataTypeFromArrowField_V3(field, metadata_settings.use_wide_char_);
+          GetDataTypeFromArrowFieldV3(field, metadata_settings.use_wide_char_);
 
       ColumnMetadata metadata(field->metadata());
 
@@ -233,7 +233,7 @@ GetColumns_Transformer::GetColumns_Transformer(
 std::shared_ptr<RecordBatch> GetColumns_Transformer::Transform(
     const std::shared_ptr<RecordBatch>& original) {
   const Result<std::shared_ptr<RecordBatch>>& result =
-      Transform_inner(odbc_version_, original, column_name_pattern_, metadata_settings_);
+      TransformInner(odbc_version_, original, column_name_pattern_, metadata_settings_);
   ThrowIfNotOK(result.status());
 
   return result.ValueOrDie();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.cc
@@ -78,12 +78,12 @@ std::shared_ptr<Schema> GetTypeInfo_V2_Schema() {
   });
 }
 
-Result<std::shared_ptr<RecordBatch>> Transform_inner(
+Result<std::shared_ptr<RecordBatch>> TransformInner(
     const odbcabstraction::OdbcVersion odbc_version,
     const std::shared_ptr<RecordBatch>& original, int data_type,
     const MetadataSettings& metadata_settings_) {
-  GetTypeInfo_RecordBatchBuilder builder(odbc_version);
-  GetTypeInfo_RecordBatchBuilder::Data data;
+  GetTypeInfoRecordBatchBuilder builder(odbc_version);
+  GetTypeInfoRecordBatchBuilder::Data data;
 
   GetTypeInfoReader reader(original);
 
@@ -139,11 +139,11 @@ Result<std::shared_ptr<RecordBatch>> Transform_inner(
 }
 }  // namespace
 
-GetTypeInfo_RecordBatchBuilder::GetTypeInfo_RecordBatchBuilder(
+GetTypeInfoRecordBatchBuilder::GetTypeInfoRecordBatchBuilder(
     odbcabstraction::OdbcVersion odbc_version)
     : odbc_version_(odbc_version) {}
 
-Result<std::shared_ptr<RecordBatch>> GetTypeInfo_RecordBatchBuilder::Build() {
+Result<std::shared_ptr<RecordBatch>> GetTypeInfoRecordBatchBuilder::Build() {
   ARROW_ASSIGN_OR_RAISE(auto TYPE_NAME_Array, TYPE_NAME_Builder_.Finish())
   ARROW_ASSIGN_OR_RAISE(auto DATA_TYPE_Array, DATA_TYPE_Builder_.Finish())
   ARROW_ASSIGN_OR_RAISE(auto COLUMN_SIZE_Array, COLUMN_SIZE_Builder_.Finish())
@@ -181,8 +181,8 @@ Result<std::shared_ptr<RecordBatch>> GetTypeInfo_RecordBatchBuilder::Build() {
   return RecordBatch::Make(schema, num_rows_, arrays);
 }
 
-Status GetTypeInfo_RecordBatchBuilder::Append(
-    const GetTypeInfo_RecordBatchBuilder::Data& data) {
+Status GetTypeInfoRecordBatchBuilder::Append(
+    const GetTypeInfoRecordBatchBuilder::Data& data) {
   ARROW_RETURN_NOT_OK(AppendToBuilder(TYPE_NAME_Builder_, data.type_name));
   ARROW_RETURN_NOT_OK(AppendToBuilder(DATA_TYPE_Builder_, data.data_type));
   ARROW_RETURN_NOT_OK(AppendToBuilder(COLUMN_SIZE_Builder_, data.column_size));
@@ -210,23 +210,23 @@ Status GetTypeInfo_RecordBatchBuilder::Append(
   return Status::OK();
 }
 
-GetTypeInfo_Transformer::GetTypeInfo_Transformer(
+GetTypeInfoTransformer::GetTypeInfoTransformer(
     const MetadataSettings& metadata_settings,
     const odbcabstraction::OdbcVersion odbc_version, int data_type)
     : metadata_settings_(metadata_settings),
       odbc_version_(odbc_version),
       data_type_(data_type) {}
 
-std::shared_ptr<RecordBatch> GetTypeInfo_Transformer::Transform(
+std::shared_ptr<RecordBatch> GetTypeInfoTransformer::Transform(
     const std::shared_ptr<RecordBatch>& original) {
   const Result<std::shared_ptr<RecordBatch>>& result =
-      Transform_inner(odbc_version_, original, data_type_, metadata_settings_);
+      TransformInner(odbc_version_, original, data_type_, metadata_settings_);
   ThrowIfNotOK(result.status());
 
   return result.ValueOrDie();
 }
 
-std::shared_ptr<Schema> GetTypeInfo_Transformer::GetTransformedSchema() {
+std::shared_ptr<Schema> GetTypeInfoTransformer::GetTransformedSchema() {
   return odbc_version_ == odbcabstraction::V_3 ? GetTypeInfo_V3_Schema()
                                                : GetTypeInfo_V2_Schema();
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.h
@@ -36,7 +36,7 @@ using arrow::StringBuilder;
 using odbcabstraction::MetadataSettings;
 using std::optional;
 
-class GetTypeInfo_RecordBatchBuilder {
+class GetTypeInfoRecordBatchBuilder {
  private:
   odbcabstraction::OdbcVersion odbc_version_;
 
@@ -84,23 +84,23 @@ class GetTypeInfo_RecordBatchBuilder {
     optional<int16_t> interval_precision;
   };
 
-  explicit GetTypeInfo_RecordBatchBuilder(odbcabstraction::OdbcVersion odbc_version);
+  explicit GetTypeInfoRecordBatchBuilder(odbcabstraction::OdbcVersion odbc_version);
 
   Result<std::shared_ptr<RecordBatch>> Build();
 
   Status Append(const Data& data);
 };
 
-class GetTypeInfo_Transformer : public RecordBatchTransformer {
+class GetTypeInfoTransformer : public RecordBatchTransformer {
  private:
   const MetadataSettings& metadata_settings_;
   odbcabstraction::OdbcVersion odbc_version_;
   int data_type_;
 
  public:
-  explicit GetTypeInfo_Transformer(const MetadataSettings& metadata_settings,
-                                   odbcabstraction::OdbcVersion odbc_version,
-                                   int data_type);
+  explicit GetTypeInfoTransformer(const MetadataSettings& metadata_settings,
+                                  odbcabstraction::OdbcVersion odbc_version,
+                                  int data_type);
 
   std::shared_ptr<RecordBatch> Transform(
       const std::shared_ptr<RecordBatch>& original) override;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.cc
@@ -63,15 +63,15 @@ FlightStreamChunkBuffer::FlightStreamChunkBuffer(
     BlockingQueue<std::pair<Result<FlightStreamChunk>,
                             std::shared_ptr<FlightSqlClient>>>::Supplier supplier = [=] {
       auto result = stream_reader_ptr->Next();
-      bool isNotOk = !result.ok();
-      bool isNotEmpty = result.ok() && (result.ValueOrDie().data != nullptr);
+      bool is_not_ok = !result.ok();
+      bool is_not_empty = result.ok() && (result.ValueOrDie().data != nullptr);
 
       // If result is valid, save the temp Flight SQL Client for future stream reader
       // call. temp_flight_sql_client is intentionally null if the list of endpoint
       // Locations is empty.
       // After all data is fetched from reader, the temp client is closed.
       return boost::make_optional(
-          isNotOk || isNotEmpty,
+          is_not_ok || is_not_empty,
           std::make_pair(std::move(result), temp_flight_sql_client));
     };
     queue_.AddProducer(std::move(supplier));
@@ -80,12 +80,12 @@ FlightStreamChunkBuffer::FlightStreamChunkBuffer(
 
 bool FlightStreamChunkBuffer::GetNext(FlightStreamChunk* chunk) {
   std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>
-      closeableEndpointStreamPair;
-  if (!queue_.Pop(&closeableEndpointStreamPair)) {
+      closeable_endpoint_stream_pair;
+  if (!queue_.Pop(&closeable_endpoint_stream_pair)) {
     return false;
   }
 
-  Result<FlightStreamChunk> result = closeableEndpointStreamPair.first;
+  Result<FlightStreamChunk> result = closeable_endpoint_stream_pair.first;
   if (!result.status().ok()) {
     Close();
     throw odbcabstraction::DriverException(result.status().message());

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer_test.cc
@@ -90,7 +90,7 @@ FlightInfo MultipleEndpointsFlightInfo(Location location1, Location location2) {
                                        100000, false, "");
 }
 
-void verifyArraysContainIntsOnly(std::shared_ptr<Array> intArray) {
+void VerifyArraysContainIntsOnly(std::shared_ptr<Array> intArray) {
   for (int64_t i = 0; i < intArray->length(); ++i) {
     // null values are accepted
     if (!intArray->IsNull(i)) {
@@ -125,7 +125,7 @@ TEST_F(FlightStreamChunkBufferTest, TestMultipleEndpointsInt) {
       // Each array has random length
       EXPECT_GT(array->length(), 0);
 
-      verifyArraysContainIntsOnly(array);
+      VerifyArraysContainIntsOnly(array);
     }
   }
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/configuration.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/configuration.h
@@ -55,7 +55,7 @@ class Configuration {
   void Clear();
   bool IsSet(const std::string_view& key) const;
   const std::string& Get(const std::string_view& key) const;
-  void Set(const std::string_view& key, const std::wstring& wValue);
+  void Set(const std::string_view& key, const std::wstring& wvalue);
   void Set(const std::string_view& key, const std::string& value);
   void Emplace(const std::string_view& key, std::string&& value);
   /**

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
@@ -63,7 +63,7 @@ class AddPropertyWindow : public CustomWindow {
 
   void OnCreate() override;
 
-  bool OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) override;
+  bool OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) override;
 
   /**
    * Get the property from the dialog.
@@ -76,26 +76,26 @@ class AddPropertyWindow : public CustomWindow {
   /**
    * Create property edit boxes.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreateEdits(int posX, int posY, int sizeX);
+  int CreateEdits(int pos_x, int pos_y, int size_x);
 
   void CheckEnableOk();
 
   std::vector<std::unique_ptr<Window> > labels;
 
   /** Ok button. */
-  std::unique_ptr<Window> okButton;
+  std::unique_ptr<Window> ok_button;
 
   /** Cancel button. */
-  std::unique_ptr<Window> cancelButton;
+  std::unique_ptr<Window> cancel_button;
 
-  std::unique_ptr<Window> keyEdit;
+  std::unique_ptr<Window> key_edit;
 
-  std::unique_ptr<Window> valueEdit;
+  std::unique_ptr<Window> value_edit;
 
   std::wstring key;
 
@@ -110,7 +110,7 @@ class AddPropertyWindow : public CustomWindow {
   /** Flag indicating whether OK option was selected. */
   bool accepted;
 
-  bool isInitialized;
+  bool is_initialized;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/custom_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/custom_window.h
@@ -62,10 +62,10 @@ class CustomWindow : public Window {
    * Constructor.
    *
    * @param parent Parent window.
-   * @param className Window class name.
+   * @param class_name Window class name.
    * @param title Window title.
    */
-  CustomWindow(Window* parent, const wchar_t* className, const wchar_t* title);
+  CustomWindow(Window* parent, const wchar_t* class_name, const wchar_t* title);
 
   /**
    * Destructor.
@@ -77,12 +77,12 @@ class CustomWindow : public Window {
    * Pure virtual. Should be defined by user.
    *
    * @param msg Message.
-   * @param wParam Word-sized parameter.
-   * @param lParam Long parameter.
+   * @param wparam Word-sized parameter.
+   * @param lparam Long parameter.
    * @return Should return true if the message has been
    *     processed by the handler and false otherwise.
    */
-  virtual bool OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) = 0;
+  virtual bool OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) = 0;
 
   /**
    * Callback that is called upon window creation.
@@ -97,11 +97,11 @@ class CustomWindow : public Window {
    *
    * @param hwnd Window handle.
    * @param msg Message.
-   * @param wParam Word-sized parameter.
-   * @param lParam Long parameter.
+   * @param wparam Word-sized parameter.
+   * @param lparam Long parameter.
    * @return Operation result.
    */
-  static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+  static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam);
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h
@@ -90,56 +90,56 @@ class DsnConfigurationWindow : public CustomWindow {
 
   void OnCreate() override;
 
-  bool OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) override;
+  bool OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) override;
 
  private:
   /**
    * Create connection settings group box.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreateConnectionSettingsGroup(int posX, int posY, int sizeX);
+  int CreateConnectionSettingsGroup(int pos_x, int pos_y, int size_x);
 
   /**
    * Create aythentication settings group box.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreateAuthSettingsGroup(int posX, int posY, int sizeX);
+  int CreateAuthSettingsGroup(int pos_x, int pos_y, int size_x);
 
   /**
    * Create Encryption settings group box.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreateEncryptionSettingsGroup(int posX, int posY, int sizeX);
+  int CreateEncryptionSettingsGroup(int pos_x, int pos_y, int size_x);
 
   /**
    * Create advanced properties group box.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreatePropertiesGroup(int posX, int posY, int sizeX);
+  int CreatePropertiesGroup(int pos_x, int pos_y, int size_x);
 
-  void SelectTab(int tabIndex);
+  void SelectTab(int tab_index);
 
   void CheckEnableOk();
 
   void CheckAuthType();
 
-  void SaveParameters(Configuration& targetConfig);
+  void SaveParameters(Configuration& target_config);
 
   /** Window width. */
   int width;
@@ -147,66 +147,66 @@ class DsnConfigurationWindow : public CustomWindow {
   /** Window height. */
   int height;
 
-  std::unique_ptr<Window> tabControl;
+  std::unique_ptr<Window> tab_control;
 
-  std::unique_ptr<Window> commonContent;
+  std::unique_ptr<Window> common_content;
 
-  std::unique_ptr<Window> advancedContent;
+  std::unique_ptr<Window> advanced_content;
 
   /** Connection settings group box. */
-  std::unique_ptr<Window> connectionSettingsGroupBox;
+  std::unique_ptr<Window> connection_settings_group_box;
 
   /** Authentication settings group box. */
-  std::unique_ptr<Window> authSettingsGroupBox;
+  std::unique_ptr<Window> auth_settings_group_box;
 
   /** Encryption settings group box. */
-  std::unique_ptr<Window> encryptionSettingsGroupBox;
+  std::unique_ptr<Window> encryption_settings_group_box;
 
   std::vector<std::unique_ptr<Window> > labels;
 
   /** Test button. */
-  std::unique_ptr<Window> testButton;
+  std::unique_ptr<Window> test_button;
 
   /** Ok button. */
-  std::unique_ptr<Window> okButton;
+  std::unique_ptr<Window> ok_button;
 
   /** Cancel button. */
-  std::unique_ptr<Window> cancelButton;
+  std::unique_ptr<Window> cancel_button;
 
   /** DSN name edit field. */
-  std::unique_ptr<Window> nameEdit;
+  std::unique_ptr<Window> name_edit;
 
-  std::unique_ptr<Window> serverEdit;
+  std::unique_ptr<Window> server_edit;
 
-  std::unique_ptr<Window> portEdit;
+  std::unique_ptr<Window> port_edit;
 
-  std::unique_ptr<Window> authTypeComboBox;
+  std::unique_ptr<Window> auth_type_combo_box;
 
   /** User edit. */
-  std::unique_ptr<Window> userEdit;
+  std::unique_ptr<Window> user_edit;
 
   /** Password edit. */
-  std::unique_ptr<Window> passwordEdit;
+  std::unique_ptr<Window> password_edit;
 
-  std::unique_ptr<Window> authTokenEdit;
+  std::unique_ptr<Window> auth_token_edit;
 
-  std::unique_ptr<Window> enableEncryptionCheckBox;
+  std::unique_ptr<Window> enable_encryption_check_box;
 
-  std::unique_ptr<Window> certificateEdit;
+  std::unique_ptr<Window> certificate_edit;
 
-  std::unique_ptr<Window> certificateBrowseButton;
+  std::unique_ptr<Window> certificate_browse_button;
 
-  std::unique_ptr<Window> useSystemCertStoreCheckBox;
+  std::unique_ptr<Window> use_system_cert_store_check_box;
 
-  std::unique_ptr<Window> disableCertVerificationCheckBox;
+  std::unique_ptr<Window> disable_cert_verification_check_box;
 
-  std::unique_ptr<Window> propertyGroupBox;
+  std::unique_ptr<Window> property_group_box;
 
-  std::unique_ptr<Window> propertyList;
+  std::unique_ptr<Window> property_list;
 
-  std::unique_ptr<Window> addButton;
+  std::unique_ptr<Window> add_button;
 
-  std::unique_ptr<Window> deleteButton;
+  std::unique_ptr<Window> delete_button;
 
   /** Configuration. */
   Configuration& config;
@@ -214,7 +214,7 @@ class DsnConfigurationWindow : public CustomWindow {
   /** Flag indicating whether OK option was selected. */
   bool accepted;
 
-  bool isInitialized;
+  bool is_initialized;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h
@@ -41,10 +41,10 @@ class Window {
    * Constructor for a new window that is going to be created.
    *
    * @param parent Parent window handle.
-   * @param className Window class name.
+   * @param class_name Window class name.
    * @param title Window title.
    */
-  Window(Window* parent, const wchar_t* className, const wchar_t* title);
+  Window(Window* parent, const wchar_t* class_name, const wchar_t* title);
 
   /**
    * Constructor for the existing window.
@@ -62,13 +62,13 @@ class Window {
    * Create window.
    *
    * @param style Window style.
-   * @param posX Window x position.
-   * @param posY Window y position.
+   * @param pos_x Window x position.
+   * @param pos_y Window y position.
    * @param width Window width.
    * @param height Window height.
    * @param id ID for child window.
    */
-  void Create(DWORD style, int posX, int posY, int width, int height, int id);
+  void Create(DWORD style, int pos_x, int pos_y, int width, int height, int id);
 
   /**
    * Create child tab controlwindow.
@@ -81,100 +81,101 @@ class Window {
   /**
    * Create child list view window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param id ID to be assigned to the created window.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateList(int posX, int posY, int sizeX, int sizeY, int id);
+  std::unique_ptr<Window> CreateList(int pos_x, int pos_y, int size_x, int size_y,
+                                     int id);
 
   /**
    * Create child group box window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateGroupBox(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateGroupBox(int pos_x, int pos_y, int size_x, int size_y,
                                          const wchar_t* title, int id);
 
   /**
    * Create child label window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateLabel(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateLabel(int pos_x, int pos_y, int size_x, int size_y,
                                       const wchar_t* title, int id);
 
   /**
    * Create child Edit window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @param style Window style.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateEdit(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateEdit(int pos_x, int pos_y, int size_x, int size_y,
                                      const wchar_t* title, int id, int style = 0);
 
   /**
    * Create child button window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @param style Window style.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateButton(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateButton(int pos_x, int pos_y, int size_x, int size_y,
                                        const wchar_t* title, int id, int style = 0);
 
   /**
    * Create child CheckBox window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @param state Checked state of checkbox
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateCheckBox(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateCheckBox(int pos_x, int pos_y, int size_x, int size_y,
                                          const wchar_t* title, int id, bool state);
 
   /**
    * Create child ComboBox window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateComboBox(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateComboBox(int pos_x, int pos_y, int size_x, int size_y,
                                          const wchar_t* title, int id);
 
   /**
@@ -285,7 +286,7 @@ class Window {
   void SetHandle(HWND value) { handle = value; }
 
   /** Window class name. */
-  std::wstring className;
+  std::wstring class_name;
 
   /** Window title. */
   std::wstring title;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/main.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/main.cc
@@ -28,6 +28,7 @@
 #include <memory>
 #include "arrow/flight/api.h"
 #include "arrow/flight/sql/api.h"
+#include "arrow/util/logging.h"
 
 using arrow::Status;
 using arrow::flight::FlightClient;
@@ -48,18 +49,18 @@ void TestBindColumn(const std::shared_ptr<Connection>& connection) {
   const std::shared_ptr<ResultSet>& result_set = statement->GetResultSet();
 
   const int batch_size = 100;
-  const int max_strlen = 1000;
+  const int max_str_len = 1000;
 
-  char IncidntNum[batch_size][max_strlen];
-  ssize_t IncidntNum_length[batch_size];
+  char incidnt_num[batch_size][max_str_len];
+  ssize_t incidnt_num_length[batch_size];
 
-  char Category[batch_size][max_strlen];
-  ssize_t Category_length[batch_size];
+  char category[batch_size][max_str_len];
+  ssize_t category_length[batch_size];
 
-  result_set->BindColumn(1, driver::odbcabstraction::CDataType_CHAR, 0, 0, IncidntNum,
-                         max_strlen, IncidntNum_length);
-  result_set->BindColumn(2, driver::odbcabstraction::CDataType_CHAR, 0, 0, Category,
-                         max_strlen, Category_length);
+  result_set->BindColumn(1, driver::odbcabstraction::CDataType_CHAR, 0, 0, incidnt_num,
+                         max_str_len, incidnt_num_length);
+  result_set->BindColumn(2, driver::odbcabstraction::CDataType_CHAR, 0, 0, category,
+                         max_str_len, category_length);
 
   size_t total = 0;
   while (true) {
@@ -70,8 +71,8 @@ void TestBindColumn(const std::shared_ptr<Connection>& connection) {
     std::cout << "Total:" << total << std::endl;
 
     for (int i = 0; i < fetched_rows; ++i) {
-      std::cout << "Row[" << i << "] IncidntNum: '" << IncidntNum[i] << "', Category: '"
-                << Category[i] << "'" << std::endl;
+      ARROW_LOG(DEBUG) << "Row[" << i << "] incidnt_num: '" << incidnt_num[i]
+                       << "', Category: '" << category[i] << "'";
     }
 
     if (fetched_rows < batch_size) break;
@@ -114,34 +115,34 @@ void TestBindColumnBigInt(const std::shared_ptr<Connection>& connection) {
   const int batch_size = 100;
   const int max_strlen = 1000;
 
-  char IncidntNum[batch_size][max_strlen];
-  ssize_t IncidntNum_length[batch_size];
+  char incidnt_num[batch_size][max_strlen];
+  ssize_t incidnt_num_length[batch_size];
 
   double double_field[batch_size];
   ssize_t double_field_length[batch_size];
 
-  char Category[batch_size][max_strlen];
-  ssize_t Category_length[batch_size];
+  char category[batch_size][max_strlen];
+  ssize_t category_length[batch_size];
 
-  result_set->BindColumn(1, driver::odbcabstraction::CDataType_CHAR, 0, 0, IncidntNum,
-                         max_strlen, IncidntNum_length);
+  result_set->BindColumn(1, driver::odbcabstraction::CDataType_CHAR, 0, 0, incidnt_num,
+                         max_strlen, incidnt_num_length);
   result_set->BindColumn(2, driver::odbcabstraction::CDataType_DOUBLE, 0, 0, double_field,
                          max_strlen, double_field_length);
-  result_set->BindColumn(3, driver::odbcabstraction::CDataType_CHAR, 0, 0, Category,
-                         max_strlen, Category_length);
+  result_set->BindColumn(3, driver::odbcabstraction::CDataType_CHAR, 0, 0, category,
+                         max_strlen, category_length);
 
   size_t total = 0;
   while (true) {
     size_t fetched_rows = result_set->Move(batch_size, 0, 0, nullptr);
-    std::cout << "Fetched " << fetched_rows << " rows." << std::endl;
+    ARROW_LOG(DEBUG) << "Fetched " << fetched_rows << " rows.";
 
     total += fetched_rows;
-    std::cout << "Total:" << total << std::endl;
+    ARROW_LOG(DEBUG) << "Total:" << total;
 
     for (int i = 0; i < fetched_rows; ++i) {
-      std::cout << "Row[" << i << "] IncidntNum: '" << IncidntNum[i] << "', "
-                << "double_field: '" << double_field[i] << "', "
-                << "Category: '" << Category[i] << "'" << std::endl;
+      ARROW_LOG(DEBUG) << "Row[" << i << "] incidnt_num: '" << incidnt_num[i] << "', "
+                       << "double_field: '" << double_field[i] << "', "
+                       << "category: '" << category[i] << "'";
     }
 
     if (fetched_rows < batch_size) break;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/system_dsn.cc
@@ -36,10 +36,10 @@ void PostLastInstallerError() {
 
   std::wstringstream buf;
   buf << L"Message: \"" << msg << L"\", Code: " << code;
-  std::wstring errorMsg = buf.str();
+  std::wstring error_msg = buf.str();
 
-  MessageBox(NULL, errorMsg.c_str(), L"Error!", MB_ICONEXCLAMATION | MB_OK);
-  SQLPostInstallerError(code, errorMsg.c_str());
+  MessageBox(NULL, error_msg.c_str(), L"Error!", MB_ICONEXCLAMATION | MB_OK);
+  SQLPostInstallerError(code, error_msg.c_str());
 }
 
 /**
@@ -66,9 +66,9 @@ bool UnregisterDsn(const std::wstring& dsn) {
  */
 bool RegisterDsn(const Configuration& config, LPCWSTR driver) {
   const std::string& dsn = config.Get(FlightSqlConnection::DSN);
-  std::wstring wDsn = arrow::util::UTF8ToWideString(dsn).ValueOr(L"");
+  std::wstring wdsn = arrow::util::UTF8ToWideString(dsn).ValueOr(L"");
 
-  if (!SQLWriteDSNToIni(wDsn.c_str(), driver)) {
+  if (!SQLWriteDSNToIni(wdsn.c_str(), driver)) {
     PostLastInstallerError();
     return false;
   }
@@ -81,9 +81,9 @@ bool RegisterDsn(const Configuration& config, LPCWSTR driver) {
       continue;
     }
 
-    std::wstring wKey = arrow::util::UTF8ToWideString(key).ValueOr(L"");
-    std::wstring wValue = arrow::util::UTF8ToWideString(it->second).ValueOr(L"");
-    if (!SQLWritePrivateProfileString(wDsn.c_str(), wKey.c_str(), wValue.c_str(),
+    std::wstring wkey = arrow::util::UTF8ToWideString(key).ValueOr(L"");
+    std::wstring wvalue = arrow::util::UTF8ToWideString(it->second).ValueOr(L"");
+    if (!SQLWritePrivateProfileString(wdsn.c_str(), wkey.c_str(), wvalue.c_str(),
                                       L"ODBC.INI")) {
       PostLastInstallerError();
       return false;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/system_dsn.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/system_dsn.h
@@ -27,23 +27,23 @@ using driver::odbcabstraction::Connection;
 /**
  * Display connection window for user to configure connection parameters.
  *
- * @param windowParent Parent window handle.
+ * @param window_parent Parent window handle.
  * @param config Output configuration.
  * @return True on success and false on fail.
  */
-bool DisplayConnectionWindow(void* windowParent, Configuration& config);
+bool DisplayConnectionWindow(void* window_parent, Configuration& config);
 
 /**
  * For SQLDriverConnect.
  * Display connection window for user to configure connection parameters.
  *
- * @param windowParent Parent window handle.
+ * @param window_parent Parent window handle.
  * @param config Output configuration, presumed to be empty, it will be using values from
  * properties.
  * @param properties Output properties.
  * @return True on success and false on fail.
  */
-bool DisplayConnectionWindow(void* windowParent, Configuration& config,
+bool DisplayConnectionWindow(void* window_parent, Configuration& config,
                              Connection::ConnPropertyMap& properties);
 #endif
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/system_trust_store.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/system_trust_store.cc
@@ -35,13 +35,13 @@ std::string SystemTrustStore::GetNext() const {
   CryptBinaryToString(p_context_->pbCertEncoded, p_context_->cbCertEncoded,
                       CRYPT_STRING_BASE64HEADER, nullptr, &size);
 
-  std::wstring wCert;
-  wCert.resize(size);
+  std::wstring wcert;
+  wcert.resize(size);
   CryptBinaryToString(p_context_->pbCertEncoded, p_context_->cbCertEncoded,
-                      CRYPT_STRING_BASE64HEADER, &wCert[0], &size);
-  wCert.resize(size);
+                      CRYPT_STRING_BASE64HEADER, &wcert[0], &size);
+  wcert.resize(size);
 
-  std::string cert = arrow::util::WideStringToUTF8(wCert).ValueOr("");
+  std::string cert = arrow::util::WideStringToUTF8(wcert).ValueOr("");
 
   return cert;
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
@@ -37,7 +37,7 @@ AddPropertyWindow::AddPropertyWindow(Window* parent)
       width(300),
       height(120),
       accepted(false),
-      isInitialized(false) {
+      is_initialized(false) {
   // No-op.
 }
 
@@ -47,20 +47,20 @@ AddPropertyWindow::~AddPropertyWindow() {
 
 void AddPropertyWindow::Create() {
   // Finding out parent position.
-  RECT parentRect;
-  GetWindowRect(parent->GetHandle(), &parentRect);
+  RECT parent_rect;
+  GetWindowRect(parent->GetHandle(), &parent_rect);
 
   // Positioning window to the center of parent window.
-  const int posX = parentRect.left + (parentRect.right - parentRect.left - width) / 2;
-  const int posY = parentRect.top + (parentRect.bottom - parentRect.top - height) / 2;
+  const int pos_x = parent_rect.left + (parent_rect.right - parent_rect.left - width) / 2;
+  const int pos_y = parent_rect.top + (parent_rect.bottom - parent_rect.top - height) / 2;
 
-  RECT desiredRect = {posX, posY, posX + width, posY + height};
-  AdjustWindowRect(&desiredRect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
+  RECT desired_rect = {pos_x, pos_y, pos_x + width, pos_y + height};
+  AdjustWindowRect(&desired_rect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
                    FALSE);
 
-  Window::Create(WS_OVERLAPPED | WS_SYSMENU, desiredRect.left, desiredRect.top,
-                 desiredRect.right - desiredRect.left,
-                 desiredRect.bottom - desiredRect.top, 0);
+  Window::Create(WS_OVERLAPPED | WS_SYSMENU, desired_rect.left, desired_rect.top,
+                 desired_rect.right - desired_rect.left,
+                 desired_rect.bottom - desired_rect.top, 0);
 
   if (!handle) {
     std::stringstream buf;
@@ -79,61 +79,62 @@ bool AddPropertyWindow::GetProperty(std::wstring& key, std::wstring& value) {
 }
 
 void AddPropertyWindow::OnCreate() {
-  int groupPosY = MARGIN;
-  int groupSizeY = width - 2 * MARGIN;
+  int group_pos_y = MARGIN;
+  int group_size_y = width - 2 * MARGIN;
 
-  groupPosY += INTERVAL + CreateEdits(MARGIN, groupPosY, groupSizeY);
+  group_pos_y += INTERVAL + CreateEdits(MARGIN, group_pos_y, group_size_y);
 
-  int cancelPosX = width - MARGIN - BUTTON_WIDTH;
-  int okPosX = cancelPosX - INTERVAL - BUTTON_WIDTH;
+  int cancel_pos_x = width - MARGIN - BUTTON_WIDTH;
+  int ok_pos_x = cancel_pos_x - INTERVAL - BUTTON_WIDTH;
 
-  okButton = CreateButton(okPosX, groupPosY, BUTTON_WIDTH, BUTTON_HEIGHT, L"Ok",
-                          ChildId::OK_BUTTON, BS_DEFPUSHBUTTON);
-  cancelButton = CreateButton(cancelPosX, groupPosY, BUTTON_WIDTH, BUTTON_HEIGHT,
-                              L"Cancel", ChildId::CANCEL_BUTTON);
-  isInitialized = true;
+  ok_button = CreateButton(ok_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, L"Ok",
+                           ChildId::OK_BUTTON, BS_DEFPUSHBUTTON);
+  cancel_button = CreateButton(cancel_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
+                               L"Cancel", ChildId::CANCEL_BUTTON);
+  is_initialized = true;
   CheckEnableOk();
 }
 
-int AddPropertyWindow::CreateEdits(int posX, int posY, int sizeX) {
+int AddPropertyWindow::CreateEdits(int pos_x, int pos_y, int size_x) {
   enum { LABEL_WIDTH = 30 };
 
-  const int editSizeX = sizeX - LABEL_WIDTH - INTERVAL;
-  const int editPosX = posX + LABEL_WIDTH + INTERVAL;
+  const int edit_size_x = size_x - LABEL_WIDTH - INTERVAL;
+  const int edit_pos_x = pos_x + LABEL_WIDTH + INTERVAL;
 
-  int rowPos = posY;
+  int row_pos = pos_y;
 
   labels.push_back(
-      CreateLabel(posX, rowPos, LABEL_WIDTH, ROW_HEIGHT, L"Key:", ChildId::KEY_LABEL));
-  keyEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, L"", ChildId::KEY_EDIT);
+      CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"Key:", ChildId::KEY_LABEL));
+  key_edit =
+      CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, L"", ChildId::KEY_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
-  labels.push_back(CreateLabel(posX, rowPos, LABEL_WIDTH, ROW_HEIGHT, L"Value:",
+  labels.push_back(CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"Value:",
                                ChildId::VALUE_LABEL));
-  valueEdit =
-      CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, L"", ChildId::VALUE_EDIT);
+  value_edit =
+      CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, L"", ChildId::VALUE_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
 void AddPropertyWindow::CheckEnableOk() {
-  if (!isInitialized) {
+  if (!is_initialized) {
     return;
   }
 
-  okButton->SetEnabled(!keyEdit->IsTextEmpty() && !valueEdit->IsTextEmpty());
+  ok_button->SetEnabled(!key_edit->IsTextEmpty() && !value_edit->IsTextEmpty());
 }
 
-bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
+bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
   switch (msg) {
     case WM_COMMAND: {
-      switch (LOWORD(wParam)) {
+      switch (LOWORD(wparam)) {
         case ChildId::OK_BUTTON: {
-          keyEdit->GetText(key);
-          valueEdit->GetText(value);
+          key_edit->GetText(key);
+          value_edit->GetText(value);
           accepted = true;
           PostMessage(GetHandle(), WM_CLOSE, 0, 0);
 
@@ -148,7 +149,7 @@ bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case ChildId::KEY_EDIT:
         case ChildId::VALUE_EDIT: {
-          if (HIWORD(wParam) == EN_CHANGE) {
+          if (HIWORD(wparam) == EN_CHANGE) {
             CheckEnableOk();
           }
           break;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
@@ -47,22 +47,22 @@ Result::Type ProcessMessages(Window& window) {
   return static_cast<Result::Type>(msg.wParam);
 }
 
-LRESULT CALLBACK CustomWindow::WndProc(HWND hwnd, UINT msg, WPARAM wParam,
-                                       LPARAM lParam) {
+LRESULT CALLBACK CustomWindow::WndProc(HWND hwnd, UINT msg, WPARAM wparam,
+                                       LPARAM lparam) {
   CustomWindow* window =
       reinterpret_cast<CustomWindow*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
 
   switch (msg) {
     case WM_NCCREATE: {
-      assert(lParam != NULL);
+      assert(lparam != NULL);
 
-      CREATESTRUCT* createStruct = reinterpret_cast<CREATESTRUCT*>(lParam);
+      CREATESTRUCT* create_struct = reinterpret_cast<CREATESTRUCT*>(lparam);
 
-      LONG_PTR longSelfPtr = reinterpret_cast<LONG_PTR>(createStruct->lpCreateParams);
+      LONG_PTR long_self_ptr = reinterpret_cast<LONG_PTR>(create_struct->lpCreateParams);
 
-      SetWindowLongPtr(hwnd, GWLP_USERDATA, longSelfPtr);
+      SetWindowLongPtr(hwnd, GWLP_USERDATA, long_self_ptr);
 
-      return DefWindowProc(hwnd, msg, wParam, lParam);
+      return DefWindowProc(hwnd, msg, wparam, lparam);
     }
 
     case WM_CREATE: {
@@ -79,13 +79,14 @@ LRESULT CALLBACK CustomWindow::WndProc(HWND hwnd, UINT msg, WPARAM wParam,
       break;
   }
 
-  if (window && window->OnMessage(msg, wParam, lParam)) return 0;
+  if (window && window->OnMessage(msg, wparam, lparam)) return 0;
 
-  return DefWindowProc(hwnd, msg, wParam, lParam);
+  return DefWindowProc(hwnd, msg, wparam, lparam);
 }
 
-CustomWindow::CustomWindow(Window* parent, const wchar_t* className, const wchar_t* title)
-    : Window(parent, className, title) {
+CustomWindow::CustomWindow(Window* parent, const wchar_t* class_name,
+                           const wchar_t* title)
+    : Window(parent, class_name, title) {
   WNDCLASS wcx;
 
   wcx.style = CS_HREDRAW | CS_VREDRAW;
@@ -97,7 +98,7 @@ CustomWindow::CustomWindow(Window* parent, const wchar_t* className, const wchar
   wcx.hCursor = LoadCursor(NULL, IDC_ARROW);
   wcx.hbrBackground = (HBRUSH)COLOR_WINDOW;
   wcx.lpszMenuName = NULL;
-  wcx.lpszClassName = className;
+  wcx.lpszClassName = class_name;
 
   if (!RegisterClass(&wcx)) {
     std::stringstream buf;
@@ -106,7 +107,7 @@ CustomWindow::CustomWindow(Window* parent, const wchar_t* className, const wchar
   }
 }
 
-CustomWindow::~CustomWindow() { UnregisterClass(className.c_str(), GetHInstance()); }
+CustomWindow::~CustomWindow() { UnregisterClass(class_name.c_str(), GetHInstance()); }
 
 }  // namespace config
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
@@ -36,19 +36,19 @@
 
 namespace {
 std::string TestConnection(const driver::flight_sql::config::Configuration& config) {
-  std::unique_ptr<driver::flight_sql::FlightSqlConnection> flightSqlConn(
+  std::unique_ptr<driver::flight_sql::FlightSqlConnection> flight_sql_conn(
       new driver::flight_sql::FlightSqlConnection(driver::odbcabstraction::V_3));
 
-  std::vector<std::string_view> missingProperties;
-  flightSqlConn->Connect(config.GetProperties(), missingProperties);
+  std::vector<std::string_view> missing_properties;
+  flight_sql_conn->Connect(config.GetProperties(), missing_properties);
 
   // This should have been checked before enabling the Test button.
-  assert(missingProperties.empty());
-  std::string serverName =
-      boost::get<std::string>(flightSqlConn->GetInfo(SQL_SERVER_NAME));
-  std::string serverVersion =
-      boost::get<std::string>(flightSqlConn->GetInfo(SQL_DBMS_VER));
-  return "Server Name: " + serverName + "\n" + "Server Version: " + serverVersion;
+  assert(missing_properties.empty());
+  std::string server_name =
+      boost::get<std::string>(flight_sql_conn->GetInfo(SQL_SERVER_NAME));
+  std::string server_version =
+      boost::get<std::string>(flight_sql_conn->GetInfo(SQL_DBMS_VER));
+  return "Server Name: " + server_name + "\n" + "Server Version: " + server_version;
 }
 }  // namespace
 
@@ -63,7 +63,7 @@ DsnConfigurationWindow::DsnConfigurationWindow(Window* parent,
       height(375),
       config(config),
       accepted(false),
-      isInitialized(false) {
+      is_initialized(false) {
   // No-op.
 }
 
@@ -73,20 +73,20 @@ DsnConfigurationWindow::~DsnConfigurationWindow() {
 
 void DsnConfigurationWindow::Create() {
   // Finding out parent position.
-  RECT parentRect;
-  GetWindowRect(parent->GetHandle(), &parentRect);
+  RECT parent_rect;
+  GetWindowRect(parent->GetHandle(), &parent_rect);
 
   // Positioning window to the center of parent window.
-  const int posX = parentRect.left + (parentRect.right - parentRect.left - width) / 2;
-  const int posY = parentRect.top + (parentRect.bottom - parentRect.top - height) / 2;
+  const int pos_x = parent_rect.left + (parent_rect.right - parent_rect.left - width) / 2;
+  const int pos_y = parent_rect.top + (parent_rect.bottom - parent_rect.top - height) / 2;
 
-  RECT desiredRect = {posX, posY, posX + width, posY + height};
-  AdjustWindowRect(&desiredRect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
+  RECT desired_rect = {pos_x, pos_y, pos_x + width, pos_y + height};
+  AdjustWindowRect(&desired_rect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
                    FALSE);
 
-  Window::Create(WS_OVERLAPPED | WS_SYSMENU, desiredRect.left, desiredRect.top,
-                 desiredRect.right - desiredRect.left,
-                 desiredRect.bottom - desiredRect.top, 0);
+  Window::Create(WS_OVERLAPPED | WS_SYSMENU, desired_rect.left, desired_rect.top,
+                 desired_rect.right - desired_rect.left,
+                 desired_rect.bottom - desired_rect.top, 0);
 
   if (!handle) {
     std::stringstream buf;
@@ -96,384 +96,390 @@ void DsnConfigurationWindow::Create() {
 }
 
 void DsnConfigurationWindow::OnCreate() {
-  tabControl = CreateTabControl(ChildId::TAB_CONTROL);
-  tabControl->AddTab(L"Common", COMMON_TAB);
-  tabControl->AddTab(L"Advanced", ADVANCED_TAB);
+  tab_control = CreateTabControl(ChildId::TAB_CONTROL);
+  tab_control->AddTab(L"Common", COMMON_TAB);
+  tab_control->AddTab(L"Advanced", ADVANCED_TAB);
 
-  int groupPosY = 3 * MARGIN;
-  int groupSizeY = width - 2 * MARGIN;
+  int group_pos_y = 3 * MARGIN;
+  int group_size_y = width - 2 * MARGIN;
 
-  int commonGroupPosY = groupPosY;
-  commonGroupPosY +=
-      INTERVAL + CreateConnectionSettingsGroup(MARGIN, commonGroupPosY, groupSizeY);
-  commonGroupPosY +=
-      INTERVAL + CreateAuthSettingsGroup(MARGIN, commonGroupPosY, groupSizeY);
+  int common_group_pos_y = group_pos_y;
+  common_group_pos_y +=
+      INTERVAL + CreateConnectionSettingsGroup(MARGIN, common_group_pos_y, group_size_y);
+  common_group_pos_y +=
+      INTERVAL + CreateAuthSettingsGroup(MARGIN, common_group_pos_y, group_size_y);
 
-  int advancedGroupPosY = groupPosY;
-  advancedGroupPosY +=
-      INTERVAL + CreateEncryptionSettingsGroup(MARGIN, advancedGroupPosY, groupSizeY);
-  advancedGroupPosY +=
-      INTERVAL + CreatePropertiesGroup(MARGIN, advancedGroupPosY, groupSizeY);
+  int advanced_group_pos_y = group_pos_y;
+  advanced_group_pos_y += INTERVAL + CreateEncryptionSettingsGroup(
+                                         MARGIN, advanced_group_pos_y, group_size_y);
+  advanced_group_pos_y +=
+      INTERVAL + CreatePropertiesGroup(MARGIN, advanced_group_pos_y, group_size_y);
 
-  int testPosX = MARGIN;
-  int cancelPosX = width - MARGIN - BUTTON_WIDTH;
-  int okPosX = cancelPosX - INTERVAL - BUTTON_WIDTH;
+  int test_pos_x = MARGIN;
+  int cancel_pos_x = width - MARGIN - BUTTON_WIDTH;
+  int ok_pos_x = cancel_pos_x - INTERVAL - BUTTON_WIDTH;
 
-  int buttonPosY = std::max(commonGroupPosY, advancedGroupPosY);
-  testButton = CreateButton(testPosX, buttonPosY, BUTTON_WIDTH + 20, BUTTON_HEIGHT,
-                            L"Test Connection", ChildId::TEST_CONNECTION_BUTTON);
-  okButton = CreateButton(okPosX, buttonPosY, BUTTON_WIDTH, BUTTON_HEIGHT, L"Ok",
-                          ChildId::OK_BUTTON);
-  cancelButton = CreateButton(cancelPosX, buttonPosY, BUTTON_WIDTH, BUTTON_HEIGHT,
-                              L"Cancel", ChildId::CANCEL_BUTTON);
-  isInitialized = true;
+  int button_pos_y = std::max(common_group_pos_y, advanced_group_pos_y);
+  test_button = CreateButton(test_pos_x, button_pos_y, BUTTON_WIDTH + 20, BUTTON_HEIGHT,
+                             L"Test Connection", ChildId::TEST_CONNECTION_BUTTON);
+  ok_button = CreateButton(ok_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, L"Ok",
+                           ChildId::OK_BUTTON);
+  cancel_button = CreateButton(cancel_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
+                               L"Cancel", ChildId::CANCEL_BUTTON);
+  is_initialized = true;
   CheckEnableOk();
   SelectTab(COMMON_TAB);
 }
 
-int DsnConfigurationWindow::CreateConnectionSettingsGroup(int posX, int posY, int sizeX) {
+int DsnConfigurationWindow::CreateConnectionSettingsGroup(int pos_x, int pos_y,
+                                                          int size_x) {
   enum { LABEL_WIDTH = 100 };
 
-  const int labelPosX = posX + INTERVAL;
+  const int label_pos_x = pos_x + INTERVAL;
 
-  const int editSizeX = sizeX - LABEL_WIDTH - 3 * INTERVAL;
-  const int editPosX = labelPosX + LABEL_WIDTH + INTERVAL;
+  const int edit_size_x = size_x - LABEL_WIDTH - 3 * INTERVAL;
+  const int edit_pos_x = label_pos_x + LABEL_WIDTH + INTERVAL;
 
-  int rowPos = posY + 2 * INTERVAL;
+  int row_pos = pos_y + 2 * INTERVAL;
 
   std::string val = config.Get(FlightSqlConnection::DSN);
-  std::wstring wVal = arrow::util::UTF8ToWideString(val).ValueOr(L"");
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  std::wstring wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                L"Data Source Name:", ChildId::NAME_LABEL));
-  nameEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, wVal.c_str(),
-                        ChildId::NAME_EDIT);
+  name_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                         ChildId::NAME_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::HOST);
-  wVal = arrow::util::UTF8ToWideString(val).ValueOr(L"");
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT, L"Host Name:",
-                               ChildId::SERVER_LABEL));
-  serverEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, wVal.c_str(),
-                          ChildId::SERVER_EDIT);
+  wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                               L"Host Name:", ChildId::SERVER_LABEL));
+  server_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                           ChildId::SERVER_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::PORT);
-  wVal = arrow::util::UTF8ToWideString(val).ValueOr(L"");
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT, L"Port:",
+  wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"Port:",
                                ChildId::PORT_LABEL));
-  portEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, wVal.c_str(),
-                        ChildId::PORT_EDIT, ES_NUMBER);
+  port_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                         ChildId::PORT_EDIT, ES_NUMBER);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
-  connectionSettingsGroupBox =
-      CreateGroupBox(posX, posY, sizeX, rowPos - posY, L"Connection settings",
+  connection_settings_group_box =
+      CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, L"Connection settings",
                      ChildId::CONNECTION_SETTINGS_GROUP_BOX);
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
-int DsnConfigurationWindow::CreateAuthSettingsGroup(int posX, int posY, int sizeX) {
+int DsnConfigurationWindow::CreateAuthSettingsGroup(int pos_x, int pos_y, int size_x) {
   enum { LABEL_WIDTH = 120 };
 
-  const int labelPosX = posX + INTERVAL;
+  const int label_pos_x = pos_x + INTERVAL;
 
-  const int editSizeX = sizeX - LABEL_WIDTH - 3 * INTERVAL;
-  const int editPosX = labelPosX + LABEL_WIDTH + INTERVAL;
+  const int edit_size_x = size_x - LABEL_WIDTH - 3 * INTERVAL;
+  const int edit_pos_x = label_pos_x + LABEL_WIDTH + INTERVAL;
 
-  int rowPos = posY + 2 * INTERVAL;
+  int row_pos = pos_y + 2 * INTERVAL;
 
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                L"Authentication Type:", ChildId::AUTH_TYPE_LABEL));
-  authTypeComboBox = CreateComboBox(editPosX, rowPos, editSizeX, ROW_HEIGHT,
-                                    L"Authentication Type:", ChildId::AUTH_TYPE_COMBOBOX);
-  authTypeComboBox->AddString(L"Basic Authentication");
-  authTypeComboBox->AddString(L"Token Authentication");
+  auth_type_combo_box =
+      CreateComboBox(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT,
+                     L"Authentication Type:", ChildId::AUTH_TYPE_COMBOBOX);
+  auth_type_combo_box->AddString(L"Basic Authentication");
+  auth_type_combo_box->AddString(L"Token Authentication");
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   std::string val = config.Get(FlightSqlConnection::UID);
-  std::wstring wVal = arrow::util::UTF8ToWideString(val).ValueOr(L"");
+  std::wstring wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
 
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT, L"User:",
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"User:",
                                ChildId::USER_LABEL));
-  userEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, wVal.c_str(),
-                        ChildId::USER_EDIT);
+  user_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                         ChildId::USER_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::PWD);
-  wVal = arrow::util::UTF8ToWideString(val).ValueOr(L"");
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT, L"Password:",
-                               ChildId::PASSWORD_LABEL));
-  passwordEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, wVal.c_str(),
-                            ChildId::USER_EDIT, ES_PASSWORD);
+  wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                               L"Password:", ChildId::PASSWORD_LABEL));
+  password_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                             ChildId::USER_EDIT, ES_PASSWORD);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   const auto& token = config.Get(FlightSqlConnection::TOKEN);
-  wVal = arrow::util::UTF8ToWideString(token).ValueOr(L"");
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  wval = arrow::util::UTF8ToWideString(token).ValueOr(L"");
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                L"Authentication Token:", ChildId::AUTH_TOKEN_LABEL));
-  authTokenEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, wVal.c_str(),
-                             ChildId::AUTH_TOKEN_EDIT);
-  authTokenEdit->SetEnabled(false);
+  auth_token_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                               ChildId::AUTH_TOKEN_EDIT);
+  auth_token_edit->SetEnabled(false);
 
   // Ensure the right elements are selected.
-  authTypeComboBox->SetSelection(token.empty() ? 0 : 1);
+  auth_type_combo_box->SetSelection(token.empty() ? 0 : 1);
   CheckAuthType();
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
-  authSettingsGroupBox =
-      CreateGroupBox(posX, posY, sizeX, rowPos - posY, L"Authentication settings",
+  auth_settings_group_box =
+      CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, L"Authentication settings",
                      ChildId::AUTH_SETTINGS_GROUP_BOX);
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
-int DsnConfigurationWindow::CreateEncryptionSettingsGroup(int posX, int posY, int sizeX) {
+int DsnConfigurationWindow::CreateEncryptionSettingsGroup(int pos_x, int pos_y,
+                                                          int size_x) {
   enum { LABEL_WIDTH = 120 };
 
-  const int labelPosX = posX + INTERVAL;
+  const int label_pos_x = pos_x + INTERVAL;
 
-  const int editSizeX = sizeX - LABEL_WIDTH - 3 * INTERVAL;
-  const int editPosX = labelPosX + LABEL_WIDTH + INTERVAL;
+  const int edit_size_x = size_x - LABEL_WIDTH - 3 * INTERVAL;
+  const int edit_pos_x = label_pos_x + LABEL_WIDTH + INTERVAL;
 
-  int rowPos = posY + 2 * INTERVAL;
+  int row_pos = pos_y + 2 * INTERVAL;
 
   std::string val = config.Get(FlightSqlConnection::USE_ENCRYPTION);
 
   // Enable encryption default value is true
-  const bool enableEncryption = driver::odbcabstraction::AsBool(val).value_or(true);
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  const bool enable_encryption = driver::odbcabstraction::AsBool(val).value_or(true);
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                L"Use Encryption:", ChildId::ENABLE_ENCRYPTION_LABEL));
-  enableEncryptionCheckBox =
-      CreateCheckBox(editPosX, rowPos - 2, editSizeX, ROW_HEIGHT, L"",
-                     ChildId::ENABLE_ENCRYPTION_CHECKBOX, enableEncryption);
+  enable_encryption_check_box =
+      CreateCheckBox(edit_pos_x, row_pos - 2, edit_size_x, ROW_HEIGHT, L"",
+                     ChildId::ENABLE_ENCRYPTION_CHECKBOX, enable_encryption);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::TRUSTED_CERTS);
-  std::wstring wVal = arrow::util::UTF8ToWideString(val).ValueOr(L"");
+  std::wstring wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
 
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                L"Certificate:", ChildId::CERTIFICATE_LABEL));
-  certificateEdit = CreateEdit(editPosX, rowPos, editSizeX - MARGIN - BUTTON_WIDTH,
-                               ROW_HEIGHT, wVal.c_str(), ChildId::CERTIFICATE_EDIT);
-  certificateBrowseButton =
-      CreateButton(editPosX + editSizeX - BUTTON_WIDTH, rowPos - 2, BUTTON_WIDTH,
+  certificate_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x - MARGIN - BUTTON_WIDTH,
+                                ROW_HEIGHT, wval.c_str(), ChildId::CERTIFICATE_EDIT);
+  certificate_browse_button =
+      CreateButton(edit_pos_x + edit_size_x - BUTTON_WIDTH, row_pos - 2, BUTTON_WIDTH,
                    BUTTON_HEIGHT, L"Browse", ChildId::CERTIFICATE_BROWSE_BUTTON);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::USE_SYSTEM_TRUST_STORE).c_str();
 
   // System trust store default value is true
-  const bool useSystemCertStore = driver::odbcabstraction::AsBool(val).value_or(true);
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, 2 * ROW_HEIGHT,
+  const bool use_system_cert_store = driver::odbcabstraction::AsBool(val).value_or(true);
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
                                L"Use System Certificate Store:",
                                ChildId::USE_SYSTEM_CERT_STORE_LABEL));
-  useSystemCertStoreCheckBox =
-      CreateCheckBox(editPosX, rowPos - 2, 20, 2 * ROW_HEIGHT, L"",
-                     ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX, useSystemCertStore);
+  use_system_cert_store_check_box =
+      CreateCheckBox(edit_pos_x, row_pos - 2, 20, 2 * ROW_HEIGHT, L"",
+                     ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX, use_system_cert_store);
 
   val = config.Get(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION).c_str();
 
-  const int rightPosX = labelPosX + (sizeX - (2 * INTERVAL)) / 2;
-  const int rightCheckPosX = rightPosX + (editPosX - labelPosX);
-  const bool disableCertVerification =
+  const int right_pos_x = label_pos_x + (size_x - (2 * INTERVAL)) / 2;
+  const int right_check_pos_x = right_pos_x + (edit_pos_x - label_pos_x);
+  const bool disable_cert_verification =
       driver::odbcabstraction::AsBool(val).value_or(false);
-  labels.push_back(CreateLabel(rightPosX, rowPos, LABEL_WIDTH, 2 * ROW_HEIGHT,
+  labels.push_back(CreateLabel(right_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
                                L"Disable Certificate Verification:",
                                ChildId::DISABLE_CERT_VERIFICATION_LABEL));
-  disableCertVerificationCheckBox = CreateCheckBox(
-      rightCheckPosX, rowPos - 2, 20, 2 * ROW_HEIGHT, L"",
-      ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX, disableCertVerification);
+  disable_cert_verification_check_box = CreateCheckBox(
+      right_check_pos_x, row_pos - 2, 20, 2 * ROW_HEIGHT, L"",
+      ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX, disable_cert_verification);
 
-  rowPos += INTERVAL + static_cast<int>(1.5 * static_cast<int>(ROW_HEIGHT));
+  row_pos += INTERVAL + static_cast<int>(1.5 * static_cast<int>(ROW_HEIGHT));
 
-  encryptionSettingsGroupBox =
-      CreateGroupBox(posX, posY, sizeX, rowPos - posY, L"Encryption settings",
+  encryption_settings_group_box =
+      CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, L"Encryption settings",
                      ChildId::AUTH_SETTINGS_GROUP_BOX);
 
-  certificateEdit->SetEnabled(enableEncryption);
-  certificateBrowseButton->SetEnabled(enableEncryption);
-  useSystemCertStoreCheckBox->SetEnabled(enableEncryption);
-  disableCertVerificationCheckBox->SetEnabled(enableEncryption);
+  certificate_edit->SetEnabled(enable_encryption);
+  certificate_browse_button->SetEnabled(enable_encryption);
+  use_system_cert_store_check_box->SetEnabled(enable_encryption);
+  disable_cert_verification_check_box->SetEnabled(enable_encryption);
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
-int DsnConfigurationWindow::CreatePropertiesGroup(int posX, int posY, int sizeX) {
+int DsnConfigurationWindow::CreatePropertiesGroup(int pos_x, int pos_y, int size_x) {
   enum { LABEL_WIDTH = 120 };
 
-  const int labelPosX = posX + INTERVAL;
-  const int listSize = sizeX - 2 * INTERVAL;
-  const int columnSize = listSize / 2;
+  const int label_pos_x = pos_x + INTERVAL;
+  const int list_size = size_x - 2 * INTERVAL;
+  const int column_size = list_size / 2;
 
-  int rowPos = posY + 2 * INTERVAL;
-  const int listHeight = 5 * ROW_HEIGHT;
+  int row_pos = pos_y + 2 * INTERVAL;
+  const int list_height = 5 * ROW_HEIGHT;
 
-  propertyList =
-      CreateList(labelPosX, rowPos, listSize, listHeight, ChildId::PROPERTY_LIST);
-  propertyList->ListAddColumn(L"Key", 0, columnSize);
-  propertyList->ListAddColumn(L"Value", 1, columnSize);
+  property_list =
+      CreateList(label_pos_x, row_pos, list_size, list_height, ChildId::PROPERTY_LIST);
+  property_list->ListAddColumn(L"Key", 0, column_size);
+  property_list->ListAddColumn(L"Value", 1, column_size);
 
   const auto keys = config.GetCustomKeys();
   for (const auto& key : keys) {
-    std::wstring wKey = arrow::util::UTF8ToWideString(key).ValueOr(L"");
-    std::wstring wVal = arrow::util::UTF8ToWideString(config.Get(key)).ValueOr(L"");
+    std::wstring wkey = arrow::util::UTF8ToWideString(key).ValueOr(L"");
+    std::wstring wval = arrow::util::UTF8ToWideString(config.Get(key)).ValueOr(L"");
 
-    propertyList->ListAddItem({wKey, wVal});
+    property_list->ListAddItem({wkey, wval});
   }
 
-  SendMessage(propertyList->GetHandle(), LVM_SETEXTENDEDLISTVIEWSTYLE,
+  SendMessage(property_list->GetHandle(), LVM_SETEXTENDEDLISTVIEWSTYLE,
               LVS_EX_FULLROWSELECT, LVS_EX_FULLROWSELECT);
 
-  rowPos += INTERVAL + listHeight;
+  row_pos += INTERVAL + list_height;
 
-  int deletePosX = width - INTERVAL - MARGIN - BUTTON_WIDTH;
-  int addPosX = deletePosX - INTERVAL - BUTTON_WIDTH;
-  addButton = CreateButton(addPosX, rowPos, BUTTON_WIDTH, BUTTON_HEIGHT, L"Add",
-                           ChildId::ADD_BUTTON);
-  deleteButton = CreateButton(deletePosX, rowPos, BUTTON_WIDTH, BUTTON_HEIGHT, L"Delete",
-                              ChildId::DELETE_BUTTON);
+  int delete_pos_x = width - INTERVAL - MARGIN - BUTTON_WIDTH;
+  int add_pos_x = delete_pos_x - INTERVAL - BUTTON_WIDTH;
+  add_button = CreateButton(add_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT, L"Add",
+                            ChildId::ADD_BUTTON);
+  delete_button = CreateButton(delete_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT,
+                               L"Delete", ChildId::DELETE_BUTTON);
 
-  rowPos += INTERVAL + BUTTON_HEIGHT;
+  row_pos += INTERVAL + BUTTON_HEIGHT;
 
-  propertyGroupBox = CreateGroupBox(posX, posY, sizeX, rowPos - posY,
-                                    L"Advanced properties", ChildId::PROPERTY_GROUP_BOX);
+  property_group_box =
+      CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, L"Advanced properties",
+                     ChildId::PROPERTY_GROUP_BOX);
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
-void DsnConfigurationWindow::SelectTab(int tabIndex) {
-  if (!isInitialized) {
+void DsnConfigurationWindow::SelectTab(int tab_index) {
+  if (!is_initialized) {
     return;
   }
 
-  connectionSettingsGroupBox->SetVisible(COMMON_TAB == tabIndex);
-  authSettingsGroupBox->SetVisible(COMMON_TAB == tabIndex);
-  nameEdit->SetVisible(COMMON_TAB == tabIndex);
-  serverEdit->SetVisible(COMMON_TAB == tabIndex);
-  portEdit->SetVisible(COMMON_TAB == tabIndex);
-  authTypeComboBox->SetVisible(COMMON_TAB == tabIndex);
-  userEdit->SetVisible(COMMON_TAB == tabIndex);
-  passwordEdit->SetVisible(COMMON_TAB == tabIndex);
-  authTokenEdit->SetVisible(COMMON_TAB == tabIndex);
+  connection_settings_group_box->SetVisible(COMMON_TAB == tab_index);
+  auth_settings_group_box->SetVisible(COMMON_TAB == tab_index);
+  name_edit->SetVisible(COMMON_TAB == tab_index);
+  server_edit->SetVisible(COMMON_TAB == tab_index);
+  port_edit->SetVisible(COMMON_TAB == tab_index);
+  auth_type_combo_box->SetVisible(COMMON_TAB == tab_index);
+  user_edit->SetVisible(COMMON_TAB == tab_index);
+  password_edit->SetVisible(COMMON_TAB == tab_index);
+  auth_token_edit->SetVisible(COMMON_TAB == tab_index);
   for (size_t i = 0; i < 7; ++i) {
-    labels[i]->SetVisible(COMMON_TAB == tabIndex);
+    labels[i]->SetVisible(COMMON_TAB == tab_index);
   }
 
-  encryptionSettingsGroupBox->SetVisible(ADVANCED_TAB == tabIndex);
-  enableEncryptionCheckBox->SetVisible(ADVANCED_TAB == tabIndex);
-  certificateEdit->SetVisible(ADVANCED_TAB == tabIndex);
-  certificateBrowseButton->SetVisible(ADVANCED_TAB == tabIndex);
-  useSystemCertStoreCheckBox->SetVisible(ADVANCED_TAB == tabIndex);
-  disableCertVerificationCheckBox->SetVisible(ADVANCED_TAB == tabIndex);
-  propertyGroupBox->SetVisible(ADVANCED_TAB == tabIndex);
-  propertyList->SetVisible(ADVANCED_TAB == tabIndex);
-  addButton->SetVisible(ADVANCED_TAB == tabIndex);
-  deleteButton->SetVisible(ADVANCED_TAB == tabIndex);
+  encryption_settings_group_box->SetVisible(ADVANCED_TAB == tab_index);
+  enable_encryption_check_box->SetVisible(ADVANCED_TAB == tab_index);
+  certificate_edit->SetVisible(ADVANCED_TAB == tab_index);
+  certificate_browse_button->SetVisible(ADVANCED_TAB == tab_index);
+  use_system_cert_store_check_box->SetVisible(ADVANCED_TAB == tab_index);
+  disable_cert_verification_check_box->SetVisible(ADVANCED_TAB == tab_index);
+  property_group_box->SetVisible(ADVANCED_TAB == tab_index);
+  property_list->SetVisible(ADVANCED_TAB == tab_index);
+  add_button->SetVisible(ADVANCED_TAB == tab_index);
+  delete_button->SetVisible(ADVANCED_TAB == tab_index);
   for (size_t i = 7; i < labels.size(); ++i) {
-    labels[i]->SetVisible(ADVANCED_TAB == tabIndex);
+    labels[i]->SetVisible(ADVANCED_TAB == tab_index);
   }
 }
 
 void DsnConfigurationWindow::CheckEnableOk() {
-  if (!isInitialized) {
+  if (!is_initialized) {
     return;
   }
 
-  bool enableOk = !nameEdit->IsTextEmpty();
-  enableOk = enableOk && !serverEdit->IsTextEmpty();
-  enableOk = enableOk && !portEdit->IsTextEmpty();
-  if (authTokenEdit->IsEnabled()) {
-    enableOk = enableOk && !authTokenEdit->IsTextEmpty();
+  bool enable_ok = !name_edit->IsTextEmpty();
+  enable_ok = enable_ok && !server_edit->IsTextEmpty();
+  enable_ok = enable_ok && !port_edit->IsTextEmpty();
+  if (auth_token_edit->IsEnabled()) {
+    enable_ok = enable_ok && !auth_token_edit->IsTextEmpty();
   } else {
-    enableOk = enableOk && !userEdit->IsTextEmpty();
-    enableOk = enableOk && !passwordEdit->IsTextEmpty();
+    enable_ok = enable_ok && !user_edit->IsTextEmpty();
+    enable_ok = enable_ok && !password_edit->IsTextEmpty();
   }
 
-  testButton->SetEnabled(enableOk);
-  okButton->SetEnabled(enableOk);
+  test_button->SetEnabled(enable_ok);
+  ok_button->SetEnabled(enable_ok);
 }
 
-void DsnConfigurationWindow::SaveParameters(Configuration& targetConfig) {
-  targetConfig.Clear();
+void DsnConfigurationWindow::SaveParameters(Configuration& target_config) {
+  target_config.Clear();
 
   std::wstring text;
-  nameEdit->GetText(text);
-  targetConfig.Set(FlightSqlConnection::DSN, text);
-  serverEdit->GetText(text);
-  targetConfig.Set(FlightSqlConnection::HOST, text);
-  portEdit->GetText(text);
+  name_edit->GetText(text);
+  target_config.Set(FlightSqlConnection::DSN, text);
+  server_edit->GetText(text);
+  target_config.Set(FlightSqlConnection::HOST, text);
+  port_edit->GetText(text);
   try {
-    const int portInt = std::stoi(text);
-    if (0 > portInt || USHRT_MAX < portInt) {
+    const int port_int = std::stoi(text);
+    if (0 > port_int || USHRT_MAX < port_int) {
       throw odbcabstraction::DriverException("Invalid port value.");
     }
-    targetConfig.Set(FlightSqlConnection::PORT, text);
+    target_config.Set(FlightSqlConnection::PORT, text);
   } catch (odbcabstraction::DriverException&) {
     throw;
   } catch (std::exception&) {
     throw odbcabstraction::DriverException("Invalid port value.");
   }
 
-  if (0 == authTypeComboBox->GetSelection()) {
-    userEdit->GetText(text);
-    targetConfig.Set(FlightSqlConnection::UID, text);
-    passwordEdit->GetText(text);
-    targetConfig.Set(FlightSqlConnection::PWD, text);
+  if (0 == auth_type_combo_box->GetSelection()) {
+    user_edit->GetText(text);
+    target_config.Set(FlightSqlConnection::UID, text);
+    password_edit->GetText(text);
+    target_config.Set(FlightSqlConnection::PWD, text);
   } else {
-    authTokenEdit->GetText(text);
-    targetConfig.Set(FlightSqlConnection::TOKEN, text);
+    auth_token_edit->GetText(text);
+    target_config.Set(FlightSqlConnection::TOKEN, text);
   }
 
-  if (enableEncryptionCheckBox->IsChecked()) {
-    targetConfig.Set(FlightSqlConnection::USE_ENCRYPTION, TRUE_STR);
-    certificateEdit->GetText(text);
-    targetConfig.Set(FlightSqlConnection::TRUSTED_CERTS, text);
-    targetConfig.Set(FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
-                     useSystemCertStoreCheckBox->IsChecked() ? TRUE_STR : FALSE_STR);
-    targetConfig.Set(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
-                     disableCertVerificationCheckBox->IsChecked() ? TRUE_STR : FALSE_STR);
+  if (enable_encryption_check_box->IsChecked()) {
+    target_config.Set(FlightSqlConnection::USE_ENCRYPTION, TRUE_STR);
+    certificate_edit->GetText(text);
+    target_config.Set(FlightSqlConnection::TRUSTED_CERTS, text);
+    target_config.Set(
+        FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
+        use_system_cert_store_check_box->IsChecked() ? TRUE_STR : FALSE_STR);
+    target_config.Set(
+        FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
+        disable_cert_verification_check_box->IsChecked() ? TRUE_STR : FALSE_STR);
   } else {
     // System trust store verification requires encryption
-    targetConfig.Set(FlightSqlConnection::USE_ENCRYPTION, FALSE_STR);
-    targetConfig.Set(FlightSqlConnection::USE_SYSTEM_TRUST_STORE, FALSE_STR);
+    target_config.Set(FlightSqlConnection::USE_ENCRYPTION, FALSE_STR);
+    target_config.Set(FlightSqlConnection::USE_SYSTEM_TRUST_STORE, FALSE_STR);
   }
 
   // Get all the list properties.
-  const auto properties = propertyList->ListGetAll();
+  const auto properties = property_list->ListGetAll();
   for (const auto& property : properties) {
-    std::string propertyKey = arrow::util::WideStringToUTF8(property[0]).ValueOr("");
-    std::string propertyValue = arrow::util::WideStringToUTF8(property[1]).ValueOr("");
-    targetConfig.Set(propertyKey, propertyValue);
+    std::string property_key = arrow::util::WideStringToUTF8(property[0]).ValueOr("");
+    std::string property_value = arrow::util::WideStringToUTF8(property[1]).ValueOr("");
+    target_config.Set(property_key, property_value);
   }
 }
 
 void DsnConfigurationWindow::CheckAuthType() {
-  const bool isBasic = COMMON_TAB == authTypeComboBox->GetSelection();
-  userEdit->SetEnabled(isBasic);
-  passwordEdit->SetEnabled(isBasic);
-  authTokenEdit->SetEnabled(!isBasic);
+  const bool is_basic = COMMON_TAB == auth_type_combo_box->GetSelection();
+  user_edit->SetEnabled(is_basic);
+  password_edit->SetEnabled(is_basic);
+  auth_token_edit->SetEnabled(!is_basic);
 }
 
-bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
+bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
   switch (msg) {
     case WM_NOTIFY: {
-      switch (((LPNMHDR)lParam)->code) {
+      switch (((LPNMHDR)lparam)->code) {
         case TCN_SELCHANGING: {
           // Return FALSE to allow the selection to change.
           return FALSE;
         }
 
         case TCN_SELCHANGE: {
-          SelectTab(TabCtrl_GetCurSel(tabControl->GetHandle()));
+          SelectTab(TabCtrl_GetCurSel(tab_control->GetHandle()));
           break;
         }
       }
@@ -481,20 +487,21 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
     }
 
     case WM_COMMAND: {
-      switch (LOWORD(wParam)) {
+      switch (LOWORD(wparam)) {
         case ChildId::TEST_CONNECTION_BUTTON: {
           try {
-            Configuration testConfig;
-            SaveParameters(testConfig);
-            std::string testMessage = TestConnection(testConfig);
+            Configuration test_config;
+            SaveParameters(test_config);
+            std::string test_message = TestConnection(test_config);
 
-            std::wstring wTestMessage =
-                arrow::util::UTF8ToWideString(testMessage).ValueOr(L"");
-            MessageBox(NULL, wTestMessage.c_str(), L"Test Connection Success", MB_OK);
+            std::wstring w_test_message =
+                arrow::util::UTF8ToWideString(test_message).ValueOr(L"");
+            MessageBox(NULL, w_test_message.c_str(), L"Test Connection Success", MB_OK);
           } catch (odbcabstraction::DriverException& err) {
-            std::wstring wMessageText =
+            std::wstring w_message_text =
                 arrow::util::UTF8ToWideString(err.GetMessageText()).ValueOr(L"");
-            MessageBox(NULL, wMessageText.c_str(), L"Error!", MB_ICONEXCLAMATION | MB_OK);
+            MessageBox(NULL, w_message_text.c_str(), L"Error!",
+                       MB_ICONEXCLAMATION | MB_OK);
           }
 
           break;
@@ -505,9 +512,10 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
             accepted = true;
             PostMessage(GetHandle(), WM_CLOSE, 0, 0);
           } catch (odbcabstraction::DriverException& err) {
-            std::wstring wMessageText =
+            std::wstring w_message_text =
                 arrow::util::UTF8ToWideString(err.GetMessageText()).ValueOr(L"");
-            MessageBox(NULL, wMessageText.c_str(), L"Error!", MB_ICONEXCLAMATION | MB_OK);
+            MessageBox(NULL, w_message_text.c_str(), L"Error!",
+                       MB_ICONEXCLAMATION | MB_OK);
           }
 
           break;
@@ -525,7 +533,7 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
         case ChildId::PORT_EDIT:
         case ChildId::SERVER_EDIT:
         case ChildId::USER_EDIT: {
-          if (HIWORD(wParam) == EN_CHANGE) {
+          if (HIWORD(wparam) == EN_CHANGE) {
             CheckEnableOk();
           }
           break;
@@ -538,67 +546,67 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
         }
 
         case ChildId::ENABLE_ENCRYPTION_CHECKBOX: {
-          const bool toggle = !enableEncryptionCheckBox->IsChecked();
-          enableEncryptionCheckBox->SetChecked(toggle);
-          certificateEdit->SetEnabled(toggle);
-          certificateBrowseButton->SetEnabled(toggle);
-          useSystemCertStoreCheckBox->SetEnabled(toggle);
-          disableCertVerificationCheckBox->SetEnabled(toggle);
+          const bool toggle = !enable_encryption_check_box->IsChecked();
+          enable_encryption_check_box->SetChecked(toggle);
+          certificate_edit->SetEnabled(toggle);
+          certificate_browse_button->SetEnabled(toggle);
+          use_system_cert_store_check_box->SetEnabled(toggle);
+          disable_cert_verification_check_box->SetEnabled(toggle);
           break;
         }
 
         case ChildId::CERTIFICATE_BROWSE_BUTTON: {
-          OPENFILENAME openFileName;
-          wchar_t fileName[FILENAME_MAX];
+          OPENFILENAME open_file_name;
+          wchar_t file_name[FILENAME_MAX];
 
-          ZeroMemory(&openFileName, sizeof(openFileName));
-          openFileName.lStructSize = sizeof(openFileName);
-          openFileName.hwndOwner = NULL;
-          openFileName.lpstrFile = fileName;
-          openFileName.lpstrFile[0] = '\0';
-          openFileName.nMaxFile = FILENAME_MAX;
+          ZeroMemory(&open_file_name, sizeof(open_file_name));
+          open_file_name.lStructSize = sizeof(open_file_name);
+          open_file_name.hwndOwner = NULL;
+          open_file_name.lpstrFile = file_name;
+          open_file_name.lpstrFile[0] = '\0';
+          open_file_name.nMaxFile = FILENAME_MAX;
           // TODO: What type should this be?
-          openFileName.lpstrFilter = L"All\0*.*";
-          openFileName.nFilterIndex = 1;
-          openFileName.lpstrFileTitle = NULL;
-          openFileName.nMaxFileTitle = 0;
-          openFileName.lpstrInitialDir = NULL;
-          openFileName.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+          open_file_name.lpstrFilter = L"All\0*.*";
+          open_file_name.nFilterIndex = 1;
+          open_file_name.lpstrFileTitle = NULL;
+          open_file_name.nMaxFileTitle = 0;
+          open_file_name.lpstrInitialDir = NULL;
+          open_file_name.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
-          if (GetOpenFileName(&openFileName)) {
-            certificateEdit->SetText(fileName);
+          if (GetOpenFileName(&open_file_name)) {
+            certificate_edit->SetText(file_name);
           }
           break;
         }
 
         case ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX: {
-          useSystemCertStoreCheckBox->SetChecked(
-              !useSystemCertStoreCheckBox->IsChecked());
+          use_system_cert_store_check_box->SetChecked(
+              !use_system_cert_store_check_box->IsChecked());
           break;
         }
 
         case ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX: {
-          disableCertVerificationCheckBox->SetChecked(
-              !disableCertVerificationCheckBox->IsChecked());
+          disable_cert_verification_check_box->SetChecked(
+              !disable_cert_verification_check_box->IsChecked());
           break;
         }
 
         case ChildId::DELETE_BUTTON: {
-          propertyList->ListDeleteSelectedItem();
+          property_list->ListDeleteSelectedItem();
           break;
         }
 
         case ChildId::ADD_BUTTON: {
-          AddPropertyWindow addWindow(this);
-          addWindow.Create();
-          addWindow.Show();
-          addWindow.Update();
+          AddPropertyWindow add_window(this);
+          add_window.Create();
+          add_window.Show();
+          add_window.Update();
 
-          if (ProcessMessages(addWindow) == Result::OK) {
+          if (ProcessMessages(add_window) == Result::OK) {
             std::wstring key;
             std::wstring value;
-            addWindow.GetProperty(key, value);
-            propertyList->ListAddItem({key, value});
+            add_window.GetProperty(key, value);
+            property_list->ListAddItem({key, value});
           }
           break;
         }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/window.cc
@@ -34,28 +34,28 @@ namespace flight_sql {
 namespace config {
 
 HINSTANCE GetHInstance() {
-  TCHAR szFileName[MAX_PATH];
-  GetModuleFileName(NULL, szFileName, MAX_PATH);
+  TCHAR sz_file_name[MAX_PATH];
+  GetModuleFileName(NULL, sz_file_name, MAX_PATH);
 
   // TODO: This needs to be the module name.
-  HINSTANCE hInstance = GetModuleHandle(szFileName);
+  HINSTANCE h_instance = GetModuleHandle(sz_file_name);
 
-  if (hInstance == NULL) {
+  if (h_instance == NULL) {
     std::stringstream buf;
     buf << "Can not get hInstance for the module, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
   }
 
-  return hInstance;
+  return h_instance;
 }
 
-Window::Window(Window* parent, const wchar_t* className, const wchar_t* title)
-    : className(className), title(title), handle(NULL), parent(parent), created(false) {
+Window::Window(Window* parent, const wchar_t* class_name, const wchar_t* title)
+    : class_name(class_name), title(title), handle(NULL), parent(parent), created(false) {
   // No-op.
 }
 
 Window::Window(HWND handle)
-    : className(), title(), handle(handle), parent(0), created(false) {
+    : class_name(), title(), handle(handle), parent(0), created(false) {
   // No-op.
 }
 
@@ -63,14 +63,14 @@ Window::~Window() {
   if (created) Destroy();
 }
 
-void Window::Create(DWORD style, int posX, int posY, int width, int height, int id) {
+void Window::Create(DWORD style, int pos_x, int pos_y, int width, int height, int id) {
   if (handle) {
     std::stringstream buf;
     buf << "Window already created, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
   }
 
-  handle = CreateWindow(className.c_str(), title.c_str(), style, posX, posY, width,
+  handle = CreateWindow(class_name.c_str(), title.c_str(), style, pos_x, pos_y, width,
                         height, parent ? parent->GetHandle() : NULL,
                         reinterpret_cast<HMENU>(static_cast<ptrdiff_t>(id)),
                         GetHInstance(), this);
@@ -83,8 +83,8 @@ void Window::Create(DWORD style, int posX, int posY, int width, int height, int 
 
   created = true;
 
-  const HGDIOBJ hfDefault = GetStockObject(DEFAULT_GUI_FONT);
-  SendMessage(GetHandle(), WM_SETFONT, (WPARAM)hfDefault, MAKELPARAM(FALSE, 0));
+  const HGDIOBJ hf_default = GetStockObject(DEFAULT_GUI_FONT);
+  SendMessage(GetHandle(), WM_SETFONT, (WPARAM)hf_default, MAKELPARAM(FALSE, 0));
 }
 
 std::unique_ptr<Window> Window::CreateTabControl(int id) {
@@ -92,81 +92,83 @@ std::unique_ptr<Window> Window::CreateTabControl(int id) {
 
   // Get the dimensions of the parent window's client area, and
   // create a tab control child window of that size.
-  RECT rcClient;
-  GetClientRect(handle, &rcClient);
+  RECT rc_client;
+  GetClientRect(handle, &rc_client);
 
   child->Create(WS_CHILD | WS_CLIPSIBLINGS | WS_VISIBLE | WS_TABSTOP, 0, 0,
-                rcClient.right, 20, id);
+                rc_client.right, 20, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateList(int posX, int posY, int sizeX, int sizeY,
+std::unique_ptr<Window> Window::CreateList(int pos_x, int pos_y, int size_x, int size_y,
                                            int id) {
   std::unique_ptr<Window> child(new Window(this, WC_LISTVIEW, L""));
 
   child->Create(
-      WS_CHILD | WS_VISIBLE | WS_BORDER | LVS_REPORT | LVS_EDITLABELS | WS_TABSTOP, posX,
-      posY, sizeX, sizeY, id);
+      WS_CHILD | WS_VISIBLE | WS_BORDER | LVS_REPORT | LVS_EDITLABELS | WS_TABSTOP, pos_x,
+      pos_y, size_x, size_y, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateGroupBox(int posX, int posY, int sizeX, int sizeY,
-                                               const wchar_t* title, int id) {
+std::unique_ptr<Window> Window::CreateGroupBox(int pos_x, int pos_y, int size_x,
+                                               int size_y, const wchar_t* title, int id) {
   std::unique_ptr<Window> child(new Window(this, L"Button", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE | BS_GROUPBOX, posX, posY, sizeX, sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE | BS_GROUPBOX, pos_x, pos_y, size_x, size_y, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateLabel(int posX, int posY, int sizeX, int sizeY,
+std::unique_ptr<Window> Window::CreateLabel(int pos_x, int pos_y, int size_x, int size_y,
                                             const wchar_t* title, int id) {
   std::unique_ptr<Window> child(new Window(this, L"Static", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE, posX, posY, sizeX, sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE, pos_x, pos_y, size_x, size_y, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateEdit(int posX, int posY, int sizeX, int sizeY,
+std::unique_ptr<Window> Window::CreateEdit(int pos_x, int pos_y, int size_x, int size_y,
                                            const wchar_t* title, int id, int style) {
   std::unique_ptr<Window> child(new Window(this, L"Edit", title));
 
   child->Create(WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | WS_TABSTOP | style,
-                posX, posY, sizeX, sizeY, id);
+                pos_x, pos_y, size_x, size_y, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateButton(int posX, int posY, int sizeX, int sizeY,
+std::unique_ptr<Window> Window::CreateButton(int pos_x, int pos_y, int size_x, int size_y,
                                              const wchar_t* title, int id, int style) {
   std::unique_ptr<Window> child(new Window(this, L"Button", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE | WS_TABSTOP | style, posX, posY, sizeX, sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE | WS_TABSTOP | style, pos_x, pos_y, size_x, size_y,
+                id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateCheckBox(int posX, int posY, int sizeX, int sizeY,
-                                               const wchar_t* title, int id, bool state) {
+std::unique_ptr<Window> Window::CreateCheckBox(int pos_x, int pos_y, int size_x,
+                                               int size_y, const wchar_t* title, int id,
+                                               bool state) {
   std::unique_ptr<Window> child(new Window(this, L"Button", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE | BS_CHECKBOX | WS_TABSTOP, posX, posY, sizeX,
-                sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE | BS_CHECKBOX | WS_TABSTOP, pos_x, pos_y, size_x,
+                size_y, id);
 
   child->SetChecked(state);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateComboBox(int posX, int posY, int sizeX, int sizeY,
-                                               const wchar_t* title, int id) {
+std::unique_ptr<Window> Window::CreateComboBox(int pos_x, int pos_y, int size_x,
+                                               int size_y, const wchar_t* title, int id) {
   std::unique_ptr<Window> child(new Window(this, L"Combobox", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE | CBS_DROPDOWNLIST | WS_TABSTOP, posX, posY, sizeX,
-                sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE | CBS_DROPDOWNLIST | WS_TABSTOP, pos_x, pos_y,
+                size_x, size_y, id);
 
   return child;
 }
@@ -181,8 +183,8 @@ void Window::Destroy() {
   handle = NULL;
 }
 
-void Window::SetVisible(bool isVisible) {
-  ShowWindow(handle, isVisible ? SW_SHOW : SW_HIDE);
+void Window::SetVisible(bool is_visible) {
+  ShowWindow(handle, is_visible ? SW_SHOW : SW_HIDE);
 }
 
 bool Window::IsTextEmpty() const {
@@ -228,9 +230,9 @@ void Window::ListAddItem(const std::vector<std::wstring>& items) {
 }
 
 void Window::ListDeleteSelectedItem() {
-  const int rowIndex = ListView_GetSelectionMark(handle);
-  if (rowIndex >= 0) {
-    if (ListView_DeleteItem(handle, rowIndex) == -1) {
+  const int row_index = ListView_GetSelectionMark(handle);
+  if (row_index >= 0) {
+    if (ListView_DeleteItem(handle, row_index) == -1) {
       std::stringstream buf;
       buf << "Can not delete list item, error code: " << GetLastError();
       throw odbcabstraction::DriverException(buf.str());
@@ -243,11 +245,11 @@ std::vector<std::vector<std::wstring> > Window::ListGetAll() {
   wchar_t buf[BUF_LEN];
 
   std::vector<std::vector<std::wstring> > values;
-  const int numColumns = Header_GetItemCount(ListView_GetHeader(handle));
-  const int numItems = ListView_GetItemCount(handle);
-  for (int i = 0; i < numItems; ++i) {
+  const int num_columns = Header_GetItemCount(ListView_GetHeader(handle));
+  const int num_items = ListView_GetItemCount(handle);
+  for (int i = 0; i < num_items; ++i) {
     std::vector<std::wstring> row;
-    for (int j = 0; j < numColumns; ++j) {
+    for (int j = 0; j < num_columns; ++j) {
       ListView_GetItemText(handle, i, j, buf, BUF_LEN);
       row.emplace_back(buf);
     }
@@ -258,11 +260,11 @@ std::vector<std::vector<std::wstring> > Window::ListGetAll() {
 }
 
 void Window::AddTab(const std::wstring& name, int index) {
-  TCITEM tabControlItem;
-  tabControlItem.mask = TCIF_TEXT | TCIF_IMAGE;
-  tabControlItem.iImage = -1;
-  tabControlItem.pszText = const_cast<wchar_t*>(name.c_str());
-  if (TabCtrl_InsertItem(handle, index, &tabControlItem) == -1) {
+  TCITEM tab_control_item;
+  tab_control_item.mask = TCIF_TEXT | TCIF_IMAGE;
+  tab_control_item.iImage = -1;
+  tab_control_item.pszText = const_cast<wchar_t*>(name.c_str());
+  if (TabCtrl_InsertItem(handle, index, &tab_control_item) == -1) {
     std::stringstream buf;
     buf << "Can not add tab, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/utils.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/utils.cc
@@ -51,20 +51,21 @@ bool IsComplexType(arrow::Type::type type_id) {
   }
 }
 
-odbcabstraction::SqlDataType GetDefaultSqlCharType(bool useWideChar) {
-  return useWideChar ? odbcabstraction::SqlDataType_WCHAR
-                     : odbcabstraction::SqlDataType_CHAR;
+odbcabstraction::SqlDataType GetDefaultSqlCharType(bool use_wide_char) {
+  return use_wide_char ? odbcabstraction::SqlDataType_WCHAR
+                       : odbcabstraction::SqlDataType_CHAR;
 }
-odbcabstraction::SqlDataType GetDefaultSqlVarcharType(bool useWideChar) {
-  return useWideChar ? odbcabstraction::SqlDataType_WVARCHAR
-                     : odbcabstraction::SqlDataType_VARCHAR;
+odbcabstraction::SqlDataType GetDefaultSqlVarcharType(bool use_wide_char) {
+  return use_wide_char ? odbcabstraction::SqlDataType_WVARCHAR
+                       : odbcabstraction::SqlDataType_VARCHAR;
 }
-odbcabstraction::SqlDataType GetDefaultSqlLongVarcharType(bool useWideChar) {
-  return useWideChar ? odbcabstraction::SqlDataType_WLONGVARCHAR
-                     : odbcabstraction::SqlDataType_LONGVARCHAR;
+odbcabstraction::SqlDataType GetDefaultSqlLongVarcharType(bool use_wide_char) {
+  return use_wide_char ? odbcabstraction::SqlDataType_WLONGVARCHAR
+                       : odbcabstraction::SqlDataType_LONGVARCHAR;
 }
-odbcabstraction::CDataType GetDefaultCCharType(bool useWideChar) {
-  return useWideChar ? odbcabstraction::CDataType_WCHAR : odbcabstraction::CDataType_CHAR;
+odbcabstraction::CDataType GetDefaultCCharType(bool use_wide_char) {
+  return use_wide_char ? odbcabstraction::CDataType_WCHAR
+                       : odbcabstraction::CDataType_CHAR;
 }
 
 }  // namespace
@@ -83,8 +84,8 @@ using std::nullopt;
 /// \note use GetNonConciseDataType on the output to get the verbose type
 /// \note the concise and verbose types are the same for all but types relating to times
 /// and intervals
-SqlDataType GetDataTypeFromArrowField_V3(const std::shared_ptr<arrow::Field>& field,
-                                         bool useWideChar) {
+SqlDataType GetDataTypeFromArrowFieldV3(const std::shared_ptr<arrow::Field>& field,
+                                        bool use_wide_char) {
   const std::shared_ptr<arrow::DataType>& type = field->type();
 
   switch (type->id()) {
@@ -113,7 +114,7 @@ SqlDataType GetDataTypeFromArrowField_V3(const std::shared_ptr<arrow::Field>& fi
       return odbcabstraction::SqlDataType_BINARY;
     case arrow::Type::STRING:
     case arrow::Type::LARGE_STRING:
-      return GetDefaultSqlVarcharType(useWideChar);
+      return GetDefaultSqlVarcharType(use_wide_char);
     case arrow::Type::DATE32:
     case arrow::Type::DATE64:
       return odbcabstraction::SqlDataType_TYPE_DATE;
@@ -148,20 +149,20 @@ SqlDataType GetDataTypeFromArrowField_V3(const std::shared_ptr<arrow::Field>& fi
       break;
   }
 
-  return GetDefaultSqlVarcharType(useWideChar);
+  return GetDefaultSqlVarcharType(use_wide_char);
 }
 
-SqlDataType EnsureRightSqlCharType(SqlDataType data_type, bool useWideChar) {
+SqlDataType EnsureRightSqlCharType(SqlDataType data_type, bool use_wide_char) {
   switch (data_type) {
     case odbcabstraction::SqlDataType_CHAR:
     case odbcabstraction::SqlDataType_WCHAR:
-      return GetDefaultSqlCharType(useWideChar);
+      return GetDefaultSqlCharType(use_wide_char);
     case odbcabstraction::SqlDataType_VARCHAR:
     case odbcabstraction::SqlDataType_WVARCHAR:
-      return GetDefaultSqlVarcharType(useWideChar);
+      return GetDefaultSqlVarcharType(use_wide_char);
     case odbcabstraction::SqlDataType_LONGVARCHAR:
     case odbcabstraction::SqlDataType_WLONGVARCHAR:
-      return GetDefaultSqlLongVarcharType(useWideChar);
+      return GetDefaultSqlLongVarcharType(use_wide_char);
     default:
       return data_type;
   }
@@ -866,10 +867,10 @@ arrow::Type::type ConvertCToArrowType(odbcabstraction::CDataType data_type) {
 }
 
 odbcabstraction::CDataType ConvertArrowTypeToC(arrow::Type::type type_id,
-                                               bool useWideChar) {
+                                               bool use_wide_char) {
   switch (type_id) {
     case arrow::Type::STRING:
-      return GetDefaultCCharType(useWideChar);
+      return GetDefaultCCharType(use_wide_char);
     case arrow::Type::INT16:
       return odbcabstraction::CDataType_SSHORT;
     case arrow::Type::UINT16:
@@ -1119,14 +1120,14 @@ std::string ConvertToDBMSVer(const std::string& str) {
   return result;
 }
 
-int32_t GetDecimalTypeScale(const std::shared_ptr<arrow::DataType>& decimalType) {
-  auto decimal128Type = std::dynamic_pointer_cast<arrow::Decimal128Type>(decimalType);
-  return decimal128Type->scale();
+int32_t GetDecimalTypeScale(const std::shared_ptr<arrow::DataType>& decimal_type) {
+  auto decimal128_type = std::dynamic_pointer_cast<arrow::Decimal128Type>(decimal_type);
+  return decimal128_type->scale();
 }
 
-int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimalType) {
-  auto decimal128Type = std::dynamic_pointer_cast<arrow::Decimal128Type>(decimalType);
-  return decimal128Type->precision();
+int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimal_type) {
+  auto decimal128_type = std::dynamic_pointer_cast<arrow::Decimal128Type>(decimal_type);
+  return decimal128_type->precision();
 }
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/utils.h
@@ -60,11 +60,11 @@ arrow::Status AppendToBuilder(BUILDER& builder, T value) {
   return builder.Append(value);
 }
 
-odbcabstraction::SqlDataType GetDataTypeFromArrowField_V3(
-    const std::shared_ptr<arrow::Field>& field, bool useWideChar);
+odbcabstraction::SqlDataType GetDataTypeFromArrowFieldV3(
+    const std::shared_ptr<arrow::Field>& field, bool use_wide_char);
 
 odbcabstraction::SqlDataType EnsureRightSqlCharType(
-    odbcabstraction::SqlDataType data_type, bool useWideChar);
+    odbcabstraction::SqlDataType data_type, bool use_wide_char);
 
 int16_t ConvertSqlDataTypeFromV3ToV2(int16_t data_type_v3);
 
@@ -109,7 +109,7 @@ std::shared_ptr<arrow::DataType> GetDefaultDataTypeForTypeId(arrow::Type::type t
 arrow::Type::type ConvertCToArrowType(odbcabstraction::CDataType data_type);
 
 odbcabstraction::CDataType ConvertArrowTypeToC(arrow::Type::type type_id,
-                                               bool useWideChar);
+                                               bool use_wide_char);
 
 std::shared_ptr<arrow::Array> CheckConversion(const arrow::Result<arrow::Datum>& result);
 
@@ -118,9 +118,9 @@ ArrayConvertTask GetConverter(arrow::Type::type original_type_id,
 
 std::string ConvertToDBMSVer(const std::string& str);
 
-int32_t GetDecimalTypeScale(const std::shared_ptr<arrow::DataType>& decimalType);
+int32_t GetDecimalTypeScale(const std::shared_ptr<arrow::DataType>& decimal_type);
 
-int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimalType);
+int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimal_type);
 
 }  // namespace flight_sql
 }  // namespace driver

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/win_system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/win_system_dsn.cc
@@ -47,13 +47,13 @@ using driver::flight_sql::config::Result;
 using driver::flight_sql::config::Window;
 using driver::odbcabstraction::DriverException;
 
-bool DisplayConnectionWindow(void* windowParent, Configuration& config) {
-  HWND hwndParent = (HWND)windowParent;
+bool DisplayConnectionWindow(void* window_parent, Configuration& config) {
+  HWND hwnd_parent = (HWND)window_parent;
 
-  if (!hwndParent) return true;
+  if (!hwnd_parent) return true;
 
   try {
-    Window parent(hwndParent);
+    Window parent(hwnd_parent);
     DsnConfigurationWindow window(&parent, config);
 
     window.Create();
@@ -66,24 +66,24 @@ bool DisplayConnectionWindow(void* windowParent, Configuration& config) {
     std::stringstream buf;
     buf << "SQL State: " << err.GetSqlState() << ", Message: " << err.GetMessageText()
         << ", Code: " << err.GetNativeError();
-    std::wstring wMessage = arrow::util::UTF8ToWideString(buf.str()).ValueOr(L"");
-    MessageBox(NULL, wMessage.c_str(), L"Error!", MB_ICONEXCLAMATION | MB_OK);
+    std::wstring wmessage = arrow::util::UTF8ToWideString(buf.str()).ValueOr(L"");
+    MessageBox(NULL, wmessage.c_str(), L"Error!", MB_ICONEXCLAMATION | MB_OK);
 
-    std::wstring wMessageText =
+    std::wstring wmessage_text =
         arrow::util::UTF8ToWideString(err.GetMessageText()).ValueOr(L"");
-    SQLPostInstallerError(err.GetNativeError(), wMessageText.c_str());
+    SQLPostInstallerError(err.GetNativeError(), wmessage_text.c_str());
   }
 
   return false;
 }
 
-bool DisplayConnectionWindow(void* windowParent, Configuration& config,
+bool DisplayConnectionWindow(void* window_parent, Configuration& config,
                              Connection::ConnPropertyMap& properties) {
   for (const auto& [key, value] : properties) {
     config.Set(key, value);
   }
 
-  if (DisplayConnectionWindow(windowParent, config)) {
+  if (DisplayConnectionWindow(window_parent, config)) {
     properties = config.GetProperties();
     return true;
   } else {
@@ -92,17 +92,18 @@ bool DisplayConnectionWindow(void* windowParent, Configuration& config,
   }
 }
 
-BOOL INSTAPI ConfigDSNW(HWND hwndParent, WORD req, LPCWSTR wDriver, LPCWSTR wAttributes) {
+BOOL INSTAPI ConfigDSNW(HWND hwnd_parent, WORD req, LPCWSTR wdriver,
+                        LPCWSTR wattributes) {
   Configuration config;
   ConnectionStringParser parser(config);
   std::string attributes =
-      arrow::util::WideStringToUTF8(std::wstring(wAttributes)).ValueOr("");
+      arrow::util::WideStringToUTF8(std::wstring(wattributes)).ValueOr("");
   parser.ParseConfigAttributes(attributes.c_str());
 
   switch (req) {
     case ODBC_ADD_DSN: {
       config.LoadDefaults();
-      if (!DisplayConnectionWindow(hwndParent, config) || !RegisterDsn(config, wDriver))
+      if (!DisplayConnectionWindow(hwnd_parent, config) || !RegisterDsn(config, wdriver))
         return FALSE;
 
       break;
@@ -110,14 +111,14 @@ BOOL INSTAPI ConfigDSNW(HWND hwndParent, WORD req, LPCWSTR wDriver, LPCWSTR wAtt
 
     case ODBC_CONFIG_DSN: {
       const std::string& dsn = config.Get(FlightSqlConnection::DSN);
-      std::wstring wDsn = arrow::util::UTF8ToWideString(dsn).ValueOr(L"");
-      if (!SQLValidDSN(wDsn.c_str())) return FALSE;
+      std::wstring wdsn = arrow::util::UTF8ToWideString(dsn).ValueOr(L"");
+      if (!SQLValidDSN(wdsn.c_str())) return FALSE;
 
       Configuration loaded(config);
       loaded.LoadDsn(dsn);
 
-      if (!DisplayConnectionWindow(hwndParent, loaded) || !UnregisterDsn(wDsn.c_str()) ||
-          !RegisterDsn(loaded, wDriver))
+      if (!DisplayConnectionWindow(hwnd_parent, loaded) || !UnregisterDsn(wdsn.c_str()) ||
+          !RegisterDsn(loaded, wdriver))
         return FALSE;
 
       break;
@@ -125,8 +126,8 @@ BOOL INSTAPI ConfigDSNW(HWND hwndParent, WORD req, LPCWSTR wDriver, LPCWSTR wAtt
 
     case ODBC_REMOVE_DSN: {
       const std::string& dsn = config.Get(FlightSqlConnection::DSN);
-      std::wstring wDsn = arrow::util::UTF8ToWideString(dsn).ValueOr(L"");
-      if (!SQLValidDSN(wDsn.c_str()) || !UnregisterDsn(wDsn)) return FALSE;
+      std::wstring wdsn = arrow::util::UTF8ToWideString(dsn).ValueOr(L"");
+      if (!SQLValidDSN(wdsn.c_str()) || !UnregisterDsn(wdsn)) return FALSE;
 
       break;
     }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.h
@@ -32,73 +32,76 @@ namespace arrow {
 SQLRETURN SQLAllocHandle(SQLSMALLINT type, SQLHANDLE parent, SQLHANDLE* result);
 SQLRETURN SQLFreeHandle(SQLSMALLINT type, SQLHANDLE handle);
 SQLRETURN SQLFreeStmt(SQLHSTMT stmt, SQLUSMALLINT option);
-SQLRETURN SQLGetDiagField(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT recNumber,
-                          SQLSMALLINT diagIdentifier, SQLPOINTER diagInfoPtr,
-                          SQLSMALLINT bufferLength, SQLSMALLINT* stringLengthPtr);
-SQLRETURN SQLGetDiagRec(SQLSMALLINT handleType, SQLHANDLE handle, SQLSMALLINT recNumber,
-                        SQLWCHAR* sqlState, SQLINTEGER* nativeErrorPtr,
-                        SQLWCHAR* messageText, SQLSMALLINT bufferLength,
-                        SQLSMALLINT* textLengthPtr);
-SQLRETURN SQLGetEnvAttr(SQLHENV env, SQLINTEGER attr, SQLPOINTER valuePtr,
-                        SQLINTEGER bufferLen, SQLINTEGER* strLenPtr);
-SQLRETURN SQLSetEnvAttr(SQLHENV env, SQLINTEGER attr, SQLPOINTER valuePtr,
-                        SQLINTEGER strLen);
-SQLRETURN SQLGetConnectAttr(SQLHDBC conn, SQLINTEGER attribute, SQLPOINTER valuePtr,
-                            SQLINTEGER bufferLength, SQLINTEGER* stringLengthPtr);
+SQLRETURN SQLGetDiagField(SQLSMALLINT handle_type, SQLHANDLE handle,
+                          SQLSMALLINT rec_number, SQLSMALLINT diag_identifier,
+                          SQLPOINTER diag_info_ptr, SQLSMALLINT buffer_length,
+                          SQLSMALLINT* string_length_ptr);
+SQLRETURN SQLGetDiagRec(SQLSMALLINT handle_type, SQLHANDLE handle, SQLSMALLINT rec_number,
+                        SQLWCHAR* sql_state, SQLINTEGER* native_error_ptr,
+                        SQLWCHAR* message_text, SQLSMALLINT buffer_length,
+                        SQLSMALLINT* text_length_ptr);
+SQLRETURN SQLGetEnvAttr(SQLHENV env, SQLINTEGER attr, SQLPOINTER value_ptr,
+                        SQLINTEGER buffer_len, SQLINTEGER* str_len_ptr);
+SQLRETURN SQLSetEnvAttr(SQLHENV env, SQLINTEGER attr, SQLPOINTER value_ptr,
+                        SQLINTEGER str_len);
+SQLRETURN SQLGetConnectAttr(SQLHDBC conn, SQLINTEGER attribute, SQLPOINTER value_ptr,
+                            SQLINTEGER buffer_length, SQLINTEGER* string_length_ptr);
 SQLRETURN SQLSetConnectAttr(SQLHDBC conn, SQLINTEGER attr, SQLPOINTER value,
-                            SQLINTEGER valueLen);
-SQLRETURN SQLDriverConnect(SQLHDBC conn, SQLHWND windowHandle,
-                           SQLWCHAR* inConnectionString,
-                           SQLSMALLINT inConnectionStringLen,
-                           SQLWCHAR* outConnectionString,
-                           SQLSMALLINT outConnectionStringBufferLen,
-                           SQLSMALLINT* outConnectionStringLen,
-                           SQLUSMALLINT driverCompletion);
-SQLRETURN SQLConnect(SQLHDBC conn, SQLWCHAR* dsnName, SQLSMALLINT dsnNameLen,
-                     SQLWCHAR* userName, SQLSMALLINT userNameLen, SQLWCHAR* password,
-                     SQLSMALLINT passwordLen);
+                            SQLINTEGER value_len);
+SQLRETURN SQLDriverConnect(SQLHDBC conn, SQLHWND window_handle,
+                           SQLWCHAR* in_connection_string,
+                           SQLSMALLINT in_connection_string_len,
+                           SQLWCHAR* out_connection_string,
+                           SQLSMALLINT out_connection_string_buffer_len,
+                           SQLSMALLINT* out_connection_string_len,
+                           SQLUSMALLINT driver_completion);
+SQLRETURN SQLConnect(SQLHDBC conn, SQLWCHAR* dsn_name, SQLSMALLINT dsn_name_len,
+                     SQLWCHAR* user_name, SQLSMALLINT user_name_len, SQLWCHAR* password,
+                     SQLSMALLINT password_len);
 SQLRETURN SQLDisconnect(SQLHDBC conn);
-SQLRETURN SQLGetInfo(SQLHDBC conn, SQLUSMALLINT infoType, SQLPOINTER infoValuePtr,
-                     SQLSMALLINT bufLen, SQLSMALLINT* length);
-SQLRETURN SQLGetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER valuePtr,
-                         SQLINTEGER bufferLength, SQLINTEGER* stringLengthPtr);
-SQLRETURN SQLSetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER valuePtr,
+SQLRETURN SQLGetInfo(SQLHDBC conn, SQLUSMALLINT info_type, SQLPOINTER info_value_ptr,
+                     SQLSMALLINT buf_len, SQLSMALLINT* length);
+SQLRETURN SQLGetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER value_ptr,
+                         SQLINTEGER buffer_length, SQLINTEGER* string_length_ptr);
+SQLRETURN SQLSetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER value_ptr,
                          SQLINTEGER stringLength);
-SQLRETURN SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER textLength);
-SQLRETURN SQLPrepare(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER textLength);
+SQLRETURN SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER text_length);
+SQLRETURN SQLPrepare(SQLHSTMT stmt, SQLWCHAR* queryText, SQLINTEGER text_length);
 SQLRETURN SQLExecute(SQLHSTMT stmt);
 SQLRETURN SQLFetch(SQLHSTMT stmt);
-SQLRETURN SQLExtendedFetch(SQLHSTMT stmt, SQLUSMALLINT fetchOrientation,
-                           SQLLEN fetchOffset, SQLULEN* rowCountPtr,
-                           SQLUSMALLINT* rowStatusArray);
-SQLRETURN SQLFetchScroll(SQLHSTMT stmt, SQLSMALLINT fetchOrientation, SQLLEN fetchOffset);
-SQLRETURN SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
-                     SQLPOINTER dataPtr, SQLLEN bufferLength, SQLLEN* indicatorPtr);
+SQLRETURN SQLExtendedFetch(SQLHSTMT stmt, SQLUSMALLINT fetch_orientation,
+                           SQLLEN fetch_offset, SQLULEN* row_count_ptr,
+                           SQLUSMALLINT* row_status_array);
+SQLRETURN SQLFetchScroll(SQLHSTMT stmt, SQLSMALLINT fetch_orientation,
+                         SQLLEN fetch_offset);
+SQLRETURN SQLBindCol(SQLHSTMT stmt, SQLUSMALLINT record_number, SQLSMALLINT c_type,
+                     SQLPOINTER data_ptr, SQLLEN buffer_length, SQLLEN* indicator_ptr);
 SQLRETURN SQLCloseCursor(SQLHSTMT stmt);
-SQLRETURN SQLGetData(SQLHSTMT stmt, SQLUSMALLINT recordNumber, SQLSMALLINT cType,
-                     SQLPOINTER dataPtr, SQLLEN bufferLength, SQLLEN* indicatorPtr);
+SQLRETURN SQLGetData(SQLHSTMT stmt, SQLUSMALLINT record_number, SQLSMALLINT c_type,
+                     SQLPOINTER data_ptr, SQLLEN buffer_length, SQLLEN* indicator_ptr);
 SQLRETURN SQLMoreResults(SQLHSTMT stmt);
-SQLRETURN SQLNumResultCols(SQLHSTMT stmt, SQLSMALLINT* columnCountPtr);
-SQLRETURN SQLRowCount(SQLHSTMT stmt, SQLLEN* rowCountPtr);
-SQLRETURN SQLTables(SQLHSTMT stmt, SQLWCHAR* catalogName, SQLSMALLINT catalogNameLength,
-                    SQLWCHAR* schemaName, SQLSMALLINT schemaNameLength,
-                    SQLWCHAR* tableName, SQLSMALLINT tableNameLength, SQLWCHAR* tableType,
-                    SQLSMALLINT tableTypeLength);
-SQLRETURN SQLColumns(SQLHSTMT stmt, SQLWCHAR* catalogName, SQLSMALLINT catalogNameLength,
-                     SQLWCHAR* schemaName, SQLSMALLINT schemaNameLength,
-                     SQLWCHAR* tableName, SQLSMALLINT tableNameLength,
-                     SQLWCHAR* columnName, SQLSMALLINT columnNameLength);
-SQLRETURN SQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT recordNumber,
-                          SQLUSMALLINT fieldIdentifier, SQLPOINTER characterAttributePtr,
-                          SQLSMALLINT bufferLength, SQLSMALLINT* outputLength,
-                          SQLLEN* numericAttributePtr);
+SQLRETURN SQLNumResultCols(SQLHSTMT stmt, SQLSMALLINT* column_count_ptr);
+SQLRETURN SQLRowCount(SQLHSTMT stmt, SQLLEN* row_count_ptr);
+SQLRETURN SQLTables(SQLHSTMT stmt, SQLWCHAR* catalog_name,
+                    SQLSMALLINT catalog_name_length, SQLWCHAR* schema_name,
+                    SQLSMALLINT schema_name_length, SQLWCHAR* table_name,
+                    SQLSMALLINT table_name_length, SQLWCHAR* table_type,
+                    SQLSMALLINT table_type_length);
+SQLRETURN SQLColumns(SQLHSTMT stmt, SQLWCHAR* catalog_name,
+                     SQLSMALLINT catalog_name_length, SQLWCHAR* schema_name,
+                     SQLSMALLINT schema_name_length, SQLWCHAR* table_name,
+                     SQLSMALLINT table_name_length, SQLWCHAR* column_name,
+                     SQLSMALLINT column_name_length);
+SQLRETURN SQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT record_number,
+                          SQLUSMALLINT field_identifier,
+                          SQLPOINTER character_attribute_ptr, SQLSMALLINT buffer_length,
+                          SQLSMALLINT* output_length, SQLLEN* numeric_attribute_ptr);
 SQLRETURN SQLGetTypeInfo(SQLHSTMT stmt, SQLSMALLINT dataType);
-SQLRETURN SQLNativeSql(SQLHDBC connectionHandle, SQLWCHAR* inStatementText,
-                       SQLINTEGER inStatementTextLength, SQLWCHAR* outStatementText,
-                       SQLINTEGER bufferLength, SQLINTEGER* outStatementTextLength);
-SQLRETURN SQLDescribeCol(SQLHSTMT statementHandle, SQLUSMALLINT columnNumber,
-                         SQLWCHAR* columnName, SQLSMALLINT bufferLength,
-                         SQLSMALLINT* nameLengthPtr, SQLSMALLINT* dataTypePtr,
-                         SQLULEN* columnSizePtr, SQLSMALLINT* decimalDigitsPtr,
-                         SQLSMALLINT* nullablePtr);
+SQLRETURN SQLNativeSql(SQLHDBC conn, SQLWCHAR* in_statement_text,
+                       SQLINTEGER in_statement_text_length, SQLWCHAR* out_statement_text,
+                       SQLINTEGER buffer_length, SQLINTEGER* out_statement_text_length);
+SQLRETURN SQLDescribeCol(SQLHSTMT stmt, SQLUSMALLINT column_number, SQLWCHAR* column_name,
+                         SQLSMALLINT buffer_length, SQLSMALLINT* name_length_ptr,
+                         SQLSMALLINT* data_type_ptr, SQLULEN* column_size_ptr,
+                         SQLSMALLINT* decimal_digits_ptr, SQLSMALLINT* nullable_ptr);
 }  // namespace arrow

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
@@ -32,43 +32,44 @@ namespace ODBC {
 using driver::odbcabstraction::WcsToUtf8;
 
 template <typename T, typename O>
-inline void GetAttribute(T attributeValue, SQLPOINTER output, O outputSize,
-                         O* outputLenPtr) {
+inline void GetAttribute(T attribute_value, SQLPOINTER output, O output_size,
+                         O* output_len_ptr) {
   if (output) {
-    T* typedOutput = reinterpret_cast<T*>(output);
-    *typedOutput = attributeValue;
+    T* typed_output = reinterpret_cast<T*>(output);
+    *typed_output = attribute_value;
   }
 
-  if (outputLenPtr) {
-    *outputLenPtr = sizeof(T);
+  if (output_len_ptr) {
+    *output_len_ptr = sizeof(T);
   }
 }
 
 template <typename O>
-inline SQLRETURN GetAttributeUTF8(const std::string_view& attributeValue,
-                                  SQLPOINTER output, O outputSize, O* outputLenPtr) {
+inline SQLRETURN GetAttributeUTF8(const std::string_view& attribute_value,
+                                  SQLPOINTER output, O output_size, O* output_len_ptr) {
   if (output) {
-    size_t outputLenBeforeNul =
-        std::min(static_cast<O>(attributeValue.size()), static_cast<O>(outputSize - 1));
-    memcpy(output, attributeValue.data(), outputLenBeforeNul);
-    reinterpret_cast<char*>(output)[outputLenBeforeNul] = '\0';
+    size_t output_len_before_null =
+        std::min(static_cast<O>(attribute_value.size()), static_cast<O>(output_size - 1));
+    memcpy(output, attribute_value.data(), output_len_before_null);
+    reinterpret_cast<char*>(output)[output_len_before_null] = '\0';
   }
 
-  if (outputLenPtr) {
-    *outputLenPtr = static_cast<O>(attributeValue.size());
+  if (output_len_ptr) {
+    *output_len_ptr = static_cast<O>(attribute_value.size());
   }
 
-  if (output && outputSize < static_cast<O>(attributeValue.size() + 1)) {
+  if (output && output_size < static_cast<O>(attribute_value.size() + 1)) {
     return SQL_SUCCESS_WITH_INFO;
   }
   return SQL_SUCCESS;
 }
 
 template <typename O>
-inline SQLRETURN GetAttributeUTF8(const std::string_view& attributeValue,
-                                  SQLPOINTER output, O outputSize, O* outputLenPtr,
+inline SQLRETURN GetAttributeUTF8(const std::string_view& attribute_value,
+                                  SQLPOINTER output, O output_size, O* output_len_ptr,
                                   driver::odbcabstraction::Diagnostics& diagnostics) {
-  SQLRETURN result = GetAttributeUTF8(attributeValue, output, outputSize, outputLenPtr);
+  SQLRETURN result =
+      GetAttributeUTF8(attribute_value, output, output_size, output_len_ptr);
   if (SQL_SUCCESS_WITH_INFO == result) {
     diagnostics.AddTruncationWarning();
   }
@@ -76,35 +77,36 @@ inline SQLRETURN GetAttributeUTF8(const std::string_view& attributeValue,
 }
 
 template <typename O>
-inline SQLRETURN GetAttributeSQLWCHAR(const std::string_view& attributeValue,
-                                      bool isLengthInBytes, SQLPOINTER output,
-                                      O outputSize, O* outputLenPtr) {
-  size_t length =
-      ConvertToSqlWChar(attributeValue, reinterpret_cast<SQLWCHAR*>(output),
-                        isLengthInBytes ? outputSize : outputSize * GetSqlWCharSize());
+inline SQLRETURN GetAttributeSQLWCHAR(const std::string_view& attribute_value,
+                                      bool is_length_in_bytes, SQLPOINTER output,
+                                      O output_size, O* output_len_ptr) {
+  size_t length = ConvertToSqlWChar(
+      attribute_value, reinterpret_cast<SQLWCHAR*>(output),
+      is_length_in_bytes ? output_size : output_size * GetSqlWCharSize());
 
-  if (!isLengthInBytes) {
+  if (!is_length_in_bytes) {
     length = length / GetSqlWCharSize();
   }
 
-  if (outputLenPtr) {
-    *outputLenPtr = static_cast<O>(length);
+  if (output_len_ptr) {
+    *output_len_ptr = static_cast<O>(length);
   }
 
   if (output &&
-      outputSize < static_cast<O>(length + (isLengthInBytes ? GetSqlWCharSize() : 1))) {
+      output_size <
+          static_cast<O>(length + (is_length_in_bytes ? GetSqlWCharSize() : 1))) {
     return SQL_SUCCESS_WITH_INFO;
   }
   return SQL_SUCCESS;
 }
 
 template <typename O>
-inline SQLRETURN GetAttributeSQLWCHAR(const std::string_view& attributeValue,
-                                      bool isLengthInBytes, SQLPOINTER output,
-                                      O outputSize, O* outputLenPtr,
+inline SQLRETURN GetAttributeSQLWCHAR(const std::string_view& attribute_value,
+                                      bool is_length_in_bytes, SQLPOINTER output,
+                                      O output_size, O* output_len_ptr,
                                       driver::odbcabstraction::Diagnostics& diagnostics) {
-  SQLRETURN result = GetAttributeSQLWCHAR(attributeValue, isLengthInBytes, output,
-                                          outputSize, outputLenPtr);
+  SQLRETURN result = GetAttributeSQLWCHAR(attribute_value, is_length_in_bytes, output,
+                                          output_size, output_len_ptr);
   if (SQL_SUCCESS_WITH_INFO == result) {
     diagnostics.AddTruncationWarning();
   }
@@ -112,17 +114,17 @@ inline SQLRETURN GetAttributeSQLWCHAR(const std::string_view& attributeValue,
 }
 
 template <typename O>
-inline SQLRETURN GetStringAttribute(bool isUnicode,
-                                    const std::string_view& attributeValue,
-                                    bool isLengthInBytes, SQLPOINTER output, O outputSize,
-                                    O* outputLenPtr,
+inline SQLRETURN GetStringAttribute(bool is_unicode,
+                                    const std::string_view& attribute_value,
+                                    bool is_length_in_bytes, SQLPOINTER output,
+                                    O output_size, O* output_len_ptr,
                                     driver::odbcabstraction::Diagnostics& diagnostics) {
   SQLRETURN result = SQL_SUCCESS;
-  if (isUnicode) {
-    result = GetAttributeSQLWCHAR(attributeValue, isLengthInBytes, output, outputSize,
-                                  outputLenPtr);
+  if (is_unicode) {
+    result = GetAttributeSQLWCHAR(attribute_value, is_length_in_bytes, output,
+                                  output_size, output_len_ptr);
   } else {
-    result = GetAttributeUTF8(attributeValue, output, outputSize, outputLenPtr);
+    result = GetAttributeUTF8(attribute_value, output, output_size, output_len_ptr);
   }
 
   if (SQL_SUCCESS_WITH_INFO == result) {
@@ -132,32 +134,33 @@ inline SQLRETURN GetStringAttribute(bool isUnicode,
 }
 
 template <typename T>
-inline void SetAttribute(SQLPOINTER newValue, T& attributeToWrite) {
-  SQLLEN valueAsLen = reinterpret_cast<SQLLEN>(newValue);
-  attributeToWrite = static_cast<T>(valueAsLen);
+inline void SetAttribute(SQLPOINTER new_value, T& attribute_to_write) {
+  SQLLEN valueAsLen = reinterpret_cast<SQLLEN>(new_value);
+  attribute_to_write = static_cast<T>(valueAsLen);
 }
 
 template <typename T>
-inline void SetPointerAttribute(SQLPOINTER newValue, T& attributeToWrite) {
-  attributeToWrite = static_cast<T>(newValue);
+inline void SetPointerAttribute(SQLPOINTER new_value, T& attribute_to_write) {
+  attribute_to_write = static_cast<T>(new_value);
 }
 
-inline void SetAttributeUTF8(SQLPOINTER newValue, SQLINTEGER inputLength,
-                             std::string& attributeToWrite) {
-  const char* newValueAsChar = static_cast<const char*>(newValue);
-  attributeToWrite.assign(newValueAsChar,
-                          inputLength == SQL_NTS ? strlen(newValueAsChar) : inputLength);
+inline void SetAttributeUTF8(SQLPOINTER new_value, SQLINTEGER input_length,
+                             std::string& attribute_to_write) {
+  const char* new_value_as_char = static_cast<const char*>(new_value);
+  attribute_to_write.assign(new_value_as_char, input_length == SQL_NTS
+                                                   ? strlen(new_value_as_char)
+                                                   : input_length);
 }
 
-inline void SetAttributeSQLWCHAR(SQLPOINTER newValue, SQLINTEGER inputLengthInBytes,
-                                 std::string& attributeToWrite) {
+inline void SetAttributeSQLWCHAR(SQLPOINTER new_value, SQLINTEGER input_length_in_bytes,
+                                 std::string& attribute_to_write) {
   thread_local std::vector<uint8_t> utf8_str;
-  if (inputLengthInBytes == SQL_NTS) {
-    WcsToUtf8(newValue, &utf8_str);
+  if (input_length_in_bytes == SQL_NTS) {
+    WcsToUtf8(new_value, &utf8_str);
   } else {
-    WcsToUtf8(newValue, inputLengthInBytes / GetSqlWCharSize(), &utf8_str);
+    WcsToUtf8(new_value, input_length_in_bytes / GetSqlWCharSize(), &utf8_str);
   }
-  attributeToWrite.assign((char*)utf8_str.data());
+  attribute_to_write.assign((char*)utf8_str.data());
 }
 
 template <typename T>

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/encoding_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/encoding_utils.h
@@ -39,38 +39,39 @@ using driver::odbcabstraction::WcsToUtf8;
 // Return the number of bytes required for the conversion.
 template <typename CHAR_TYPE>
 inline size_t ConvertToSqlWChar(const std::string_view& str, SQLWCHAR* buffer,
-                                SQLLEN bufferSizeInBytes) {
+                                SQLLEN buffer_size_in_bytes) {
   thread_local std::vector<uint8_t> wstr;
   Utf8ToWcs<CHAR_TYPE>(str.data(), str.size(), &wstr);
-  SQLLEN valueLengthInBytes = wstr.size();
+  SQLLEN value_length_in_bytes = wstr.size();
 
   if (buffer) {
     memcpy(buffer, wstr.data(),
-           std::min(static_cast<SQLLEN>(wstr.size()), bufferSizeInBytes));
+           std::min(static_cast<SQLLEN>(wstr.size()), buffer_size_in_bytes));
 
     // Write a NUL terminator
-    if (bufferSizeInBytes >=
-        valueLengthInBytes + static_cast<SQLLEN>(GetSqlWCharSize())) {
-      reinterpret_cast<CHAR_TYPE*>(buffer)[valueLengthInBytes / GetSqlWCharSize()] = '\0';
+    if (buffer_size_in_bytes >=
+        value_length_in_bytes + static_cast<SQLLEN>(GetSqlWCharSize())) {
+      reinterpret_cast<CHAR_TYPE*>(buffer)[value_length_in_bytes / GetSqlWCharSize()] =
+          '\0';
     } else {
-      SQLLEN numCharsWritten = bufferSizeInBytes / GetSqlWCharSize();
+      SQLLEN num_chars_written = buffer_size_in_bytes / GetSqlWCharSize();
       // If we failed to even write one char, the buffer is too small to hold a
       // NUL-terminator.
-      if (numCharsWritten > 0) {
-        reinterpret_cast<CHAR_TYPE*>(buffer)[numCharsWritten - 1] = '\0';
+      if (num_chars_written > 0) {
+        reinterpret_cast<CHAR_TYPE*>(buffer)[num_chars_written - 1] = '\0';
       }
     }
   }
-  return valueLengthInBytes;
+  return value_length_in_bytes;
 }
 
 inline size_t ConvertToSqlWChar(const std::string_view& str, SQLWCHAR* buffer,
-                                SQLLEN bufferSizeInBytes) {
+                                SQLLEN buffer_size_in_bytes) {
   switch (GetSqlWCharSize()) {
     case sizeof(char16_t):
-      return ConvertToSqlWChar<char16_t>(str, buffer, bufferSizeInBytes);
+      return ConvertToSqlWChar<char16_t>(str, buffer, buffer_size_in_bytes);
     case sizeof(char32_t):
-      return ConvertToSqlWChar<char32_t>(str, buffer, bufferSizeInBytes);
+      return ConvertToSqlWChar<char32_t>(str, buffer, buffer_size_in_bytes);
     default:
       assert(false);
       throw DriverException("Encoding is unsupported, SQLWCHAR size: " +
@@ -98,18 +99,18 @@ inline std::string SqlWcharToString(SQLWCHAR* wchar_msg, SQLINTEGER msg_len = SQ
   return std::string(utf8_str.begin(), utf8_str.end());
 }
 
-inline std::string SqlStringToString(const unsigned char* sqlStr,
-                                     int32_t sqlStrLen = SQL_NTS) {
+inline std::string SqlStringToString(const unsigned char* sql_str,
+                                     int32_t sql_str_len = SQL_NTS) {
   std::string res;
 
-  const char* sqlStrC = reinterpret_cast<const char*>(sqlStr);
+  const char* sql_str_c = reinterpret_cast<const char*>(sql_str);
 
-  if (!sqlStr) return res;
+  if (!sql_str) return res;
 
-  if (sqlStrLen == SQL_NTS)
-    res.assign(sqlStrC);
-  else if (sqlStrLen > 0)
-    res.assign(sqlStrC, sqlStrLen);
+  if (sql_str_len == SQL_NTS)
+    res.assign(sql_str_c);
+  else if (sql_str_len > 0)
+    res.assign(sql_str_c, sql_str_len);
 
   return res;
 }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
@@ -43,68 +43,68 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
 
   /// \brief Constructor for ODBCConnection.
   /// \param[in] environment the parent environment.
-  /// \param[in] spiConnection the underlying spi connection.
+  /// \param[in] spi_connection the underlying spi connection.
   ODBCConnection(ODBCEnvironment& environment,
-                 std::shared_ptr<driver::odbcabstraction::Connection> spiConnection);
+                 std::shared_ptr<driver::odbcabstraction::Connection> spi_connection);
 
-  driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl();
+  driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl();
 
   const std::string& GetDSN() const;
-  bool isConnected() const;
+  bool IsConnected() const;
 
   /// \brief Connect to Arrow Flight SQL server.
   /// \param[in] dsn the dsn name.
   /// \param[in] properties the connection property map extracted from connection string.
   /// \param[out] missing_properties report the properties that are missing
-  void connect(std::string dsn,
+  void Connect(std::string dsn,
                const driver::odbcabstraction::Connection::ConnPropertyMap& properties,
                std::vector<std::string_view>& missing_properties);
 
-  SQLRETURN GetInfo(SQLUSMALLINT infoType, SQLPOINTER value, SQLSMALLINT bufferLength,
-                    SQLSMALLINT* outputLength, bool isUnicode);
-  void SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value, SQLINTEGER stringLength,
-                      bool isUnicode);
+  SQLRETURN GetInfo(SQLUSMALLINT info_type, SQLPOINTER value, SQLSMALLINT buffer_length,
+                    SQLSMALLINT* output_length, bool is_unicode);
+  void SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value, SQLINTEGER string_length,
+                      bool is_unicode);
   SQLRETURN GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
-                           SQLINTEGER bufferLength, SQLINTEGER* outputLength,
-                           bool isUnicode);
+                           SQLINTEGER buffer_length, SQLINTEGER* output_length,
+                           bool is_unicode);
 
   ~ODBCConnection() = default;
 
-  inline ODBCStatement& GetTrackingStatement() { return *m_attributeTrackingStatement; }
+  inline ODBCStatement& GetTrackingStatement() { return *m_attribute_tracking_statement; }
 
-  void disconnect();
+  void Disconnect();
 
-  void releaseConnection();
+  void ReleaseConnection();
 
-  std::shared_ptr<ODBCStatement> createStatement();
-  void dropStatement(ODBCStatement* statement);
+  std::shared_ptr<ODBCStatement> CreateStatement();
+  void DropStatement(ODBCStatement* statement);
 
-  std::shared_ptr<ODBCDescriptor> createDescriptor();
-  void dropDescriptor(ODBCDescriptor* descriptor);
+  std::shared_ptr<ODBCDescriptor> CreateDescriptor();
+  void DropDescriptor(ODBCDescriptor* descriptor);
 
-  inline bool IsOdbc2Connection() const { return m_is2xConnection; }
+  inline bool IsOdbc2Connection() const { return m_is_2x_connection; }
 
   /// @return the DSN or an empty string if the DSN is not found or is found after the
   /// driver
-  static std::string getDsnIfExists(const std::string& connStr);
+  static std::string GetDsnIfExists(const std::string& conn_str);
 
   /// Read properties from connection string, but does not read values from DSN
-  static void getPropertiesFromConnString(
-      const std::string& connStr,
+  static void GetPropertiesFromConnString(
+      const std::string& conn_str,
       driver::odbcabstraction::Connection::ConnPropertyMap& properties);
 
  private:
   ODBCEnvironment& m_environment;
-  std::shared_ptr<driver::odbcabstraction::Connection> m_spiConnection;
+  std::shared_ptr<driver::odbcabstraction::Connection> m_spi_connection;
   // Extra ODBC statement that's used to track and validate when statement attributes are
   // set through the connection handle. These attributes get copied to new ODBC statements
   // when they are allocated.
-  std::shared_ptr<ODBCStatement> m_attributeTrackingStatement;
+  std::shared_ptr<ODBCStatement> m_attribute_tracking_statement;
   std::vector<std::shared_ptr<ODBCStatement> > m_statements;
   std::vector<std::shared_ptr<ODBCDescriptor> > m_descriptors;
   std::string m_dsn;
-  const bool m_is2xConnection;
-  bool m_isConnected;
+  const bool m_is_2x_connection;
+  bool m_is_connected;
 };
 
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_descriptor.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_descriptor.h
@@ -38,40 +38,40 @@ class ODBCStatement;
 
 namespace ODBC {
 struct DescriptorRecord {
-  std::string m_baseColumnName;
-  std::string m_baseTableName;
-  std::string m_catalogName;
+  std::string m_base_column_name;
+  std::string m_base_table_name;
+  std::string m_catalog_name;
   std::string m_label;
-  std::string m_literalPrefix;
-  std::string m_literalSuffix;
-  std::string m_localTypeName;
+  std::string m_literal_prefix;
+  std::string m_literal_suffix;
+  std::string m_local_type_name;
   std::string m_name;
-  std::string m_schemaName;
-  std::string m_tableName;
-  std::string m_typeName;
-  SQLPOINTER m_dataPtr = NULL;
-  SQLLEN* m_indicatorPtr = NULL;
-  SQLLEN m_displaySize = 0;
-  SQLLEN m_octetLength = 0;
+  std::string m_schema_name;
+  std::string m_table_name;
+  std::string m_type_name;
+  SQLPOINTER m_data_ptr = NULL;
+  SQLLEN* m_indicator_ptr = NULL;
+  SQLLEN m_display_size = 0;
+  SQLLEN m_octet_length = 0;
   SQLULEN m_length = 0;
-  SQLINTEGER m_autoUniqueValue;
-  SQLINTEGER m_caseSensitive = SQL_TRUE;
-  SQLINTEGER m_datetimeIntervalPrecision = 0;
-  SQLINTEGER m_numPrecRadix = 0;
-  SQLSMALLINT m_conciseType = SQL_C_DEFAULT;
-  SQLSMALLINT m_datetimeIntervalCode = 0;
-  SQLSMALLINT m_fixedPrecScale = 0;
+  SQLINTEGER m_auto_unique_value;
+  SQLINTEGER m_case_sensitive = SQL_TRUE;
+  SQLINTEGER m_datetime_interval_precision = 0;
+  SQLINTEGER m_num_prec_radix = 0;
+  SQLSMALLINT m_concise_type = SQL_C_DEFAULT;
+  SQLSMALLINT m_datetime_interval_code = 0;
+  SQLSMALLINT m_fixed_prec_scale = 0;
   SQLSMALLINT m_nullable = SQL_NULLABLE_UNKNOWN;
-  SQLSMALLINT m_paramType = SQL_PARAM_INPUT;
+  SQLSMALLINT m_param_type = SQL_PARAM_INPUT;
   SQLSMALLINT m_precision = 0;
-  SQLSMALLINT m_rowVer = 0;
+  SQLSMALLINT m_row_ver = 0;
   SQLSMALLINT m_scale = 0;
   SQLSMALLINT m_searchable = SQL_SEARCHABLE;
   SQLSMALLINT m_type = SQL_C_DEFAULT;
   SQLSMALLINT m_unnamed = SQL_TRUE;
   SQLSMALLINT m_unsigned = SQL_FALSE;
   SQLSMALLINT m_updatable = SQL_FALSE;
-  bool m_isBound = false;
+  bool m_is_bound = false;
 
   void CheckConsistency();
 };
@@ -81,29 +81,29 @@ class ODBCDescriptor : public ODBCHandle<ODBCDescriptor> {
   /// \brief Construct a new ODBCDescriptor object. Link the descriptor to a connection,
   /// if applicable. A nullptr should be supplied for conn if the descriptor should not be
   /// linked.
-  ODBCDescriptor(driver::odbcabstraction::Diagnostics& baseDiagnostics,
-                 ODBCConnection* conn, ODBCStatement* stmt, bool isAppDescriptor,
-                 bool isWritable, bool is2xConnection);
+  ODBCDescriptor(driver::odbcabstraction::Diagnostics& base_diagnostics,
+                 ODBCConnection* conn, ODBCStatement* stmt, bool is_app_descriptor,
+                 bool is_writable, bool is_2x_connection);
 
-  driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl();
+  driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl();
 
   ODBCConnection& GetConnection();
 
-  void SetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                      SQLINTEGER bufferLength);
-  void SetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                SQLINTEGER bufferLength);
-  void GetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                      SQLINTEGER bufferLength, SQLINTEGER* outputLength) const;
-  void GetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                SQLINTEGER bufferLength, SQLINTEGER* outputLength);
-  SQLSMALLINT getAllocType() const;
+  void SetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
+                      SQLINTEGER buffer_length);
+  void SetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier, SQLPOINTER value,
+                SQLINTEGER buffer_length);
+  void GetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
+                      SQLINTEGER buffer_length, SQLINTEGER* output_length) const;
+  void GetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier, SQLPOINTER value,
+                SQLINTEGER buffer_length, SQLINTEGER* output_length);
+  SQLSMALLINT GetAllocType() const;
   bool IsAppDescriptor() const;
 
-  inline bool HaveBindingsChanged() const { return m_hasBindingsChanged; }
+  inline bool HaveBindingsChanged() const { return m_has_bindings_changed; }
 
-  void RegisterToStatement(ODBCStatement* statement, bool isApd);
-  void DetachFromStatement(ODBCStatement* statement, bool isApd);
+  void RegisterToStatement(ODBCStatement* statement, bool is_apd);
+  void DetachFromStatement(ODBCStatement* statement, bool is_apd);
   void ReleaseDescriptor();
 
   void PopulateFromResultSetMetadata(driver::odbcabstraction::ResultSetMetadata* rsmd);
@@ -111,49 +111,49 @@ class ODBCDescriptor : public ODBCHandle<ODBCDescriptor> {
   const std::vector<DescriptorRecord>& GetRecords() const;
   std::vector<DescriptorRecord>& GetRecords();
 
-  void BindCol(SQLSMALLINT recordNumber, SQLSMALLINT cType, SQLPOINTER dataPtr,
-               SQLLEN bufferLength, SQLLEN* indicatorPtr);
-  void SetDataPtrOnRecord(SQLPOINTER dataPtr, SQLSMALLINT recNumber);
+  void BindCol(SQLSMALLINT record_number, SQLSMALLINT c_type, SQLPOINTER data_ptr,
+               SQLLEN buffer_length, SQLLEN* indicator_ptr);
+  void SetDataPtrOnRecord(SQLPOINTER data_ptr, SQLSMALLINT rec_number);
 
-  inline SQLULEN GetBindOffset() { return m_bindOffsetPtr ? *m_bindOffsetPtr : 0UL; }
+  inline SQLULEN GetBindOffset() { return m_bind_offset_ptr ? *m_bind_offset_ptr : 0UL; }
 
   inline SQLULEN GetBoundStructOffset() {
-    // If this is SQL_BIND_BY_COLUMN, m_bindType is zero which indicates no offset due to
+    // If this is SQL_BIND_BY_COLUMN, m_bind_type is zero which indicates no offset due to
     // use of a bound struct. If this is non-zero, row-wise binding is being used so the
     // app should set this to sizeof(their struct).
-    return m_bindType;
+    return m_bind_type;
   }
 
-  inline SQLULEN GetArraySize() { return m_arraySize; }
+  inline SQLULEN GetArraySize() { return m_array_size; }
 
-  inline SQLUSMALLINT* GetArrayStatusPtr() { return m_arrayStatusPtr; }
+  inline SQLUSMALLINT* GetArrayStatusPtr() { return m_array_status_ptr; }
 
   inline void SetRowsProcessed(SQLULEN rows) {
-    if (m_rowsProccessedPtr) {
-      *m_rowsProccessedPtr = rows;
+    if (m_rows_proccessed_ptr) {
+      *m_rows_proccessed_ptr = rows;
     }
   }
 
-  inline void NotifyBindingsHavePropagated() { m_hasBindingsChanged = false; }
+  inline void NotifyBindingsHavePropagated() { m_has_bindings_changed = false; }
 
-  inline void NotifyBindingsHaveChanged() { m_hasBindingsChanged = true; }
+  inline void NotifyBindingsHaveChanged() { m_has_bindings_changed = true; }
 
  private:
   driver::odbcabstraction::Diagnostics m_diagnostics;
-  std::vector<ODBCStatement*> m_registeredOnStatementsAsApd;
-  std::vector<ODBCStatement*> m_registeredOnStatementsAsArd;
+  std::vector<ODBCStatement*> m_registered_on_statements_as_apd;
+  std::vector<ODBCStatement*> m_registered_on_statements_as_ard;
   std::vector<DescriptorRecord> m_records;
-  ODBCConnection* m_owningConnection;
-  ODBCStatement* m_parentStatement;
-  SQLUSMALLINT* m_arrayStatusPtr;
-  SQLULEN* m_bindOffsetPtr;
-  SQLULEN* m_rowsProccessedPtr;
-  SQLULEN m_arraySize;
-  SQLINTEGER m_bindType;
-  SQLSMALLINT m_highestOneBasedBoundRecord;
-  const bool m_is2xConnection;
-  bool m_isAppDescriptor;
-  bool m_isWritable;
-  bool m_hasBindingsChanged;
+  ODBCConnection* m_owning_connection;
+  ODBCStatement* m_parent_statement;
+  SQLUSMALLINT* m_array_status_ptr;
+  SQLULEN* m_bind_offset_ptr;
+  SQLULEN* m_rows_proccessed_ptr;
+  SQLULEN m_array_size;
+  SQLINTEGER m_bind_type;
+  SQLSMALLINT m_highest_one_based_bound_record;
+  const bool m_is_2x_connection;
+  bool m_is_app_descriptor;
+  bool m_is_writable;
+  bool m_has_bindings_changed;
 };
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_environment.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_environment.h
@@ -40,11 +40,11 @@ namespace ODBC {
 class ODBCEnvironment : public ODBCHandle<ODBCEnvironment> {
  public:
   explicit ODBCEnvironment(std::shared_ptr<driver::odbcabstraction::Driver> driver);
-  driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl();
-  SQLINTEGER getODBCVersion() const;
-  void setODBCVersion(SQLINTEGER version);
-  SQLINTEGER getConnectionPooling() const;
-  void setConnectionPooling(SQLINTEGER pooling);
+  driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl();
+  SQLINTEGER GetODBCVersion() const;
+  void SetODBCVersion(SQLINTEGER version);
+  SQLINTEGER GetConnectionPooling() const;
+  void SetConnectionPooling(SQLINTEGER pooling);
   std::shared_ptr<ODBCConnection> CreateConnection();
   void DropConnection(ODBCConnection* conn);
   ~ODBCEnvironment() = default;
@@ -54,7 +54,7 @@ class ODBCEnvironment : public ODBCHandle<ODBCEnvironment> {
   std::shared_ptr<driver::odbcabstraction::Driver> m_driver;
   std::unique_ptr<driver::odbcabstraction::Diagnostics> m_diagnostics;
   SQLINTEGER m_version;
-  SQLINTEGER m_connectionPooling;
+  SQLINTEGER m_connection_pooling;
 };
 
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_handle.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_handle.h
@@ -35,15 +35,15 @@ template <typename Derived>
 class ODBCHandle {
  public:
   inline driver::odbcabstraction::Diagnostics& GetDiagnostics() {
-    return static_cast<Derived*>(this)->GetDiagnostics_Impl();
+    return static_cast<Derived*>(this)->GetDiagnosticsImpl();
   }
 
-  inline driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl() {
+  inline driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl() {
     throw std::runtime_error("Illegal state -- diagnostics requested on invalid handle");
   }
 
   template <typename Function>
-  inline SQLRETURN execute(SQLRETURN rc, Function function) {
+  inline SQLRETURN Execute(SQLRETURN rc, Function function) {
     try {
       GetDiagnostics().Clear();
       rc = function();
@@ -69,9 +69,9 @@ class ODBCHandle {
   }
 
   template <typename Function>
-  inline SQLRETURN executeWithLock(SQLRETURN rc, Function function) {
+  inline SQLRETURN ExecuteWithLock(SQLRETURN rc, Function function) {
     const std::lock_guard<std::mutex> lock(mtx_);
-    return execute(rc, function);
+    return Execute(rc, function);
   }
 
   template <typename Function, bool SHOULD_LOCK = true>
@@ -81,13 +81,13 @@ class ODBCHandle {
       return SQL_INVALID_HANDLE;
     }
     if (SHOULD_LOCK) {
-      return reinterpret_cast<Derived*>(handle)->executeWithLock(rc, func);
+      return reinterpret_cast<Derived*>(handle)->ExecuteWithLock(rc, func);
     } else {
-      return reinterpret_cast<Derived*>(handle)->execute(rc, func);
+      return reinterpret_cast<Derived*>(handle)->Execute(rc, func);
     }
   }
 
-  static Derived* of(SQLHANDLE handle) { return reinterpret_cast<Derived*>(handle); }
+  static Derived* Of(SQLHANDLE handle) { return reinterpret_cast<Derived*>(handle); }
 
  private:
   std::mutex mtx_;

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
@@ -49,11 +49,11 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   ODBCStatement& operator=(const ODBCStatement&) = delete;
 
   ODBCStatement(ODBCConnection& connection,
-                std::shared_ptr<driver::odbcabstraction::Statement> spiStatement);
+                std::shared_ptr<driver::odbcabstraction::Statement> spi_statement);
 
   ~ODBCStatement() = default;
 
-  inline driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl() {
+  inline driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl() {
     return *m_diagnostics;
   }
 
@@ -66,79 +66,79 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
 
   /**
    * @brief Returns true if the number of rows fetch was greater than zero.
-   * rowCountPtr and rowStatusArray are optional arguments, they are only needed for
+   * row_count_ptr and row_status_array are optional arguments, they are only needed for
    * SQLExtendedFetch
    */
-  bool Fetch(size_t rows, SQLULEN* rowCountPtr = 0, SQLUSMALLINT* rowStatusArray = 0);
-  bool isPrepared() const;
+  bool Fetch(size_t rows, SQLULEN* row_count_ptr = 0, SQLUSMALLINT* row_status_array = 0);
+  bool IsPrepared() const;
 
-  void GetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER output,
-                   SQLINTEGER bufferSize, SQLINTEGER* strLenPtr, bool isUnicode);
-  void SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value, SQLINTEGER bufferSize,
-                   bool isUnicode);
+  void GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER output,
+                   SQLINTEGER buffer_size, SQLINTEGER* str_len_ptr, bool is_unicode);
+  void SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value,
+                   SQLINTEGER buffer_size, bool is_unicode);
 
   /**
    * @brief Revert back to implicitly allocated internal descriptors.
    * isApd as True indicates APD descritor is to be reverted.
    * isApd as False indicates ARD descritor is to be reverted.
    */
-  void RevertAppDescriptor(bool isApd);
+  void RevertAppDescriptor(bool is_apd);
 
   inline ODBCDescriptor* GetIRD() { return m_ird.get(); }
 
-  inline ODBCDescriptor* GetARD() { return m_currentArd; }
+  inline ODBCDescriptor* GetARD() { return m_current_ard; }
 
-  inline SQLULEN GetRowsetSize() { return m_rowsetSize; }
+  inline SQLULEN GetRowsetSize() { return m_rowset_size; }
 
-  SQLRETURN GetData(SQLSMALLINT recordNumber, SQLSMALLINT cType, SQLPOINTER dataPtr,
-                    SQLLEN bufferLength, SQLLEN* indicatorPtr);
+  SQLRETURN GetData(SQLSMALLINT record_number, SQLSMALLINT c_type, SQLPOINTER data_ptr,
+                    SQLLEN buffer_length, SQLLEN* indicator_ptr);
 
-  SQLRETURN getMoreResults();
+  SQLRETURN GetMoreResults();
 
   /**
    * @brief Get number of columns from data set
    */
-  void getColumnCount(SQLSMALLINT* columnCountPtr);
+  void GetColumnCount(SQLSMALLINT* column_count_ptr);
 
   /**
    * @brief Get number of rows affected by an UPDATE, INSERT, or DELETE statement
    */
-  void getRowCount(SQLLEN* rowCountPtr);
+  void GetRowCount(SQLLEN* row_count_ptr);
 
   /**
    * @brief Closes the cursor. This does _not_ un-prepare the statement or change
    * bindings.
    */
-  void closeCursor(bool suppressErrors);
+  void CloseCursor(bool suppress_errors);
 
   /**
    * @brief Releases this statement from memory.
    */
-  void releaseStatement();
+  void ReleaseStatement();
 
   void GetTables(const std::string* catalog, const std::string* schema,
-                 const std::string* table, const std::string* tableType);
+                 const std::string* table, const std::string* table_type);
   void GetColumns(const std::string* catalog, const std::string* schema,
                   const std::string* table, const std::string* column);
-  void GetTypeInfo(SQLSMALLINT dataType);
+  void GetTypeInfo(SQLSMALLINT data_type);
   void Cancel();
 
  private:
   ODBCConnection& m_connection;
-  std::shared_ptr<driver::odbcabstraction::Statement> m_spiStatement;
-  std::shared_ptr<driver::odbcabstraction::ResultSet> m_currenResult;
+  std::shared_ptr<driver::odbcabstraction::Statement> m_spi_statement;
+  std::shared_ptr<driver::odbcabstraction::ResultSet> m_current_result;
   driver::odbcabstraction::Diagnostics* m_diagnostics;
 
-  std::shared_ptr<ODBCDescriptor> m_builtInArd;
-  std::shared_ptr<ODBCDescriptor> m_builtInApd;
+  std::shared_ptr<ODBCDescriptor> m_built_in_ard;
+  std::shared_ptr<ODBCDescriptor> m_built_in_apd;
   std::shared_ptr<ODBCDescriptor> m_ipd;
   std::shared_ptr<ODBCDescriptor> m_ird;
-  ODBCDescriptor* m_currentArd;
-  ODBCDescriptor* m_currentApd;
-  SQLULEN m_rowNumber;
-  SQLULEN m_maxRows;
-  SQLULEN m_rowsetSize;  // Used by SQLExtendedFetch instead of the ARD array size.
-  bool m_isPrepared;
-  bool m_hasReachedEndOfResult;
+  ODBCDescriptor* m_current_ard;
+  ODBCDescriptor* m_current_apd;
+  SQLULEN m_row_number;
+  SQLULEN m_max_rows;
+  SQLULEN m_rowset_size;  // Used by SQLExtendedFetch instead of the ARD array size.
+  bool m_is_prepared;
+  bool m_has_reached_end_of_result;
 };
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/type_utilities.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/type_utilities.h
@@ -21,19 +21,19 @@
 #include <sqlext.h>
 
 namespace ODBC {
-inline SQLSMALLINT GetSqlTypeForODBCVersion(SQLSMALLINT type, bool isOdbc2x) {
+inline SQLSMALLINT GetSqlTypeForODBCVersion(SQLSMALLINT type, bool is_odbc_2x) {
   switch (type) {
     case SQL_DATE:
     case SQL_TYPE_DATE:
-      return isOdbc2x ? SQL_DATE : SQL_TYPE_DATE;
+      return is_odbc_2x ? SQL_DATE : SQL_TYPE_DATE;
 
     case SQL_TIME:
     case SQL_TYPE_TIME:
-      return isOdbc2x ? SQL_TIME : SQL_TYPE_TIME;
+      return is_odbc_2x ? SQL_TIME : SQL_TYPE_TIME;
 
     case SQL_TIMESTAMP:
     case SQL_TYPE_TIMESTAMP:
-      return isOdbc2x ? SQL_TIMESTAMP : SQL_TYPE_TIMESTAMP;
+      return is_odbc_2x ? SQL_TIMESTAMP : SQL_TYPE_TIMESTAMP;
 
     default:
       return type;

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/utils.h
@@ -32,22 +32,22 @@ boost::optional<bool> AsBool(const std::string& value);
 
 /// Looks up for a value inside the ConnPropertyMap and then try to parse it.
 /// In case it does not find or it cannot parse, the default value will be returned.
-/// \param connPropertyMap    the map with the connection properties.
+/// \param conn_property_map    the map with the connection properties.
 /// \param property_name      the name of the property that will be looked up.
 /// \return                   the parsed valued.
-boost::optional<bool> AsBool(const Connection::ConnPropertyMap& connPropertyMap,
+boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
                              const std::string_view& property_name);
 
 /// Looks up for a value inside the ConnPropertyMap and then try to parse it.
 /// In case it does not find or it cannot parse, the default value will be returned.
 /// \param min_value                    the minimum value to be parsed, else the default
-/// value is returned. \param connPropertyMap              the map with the connection
+/// value is returned. \param conn_property_map              the map with the connection
 /// properties. \param property_name                the name of the property that will be
 /// looked up. \return                             the parsed valued. \exception
 /// std::invalid_argument    exception from std::stoi \exception
 /// std::out_of_range        exception from std::stoi
 boost::optional<int32_t> AsInt32(int32_t min_value,
-                                 const Connection::ConnPropertyMap& connPropertyMap,
+                                 const Connection::ConnPropertyMap& conn_property_map,
                                  const std::string_view& property_name);
 }  // namespace odbcabstraction
 }  // namespace driver

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
@@ -59,171 +59,171 @@ const boost::xpressive::sregex CONNECTION_STR_REGEX(
 // Public
 // =========================================================================================
 ODBCConnection::ODBCConnection(ODBCEnvironment& environment,
-                               std::shared_ptr<Connection> spiConnection)
+                               std::shared_ptr<Connection> spi_connection)
     : m_environment(environment),
-      m_spiConnection(std::move(spiConnection)),
-      m_is2xConnection(environment.getODBCVersion() == SQL_OV_ODBC2),
-      m_isConnected(false) {}
+      m_spi_connection(std::move(spi_connection)),
+      m_is_2x_connection(environment.GetODBCVersion() == SQL_OV_ODBC2),
+      m_is_connected(false) {}
 
-Diagnostics& ODBCConnection::GetDiagnostics_Impl() {
-  return m_spiConnection->GetDiagnostics();
+Diagnostics& ODBCConnection::GetDiagnosticsImpl() {
+  return m_spi_connection->GetDiagnostics();
 }
 
-bool ODBCConnection::isConnected() const { return m_isConnected; }
+bool ODBCConnection::IsConnected() const { return m_is_connected; }
 
 const std::string& ODBCConnection::GetDSN() const { return m_dsn; }
 
-void ODBCConnection::connect(std::string dsn,
+void ODBCConnection::Connect(std::string dsn,
                              const Connection::ConnPropertyMap& properties,
                              std::vector<std::string_view>& missing_properties) {
-  if (m_isConnected) {
+  if (m_is_connected) {
     throw DriverException("Already connected.", "HY010");
   }
 
   m_dsn = std::move(dsn);
-  m_spiConnection->Connect(properties, missing_properties);
-  m_isConnected = true;
-  std::shared_ptr<Statement> spiStatement = m_spiConnection->CreateStatement();
-  m_attributeTrackingStatement = std::make_shared<ODBCStatement>(*this, spiStatement);
+  m_spi_connection->Connect(properties, missing_properties);
+  m_is_connected = true;
+  std::shared_ptr<Statement> spi_statement = m_spi_connection->CreateStatement();
+  m_attribute_tracking_statement = std::make_shared<ODBCStatement>(*this, spi_statement);
 }
 
-SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
-                                  SQLSMALLINT bufferLength, SQLSMALLINT* outputLength,
-                                  bool isUnicode) {
-  switch (infoType) {
+SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT info_type, SQLPOINTER value,
+                                  SQLSMALLINT buffer_length, SQLSMALLINT* output_length,
+                                  bool is_unicode) {
+  switch (info_type) {
     case SQL_ACTIVE_ENVIRONMENTS:
-      GetAttribute(static_cast<SQLUSMALLINT>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUSMALLINT>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
 #ifdef SQL_ASYNC_DBC_FUNCTIONS
     case SQL_ASYNC_DBC_FUNCTIONS:
       GetAttribute(static_cast<SQLUINTEGER>(SQL_ASYNC_DBC_NOT_CAPABLE), value,
-                   bufferLength, outputLength);
+                   buffer_length, output_length);
       return SQL_SUCCESS;
 #endif
     case SQL_ASYNC_MODE:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_AM_NONE), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_AM_NONE), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
 #ifdef SQL_ASYNC_NOTIFICATION
     case SQL_ASYNC_NOTIFICATION:
       GetAttribute(static_cast<SQLUINTEGER>(SQL_ASYNC_NOTIFICATION_NOT_CAPABLE), value,
-                   bufferLength, outputLength);
+                   buffer_length, output_length);
       return SQL_SUCCESS;
 #endif
     case SQL_BATCH_ROW_COUNT:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_BATCH_SUPPORT:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_DATA_SOURCE_NAME:
-      return GetStringAttribute(isUnicode, m_dsn, true, value, bufferLength, outputLength,
-                                GetDiagnostics());
+      return GetStringAttribute(is_unicode, m_dsn, true, value, buffer_length,
+                                output_length, GetDiagnostics());
     case SQL_DRIVER_ODBC_VER:
-      return GetStringAttribute(isUnicode, "03.80", true, value, bufferLength,
-                                outputLength, GetDiagnostics());
+      return GetStringAttribute(is_unicode, "03.80", true, value, buffer_length,
+                                output_length, GetDiagnostics());
     case SQL_DYNAMIC_CURSOR_ATTRIBUTES1:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_DYNAMIC_CURSOR_ATTRIBUTES2:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_CA1_NEXT), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_CA1_NEXT), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2:
       GetAttribute(static_cast<SQLUINTEGER>(SQL_CA2_READ_ONLY_CONCURRENCY), value,
-                   bufferLength, outputLength);
+                   buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_FILE_USAGE:
-      GetAttribute(static_cast<SQLUSMALLINT>(SQL_FILE_NOT_SUPPORTED), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUSMALLINT>(SQL_FILE_NOT_SUPPORTED), value,
+                   buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_KEYSET_CURSOR_ATTRIBUTES1:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_KEYSET_CURSOR_ATTRIBUTES2:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_MAX_ASYNC_CONCURRENT_STATEMENTS:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_ODBC_INTERFACE_CONFORMANCE:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_OIC_CORE), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_OIC_CORE), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     // case SQL_ODBC_STANDARD_CLI_CONFORMANCE: - mentioned in SQLGetInfo spec with no
     // description and there is no constant for this.
     case SQL_PARAM_ARRAY_ROW_COUNTS:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_PARC_NO_BATCH), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_PARC_NO_BATCH), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_PARAM_ARRAY_SELECTS:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_PAS_NO_SELECT), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_PAS_NO_SELECT), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_ROW_UPDATES:
-      return GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
-                                GetDiagnostics());
+      return GetStringAttribute(is_unicode, "N", true, value, buffer_length,
+                                output_length, GetDiagnostics());
     case SQL_SCROLL_OPTIONS:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_SO_FORWARD_ONLY), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_SO_FORWARD_ONLY), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_STATIC_CURSOR_ATTRIBUTES1:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_STATIC_CURSOR_ATTRIBUTES2:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_BOOKMARK_PERSISTENCE:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_DESCRIBE_PARAMETER:
-      return GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
-                                GetDiagnostics());
+      return GetStringAttribute(is_unicode, "N", true, value, buffer_length,
+                                output_length, GetDiagnostics());
     case SQL_MULT_RESULT_SETS:
-      return GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
-                                GetDiagnostics());
+      return GetStringAttribute(is_unicode, "N", true, value, buffer_length,
+                                output_length, GetDiagnostics());
     case SQL_MULTIPLE_ACTIVE_TXN:
-      return GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
-                                GetDiagnostics());
+      return GetStringAttribute(is_unicode, "N", true, value, buffer_length,
+                                output_length, GetDiagnostics());
     case SQL_NEED_LONG_DATA_LEN:
-      return GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
-                                GetDiagnostics());
+      return GetStringAttribute(is_unicode, "N", true, value, buffer_length,
+                                output_length, GetDiagnostics());
     case SQL_TXN_CAPABLE:
-      GetAttribute(static_cast<SQLUSMALLINT>(SQL_TC_NONE), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUSMALLINT>(SQL_TC_NONE), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_TXN_ISOLATION_OPTION:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_TABLE_TERM:
-      return GetStringAttribute(isUnicode, "table", true, value, bufferLength,
-                                outputLength, GetDiagnostics());
+      return GetStringAttribute(is_unicode, "table", true, value, buffer_length,
+                                output_length, GetDiagnostics());
     // Deprecated ODBC 2.x fields required for backwards compatibility.
     case SQL_ODBC_API_CONFORMANCE:
-      GetAttribute(static_cast<SQLUSMALLINT>(SQL_OAC_LEVEL1), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUSMALLINT>(SQL_OAC_LEVEL1), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_FETCH_DIRECTION:
-      GetAttribute(static_cast<SQLINTEGER>(SQL_FETCH_NEXT), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(SQL_FETCH_NEXT), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_LOCK_TYPES:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_POS_OPERATIONS:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_POSITIONED_STATEMENTS:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_SCROLL_CONCURRENCY:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_STATIC_SENSITIVITY:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
 
     // Driver-level string properties.
@@ -257,10 +257,10 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
     case SQL_PROCEDURES:
     case SQL_SPECIAL_CHARACTERS:
     case SQL_XOPEN_CLI_YEAR: {
-      const auto& info = m_spiConnection->GetInfo(infoType);
-      const std::string& infoValue = boost::get<std::string>(info);
-      return GetStringAttribute(isUnicode, infoValue, true, value, bufferLength,
-                                outputLength, GetDiagnostics());
+      const auto& info = m_spi_connection->GetInfo(info_type);
+      const std::string& info_value = boost::get<std::string>(info);
+      return GetStringAttribute(is_unicode, info_value, true, value, buffer_length,
+                                output_length, GetDiagnostics());
     }
 
     // Driver-level 32-bit integer properties.
@@ -347,9 +347,9 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
     case SQL_SQL92_STRING_FUNCTIONS:
     case SQL_SQL92_VALUE_EXPRESSIONS:
     case SQL_STANDARD_CLI_CONFORMANCE: {
-      const auto& info = m_spiConnection->GetInfo(infoType);
-      uint32_t infoValue = boost::get<uint32_t>(info);
-      GetAttribute(infoValue, value, bufferLength, outputLength);
+      const auto& info = m_spi_connection->GetInfo(info_type);
+      uint32_t info_value = boost::get<uint32_t>(info);
+      GetAttribute(info_value, value, buffer_length, output_length);
       return SQL_SUCCESS;
     }
 
@@ -382,24 +382,24 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
     case SQL_MAX_USER_NAME_LEN:
     case SQL_ODBC_SQL_CONFORMANCE:
     case SQL_ODBC_SAG_CLI_CONFORMANCE: {
-      const auto& info = m_spiConnection->GetInfo(infoType);
-      uint16_t infoValue = boost::get<uint16_t>(info);
-      GetAttribute(infoValue, value, bufferLength, outputLength);
+      const auto& info = m_spi_connection->GetInfo(info_type);
+      uint16_t info_value = boost::get<uint16_t>(info);
+      GetAttribute(info_value, value, buffer_length, output_length);
       return SQL_SUCCESS;
     }
 
     // Special case - SQL_DATABASE_NAME is an alias for SQL_ATTR_CURRENT_CATALOG.
     case SQL_DATABASE_NAME: {
-      const auto& attr = m_spiConnection->GetAttribute(Connection::CURRENT_CATALOG);
+      const auto& attr = m_spi_connection->GetAttribute(Connection::CURRENT_CATALOG);
       if (!attr) {
         throw DriverException("Optional feature not supported.", "HYC00");
       }
-      const std::string& infoValue = boost::get<std::string>(*attr);
-      return GetStringAttribute(isUnicode, infoValue, true, value, bufferLength,
-                                outputLength, GetDiagnostics());
+      const std::string& info_value = boost::get<std::string>(*attr);
+      return GetStringAttribute(is_unicode, info_value, true, value, buffer_length,
+                                output_length, GetDiagnostics());
     }
     default:
-      throw DriverException("Unknown SQLGetInfo type: " + std::to_string(infoType),
+      throw DriverException("Unknown SQLGetInfo type: " + std::to_string(info_type),
                             "HY096");
   }
 
@@ -407,8 +407,8 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
 }
 
 void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
-                                    SQLINTEGER stringLength, bool isUnicode) {
-  uint32_t attributeToWrite = 0;
+                                    SQLINTEGER string_length, bool is_unicode) {
+  uint32_t attribute_to_write = 0;
   bool successfully_written = false;
   switch (attribute) {
     // Internal connection attributes
@@ -460,12 +460,12 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
     // ODBCAbstraction-level attributes
     case SQL_ATTR_CURRENT_CATALOG: {
       std::string catalog;
-      if (isUnicode) {
-        SetAttributeUTF8(value, stringLength, catalog);
+      if (is_unicode) {
+        SetAttributeUTF8(value, string_length, catalog);
       } else {
-        SetAttributeSQLWCHAR(value, stringLength, catalog);
+        SetAttributeSQLWCHAR(value, string_length, catalog);
       }
-      if (!m_spiConnection->SetAttribute(Connection::CURRENT_CATALOG, catalog)) {
+      if (!m_spi_connection->SetAttribute(Connection::CURRENT_CATALOG, catalog)) {
         throw DriverException("Option value changed.", "01S02");
       }
       return;
@@ -488,29 +488,29 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
     case SQL_ATTR_ROW_BIND_TYPE:
     case SQL_ATTR_SIMULATE_CURSOR:
     case SQL_ATTR_USE_BOOKMARKS:
-      m_attributeTrackingStatement->SetStmtAttr(attribute, value, stringLength,
-                                                isUnicode);
+      m_attribute_tracking_statement->SetStmtAttr(attribute, value, string_length,
+                                                  is_unicode);
       return;
 
     case SQL_ATTR_ACCESS_MODE:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiConnection->SetAttribute(Connection::ACCESS_MODE, attributeToWrite);
+          m_spi_connection->SetAttribute(Connection::ACCESS_MODE, attribute_to_write);
       break;
     case SQL_ATTR_CONNECTION_TIMEOUT:
-      SetAttribute(value, attributeToWrite);
-      successfully_written =
-          m_spiConnection->SetAttribute(Connection::CONNECTION_TIMEOUT, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
+      successfully_written = m_spi_connection->SetAttribute(
+          Connection::CONNECTION_TIMEOUT, attribute_to_write);
       break;
     case SQL_ATTR_LOGIN_TIMEOUT:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiConnection->SetAttribute(Connection::LOGIN_TIMEOUT, attributeToWrite);
+          m_spi_connection->SetAttribute(Connection::LOGIN_TIMEOUT, attribute_to_write);
       break;
     case SQL_ATTR_PACKET_SIZE:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiConnection->SetAttribute(Connection::PACKET_SIZE, attributeToWrite);
+          m_spi_connection->SetAttribute(Connection::PACKET_SIZE, attribute_to_write);
       break;
     default:
       throw DriverException("Invalid attribute: " + std::to_string(attribute), "HY092");
@@ -523,57 +523,57 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
 }
 
 SQLRETURN ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
-                                         SQLINTEGER bufferLength,
-                                         SQLINTEGER* outputLength, bool isUnicode) {
+                                         SQLINTEGER buffer_length,
+                                         SQLINTEGER* output_length, bool is_unicode) {
   using driver::odbcabstraction::Connection;
-  boost::optional<Connection::Attribute> spiAttribute;
+  boost::optional<Connection::Attribute> spi_attribute;
 
   switch (attribute) {
     // Internal connection attributes
 #ifdef SQL_ATTR_ASYNC_DBC_EVENT
     case SQL_ATTR_ASYNC_DBC_EVENT:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return SQL_SUCCESS;
 #endif
 #ifdef SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE
     case SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE:
       GetAttribute(static_cast<SQLUINTEGER>(SQL_ASYNC_DBC_ENABLE_OFF), value,
-                   bufferLength, outputLength);
+                   buffer_length, output_length);
       return SQL_SUCCESS;
 #endif
 #ifdef SQL_ATTR_ASYNC_DBC_PCALLBACK
     case SQL_ATTR_ASYNC_DBC_PCALLBACK:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return SQL_SUCCESS;
 #endif
 #ifdef SQL_ATTR_ASYNC_DBC_PCONTEXT
     case SQL_ATTR_ASYNC_DBC_PCONTEXT:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return SQL_SUCCESS;
 #endif
     case SQL_ATTR_ASYNC_ENABLE:
-      GetAttribute(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_ATTR_AUTO_IPD:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_FALSE), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_FALSE), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
     case SQL_ATTR_AUTOCOMMIT:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_AUTOCOMMIT_ON), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_AUTOCOMMIT_ON), value, buffer_length,
+                   output_length);
       return SQL_SUCCESS;
 #ifdef SQL_ATTR_DBC_INFO_TOKEN
     case SQL_ATTR_DBC_INFO_TOKEN:
       throw DriverException("Cannot read set-only attribute", "HY092");
 #endif
     case SQL_ATTR_ENLIST_IN_DTC:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_ATTR_ODBC_CURSORS:  // DM-only.
       throw DriverException("Invalid attribute", "HY092");
     case SQL_ATTR_QUIET_MODE:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_ATTR_TRACE:  // DM-only
       throw DriverException("Invalid attribute", "HY092");
@@ -588,70 +588,70 @@ SQLRETURN ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
 
     // ODBCAbstraction-level connection attributes.
     case SQL_ATTR_CURRENT_CATALOG: {
-      const auto& catalog = m_spiConnection->GetAttribute(Connection::CURRENT_CATALOG);
+      const auto& catalog = m_spi_connection->GetAttribute(Connection::CURRENT_CATALOG);
       if (!catalog) {
         throw DriverException("Optional feature not supported.", "HYC00");
       }
-      const std::string& infoValue = boost::get<std::string>(*catalog);
-      return GetStringAttribute(isUnicode, infoValue, true, value, bufferLength,
-                                outputLength, GetDiagnostics());
+      const std::string& info_value = boost::get<std::string>(*catalog);
+      return GetStringAttribute(is_unicode, info_value, true, value, buffer_length,
+                                output_length, GetDiagnostics());
     }
 
     // These all are uint32_t attributes.
     case SQL_ATTR_ACCESS_MODE:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::ACCESS_MODE);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::ACCESS_MODE);
       break;
     case SQL_ATTR_CONNECTION_DEAD:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::CONNECTION_DEAD);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::CONNECTION_DEAD);
       break;
     case SQL_ATTR_CONNECTION_TIMEOUT:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::CONNECTION_TIMEOUT);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::CONNECTION_TIMEOUT);
       break;
     case SQL_ATTR_LOGIN_TIMEOUT:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::LOGIN_TIMEOUT);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::LOGIN_TIMEOUT);
       break;
     case SQL_ATTR_PACKET_SIZE:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::PACKET_SIZE);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::PACKET_SIZE);
       break;
     default:
       throw DriverException("Invalid attribute", "HY092");
   }
 
-  if (!spiAttribute) {
+  if (!spi_attribute) {
     throw DriverException("Invalid attribute", "HY092");
   }
 
-  GetAttribute(static_cast<SQLUINTEGER>(boost::get<uint32_t>(*spiAttribute)), value,
-               bufferLength, outputLength);
+  GetAttribute(static_cast<SQLUINTEGER>(boost::get<uint32_t>(*spi_attribute)), value,
+               buffer_length, output_length);
   return SQL_SUCCESS;
 }
 
-void ODBCConnection::disconnect() {
-  if (m_isConnected) {
+void ODBCConnection::Disconnect() {
+  if (m_is_connected) {
     // Ensure that all statements (and corresponding SPI statements) get cleaned
     // up before terminating the SPI connection in case they need to be de-allocated in
     // the reverse of the allocation order.
     m_statements.clear();
-    m_spiConnection->Close();
-    m_isConnected = false;
+    m_spi_connection->Close();
+    m_is_connected = false;
   }
 }
 
-void ODBCConnection::releaseConnection() {
-  disconnect();
+void ODBCConnection::ReleaseConnection() {
+  Disconnect();
   m_environment.DropConnection(this);
 }
 
-std::shared_ptr<ODBCStatement> ODBCConnection::createStatement() {
-  std::shared_ptr<Statement> spiStatement = m_spiConnection->CreateStatement();
+std::shared_ptr<ODBCStatement> ODBCConnection::CreateStatement() {
+  std::shared_ptr<Statement> spi_statement = m_spi_connection->CreateStatement();
   std::shared_ptr<ODBCStatement> statement =
-      std::make_shared<ODBCStatement>(*this, spiStatement);
+      std::make_shared<ODBCStatement>(*this, spi_statement);
   m_statements.push_back(statement);
   statement->CopyAttributesFromConnection(*this);
   return statement;
 }
 
-void ODBCConnection::dropStatement(ODBCStatement* stmt) {
+void ODBCConnection::DropStatement(ODBCStatement* stmt) {
   auto it = std::find_if(m_statements.begin(), m_statements.end(),
                          [&stmt](const std::shared_ptr<ODBCStatement>& statement) {
                            return statement.get() == stmt;
@@ -661,14 +661,14 @@ void ODBCConnection::dropStatement(ODBCStatement* stmt) {
   }
 }
 
-std::shared_ptr<ODBCDescriptor> ODBCConnection::createDescriptor() {
+std::shared_ptr<ODBCDescriptor> ODBCConnection::CreateDescriptor() {
   std::shared_ptr<ODBCDescriptor> desc = std::make_shared<ODBCDescriptor>(
-      m_spiConnection->GetDiagnostics(), this, nullptr, true, true, false);
+      m_spi_connection->GetDiagnostics(), this, nullptr, true, true, false);
   m_descriptors.push_back(desc);
   return desc;
 }
 
-void ODBCConnection::dropDescriptor(ODBCDescriptor* desc) {
+void ODBCConnection::DropDescriptor(ODBCDescriptor* desc) {
   auto it = std::find_if(m_descriptors.begin(), m_descriptors.end(),
                          [&desc](const std::shared_ptr<ODBCDescriptor>& descriptor) {
                            return descriptor.get() == desc;
@@ -680,9 +680,9 @@ void ODBCConnection::dropDescriptor(ODBCDescriptor* desc) {
 
 // Public Static
 // ===================================================================================
-std::string ODBCConnection::getDsnIfExists(const std::string& connStr) {
+std::string ODBCConnection::GetDsnIfExists(const std::string& conn_str) {
   const int groups[] = {1, 2};  // CONNECTION_STR_REGEX has two groups. key: 1, value: 2
-  boost::xpressive::sregex_token_iterator regex_iter(connStr.begin(), connStr.end(),
+  boost::xpressive::sregex_token_iterator regex_iter(conn_str.begin(), conn_str.end(),
                                                      CONNECTION_STR_REGEX, groups),
       end;
 
@@ -706,10 +706,10 @@ std::string ODBCConnection::getDsnIfExists(const std::string& connStr) {
   }
 }
 
-void ODBCConnection::getPropertiesFromConnString(
-    const std::string& connStr, Connection::ConnPropertyMap& properties) {
+void ODBCConnection::GetPropertiesFromConnString(
+    const std::string& conn_str, Connection::ConnPropertyMap& properties) {
   const int groups[] = {1, 2};  // CONNECTION_STR_REGEX has two groups. key: 1, value: 2
-  boost::xpressive::sregex_token_iterator regex_iter(connStr.begin(), connStr.end(),
+  boost::xpressive::sregex_token_iterator regex_iter(conn_str.begin(), conn_str.end(),
                                                      CONNECTION_STR_REGEX, groups),
       end;
 

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
@@ -42,7 +42,7 @@ SQLSMALLINT CalculateHighestBoundRecord(const std::vector<DescriptorRecord>& rec
   // Most applications will bind every column, so optimistically assume that we'll
   // find the next bound record fastest by counting backwards.
   for (size_t i = records.size(); i > 0; --i) {
-    if (records[i - 1].m_isBound) {
+    if (records[i - 1].m_is_bound) {
       return i;
     }
   }
@@ -52,76 +52,77 @@ SQLSMALLINT CalculateHighestBoundRecord(const std::vector<DescriptorRecord>& rec
 
 // Public
 // =========================================================================================
-ODBCDescriptor::ODBCDescriptor(Diagnostics& baseDiagnostics, ODBCConnection* conn,
-                               ODBCStatement* stmt, bool isAppDescriptor, bool isWritable,
-                               bool is2xConnection)
-    : m_diagnostics(baseDiagnostics.GetVendor(), baseDiagnostics.GetDataSourceComponent(),
+ODBCDescriptor::ODBCDescriptor(Diagnostics& base_diagnostics, ODBCConnection* conn,
+                               ODBCStatement* stmt, bool is_app_descriptor,
+                               bool is_writable, bool is_2x_connection)
+    : m_diagnostics(base_diagnostics.GetVendor(),
+                    base_diagnostics.GetDataSourceComponent(),
                     driver::odbcabstraction::V_3),
-      m_owningConnection(conn),
-      m_parentStatement(stmt),
-      m_arrayStatusPtr(nullptr),
-      m_bindOffsetPtr(nullptr),
-      m_rowsProccessedPtr(nullptr),
-      m_arraySize(1),
-      m_bindType(SQL_BIND_BY_COLUMN),
-      m_highestOneBasedBoundRecord(0),
-      m_is2xConnection(is2xConnection),
-      m_isAppDescriptor(isAppDescriptor),
-      m_isWritable(isWritable),
-      m_hasBindingsChanged(true) {}
+      m_owning_connection(conn),
+      m_parent_statement(stmt),
+      m_array_status_ptr(nullptr),
+      m_bind_offset_ptr(nullptr),
+      m_rows_proccessed_ptr(nullptr),
+      m_array_size(1),
+      m_bind_type(SQL_BIND_BY_COLUMN),
+      m_highest_one_based_bound_record(0),
+      m_is_2x_connection(is_2x_connection),
+      m_is_app_descriptor(is_app_descriptor),
+      m_is_writable(is_writable),
+      m_has_bindings_changed(true) {}
 
-Diagnostics& ODBCDescriptor::GetDiagnostics_Impl() { return m_diagnostics; }
+Diagnostics& ODBCDescriptor::GetDiagnosticsImpl() { return m_diagnostics; }
 
 ODBCConnection& ODBCDescriptor::GetConnection() {
-  if (m_owningConnection) {
-    return *m_owningConnection;
+  if (m_owning_connection) {
+    return *m_owning_connection;
   }
-  assert(m_parentStatement);
-  return m_parentStatement->GetConnection();
+  assert(m_parent_statement);
+  return m_parent_statement->GetConnection();
 }
 
-void ODBCDescriptor::SetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                                    SQLINTEGER bufferLength) {
+void ODBCDescriptor::SetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
+                                    SQLINTEGER buffer_length) {
   // Only these two fields can be set on the IRD.
-  if (!m_isWritable && fieldIdentifier != SQL_DESC_ARRAY_STATUS_PTR &&
-      fieldIdentifier != SQL_DESC_ROWS_PROCESSED_PTR) {
+  if (!m_is_writable && field_identifier != SQL_DESC_ARRAY_STATUS_PTR &&
+      field_identifier != SQL_DESC_ROWS_PROCESSED_PTR) {
     throw DriverException("Cannot modify read-only descriptor", "HY016");
   }
 
-  switch (fieldIdentifier) {
+  switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE:
       throw DriverException("Invalid descriptor field", "HY091");
     case SQL_DESC_ARRAY_SIZE:
-      SetAttribute(value, m_arraySize);
-      m_hasBindingsChanged = true;
+      SetAttribute(value, m_array_size);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_ARRAY_STATUS_PTR:
-      SetPointerAttribute(value, m_arrayStatusPtr);
-      m_hasBindingsChanged = true;
+      SetPointerAttribute(value, m_array_status_ptr);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_BIND_OFFSET_PTR:
-      SetPointerAttribute(value, m_bindOffsetPtr);
-      m_hasBindingsChanged = true;
+      SetPointerAttribute(value, m_bind_offset_ptr);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_BIND_TYPE:
-      SetAttribute(value, m_bindType);
-      m_hasBindingsChanged = true;
+      SetAttribute(value, m_bind_type);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_ROWS_PROCESSED_PTR:
-      SetPointerAttribute(value, m_rowsProccessedPtr);
-      m_hasBindingsChanged = true;
+      SetPointerAttribute(value, m_rows_proccessed_ptr);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_COUNT: {
-      SQLSMALLINT newCount;
-      SetAttribute(value, newCount);
-      m_records.resize(newCount);
+      SQLSMALLINT new_count;
+      SetAttribute(value, new_count);
+      m_records.resize(new_count);
 
-      if (m_isAppDescriptor && newCount <= m_highestOneBasedBoundRecord) {
-        m_highestOneBasedBoundRecord = CalculateHighestBoundRecord(m_records);
+      if (m_is_app_descriptor && new_count <= m_highest_one_based_bound_record) {
+        m_highest_one_based_bound_record = CalculateHighestBoundRecord(m_records);
       } else {
-        m_highestOneBasedBoundRecord = newCount;
+        m_highest_one_based_bound_record = new_count;
       }
-      m_hasBindingsChanged = true;
+      m_has_bindings_changed = true;
       break;
     }
     default:
@@ -129,14 +130,14 @@ void ODBCDescriptor::SetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER valu
   }
 }
 
-void ODBCDescriptor::SetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentifier,
-                              SQLPOINTER value, SQLINTEGER bufferLength) {
-  if (!m_isWritable) {
+void ODBCDescriptor::SetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier,
+                              SQLPOINTER value, SQLINTEGER buffer_length) {
+  if (!m_is_writable) {
     throw DriverException("Cannot modify read-only descriptor", "HY016");
   }
 
   // Handle header fields before validating the record number.
-  switch (fieldIdentifier) {
+  switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE:
     case SQL_DESC_ARRAY_SIZE:
     case SQL_DESC_ARRAY_STATUS_PTR:
@@ -144,23 +145,23 @@ void ODBCDescriptor::SetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentif
     case SQL_DESC_BIND_TYPE:
     case SQL_DESC_ROWS_PROCESSED_PTR:
     case SQL_DESC_COUNT:
-      SetHeaderField(fieldIdentifier, value, bufferLength);
+      SetHeaderField(field_identifier, value, buffer_length);
       return;
     default:
       break;
   }
 
-  if (recordNumber == 0) {
+  if (record_number == 0) {
     throw DriverException("Bookmarks are unsupported.", "07009");
   }
 
-  if (recordNumber > m_records.size()) {
+  if (record_number > m_records.size()) {
     throw DriverException("Invalid descriptor index", "HY009");
   }
 
-  SQLSMALLINT zeroBasedRecord = recordNumber - 1;
-  DescriptorRecord& record = m_records[zeroBasedRecord];
-  switch (fieldIdentifier) {
+  SQLSMALLINT zero_based_record = record_number - 1;
+  DescriptorRecord& record = m_records[zero_based_record];
+  switch (field_identifier) {
     case SQL_DESC_AUTO_UNIQUE_VALUE:
     case SQL_DESC_BASE_COLUMN_NAME:
     case SQL_DESC_BASE_TABLE_NAME:
@@ -184,100 +185,100 @@ void ODBCDescriptor::SetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentif
     case SQL_DESC_UPDATABLE:
       throw DriverException("Cannot modify read-only field.", "HY092");
     case SQL_DESC_CONCISE_TYPE:
-      SetAttribute(value, record.m_conciseType);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_concise_type);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_DATA_PTR:
-      SetDataPtrOnRecord(value, recordNumber);
+      SetDataPtrOnRecord(value, record_number);
       break;
     case SQL_DESC_DATETIME_INTERVAL_CODE:
-      SetAttribute(value, record.m_datetimeIntervalCode);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_datetime_interval_code);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_DATETIME_INTERVAL_PRECISION:
-      SetAttribute(value, record.m_datetimeIntervalPrecision);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_datetime_interval_precision);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_INDICATOR_PTR:
     case SQL_DESC_OCTET_LENGTH_PTR:
-      SetPointerAttribute(value, record.m_indicatorPtr);
-      m_hasBindingsChanged = true;
+      SetPointerAttribute(value, record.m_indicator_ptr);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_LENGTH:
       SetAttribute(value, record.m_length);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_NAME:
-      SetAttributeUTF8(value, bufferLength, record.m_name);
-      m_hasBindingsChanged = true;
+      SetAttributeUTF8(value, buffer_length, record.m_name);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_OCTET_LENGTH:
-      SetAttribute(value, record.m_octetLength);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_octet_length);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_PARAMETER_TYPE:
-      SetAttribute(value, record.m_paramType);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_param_type);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_PRECISION:
       SetAttribute(value, record.m_precision);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_SCALE:
       SetAttribute(value, record.m_scale);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_TYPE:
       SetAttribute(value, record.m_type);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     default:
       throw DriverException("Invalid descriptor field", "HY091");
   }
 }
 
-void ODBCDescriptor::GetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                                    SQLINTEGER bufferLength,
-                                    SQLINTEGER* outputLength) const {
-  switch (fieldIdentifier) {
+void ODBCDescriptor::GetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
+                                    SQLINTEGER buffer_length,
+                                    SQLINTEGER* output_length) const {
+  switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE: {
       SQLSMALLINT result;
-      if (m_owningConnection) {
+      if (m_owning_connection) {
         result = SQL_DESC_ALLOC_USER;
       } else {
         result = SQL_DESC_ALLOC_AUTO;
       }
-      GetAttribute(result, value, bufferLength, outputLength);
+      GetAttribute(result, value, buffer_length, output_length);
       break;
     }
     case SQL_DESC_ARRAY_SIZE:
-      GetAttribute(m_arraySize, value, bufferLength, outputLength);
+      GetAttribute(m_array_size, value, buffer_length, output_length);
       break;
     case SQL_DESC_ARRAY_STATUS_PTR:
-      GetAttribute(m_arrayStatusPtr, value, bufferLength, outputLength);
+      GetAttribute(m_array_status_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_BIND_OFFSET_PTR:
-      GetAttribute(m_bindOffsetPtr, value, bufferLength, outputLength);
+      GetAttribute(m_bind_offset_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_BIND_TYPE:
-      GetAttribute(m_bindType, value, bufferLength, outputLength);
+      GetAttribute(m_bind_type, value, buffer_length, output_length);
       break;
     case SQL_DESC_ROWS_PROCESSED_PTR:
-      GetAttribute(m_rowsProccessedPtr, value, bufferLength, outputLength);
+      GetAttribute(m_rows_proccessed_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_COUNT: {
-      // m_highestOneBasedBoundRecord equals number of records + 1
-      GetAttribute(static_cast<SQLSMALLINT>(m_highestOneBasedBoundRecord - 1), value,
-                   bufferLength, outputLength);
+      // m_highest_one_based_bound_record equals number of records + 1
+      GetAttribute(static_cast<SQLSMALLINT>(m_highest_one_based_bound_record - 1), value,
+                   buffer_length, output_length);
       break;
     }
     default:
@@ -285,11 +286,11 @@ void ODBCDescriptor::GetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER valu
   }
 }
 
-void ODBCDescriptor::GetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentifier,
-                              SQLPOINTER value, SQLINTEGER bufferLength,
-                              SQLINTEGER* outputLength) {
+void ODBCDescriptor::GetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier,
+                              SQLPOINTER value, SQLINTEGER buffer_length,
+                              SQLINTEGER* output_length) {
   // Handle header fields before validating the record number.
-  switch (fieldIdentifier) {
+  switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE:
     case SQL_DESC_ARRAY_SIZE:
     case SQL_DESC_ARRAY_STATUS_PTR:
@@ -297,230 +298,232 @@ void ODBCDescriptor::GetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentif
     case SQL_DESC_BIND_TYPE:
     case SQL_DESC_ROWS_PROCESSED_PTR:
     case SQL_DESC_COUNT:
-      GetHeaderField(fieldIdentifier, value, bufferLength, outputLength);
+      GetHeaderField(field_identifier, value, buffer_length, output_length);
       return;
     default:
       break;
   }
 
-  if (recordNumber == 0) {
+  if (record_number == 0) {
     throw DriverException("Bookmarks are unsupported.", "07009");
   }
 
-  if (recordNumber > m_records.size()) {
+  if (record_number > m_records.size()) {
     throw DriverException("Invalid descriptor index", "07009");
   }
 
   // TODO: Restrict fields based on AppDescriptor IPD, and IRD.
 
-  bool lengthInBytes = true;
-  SQLSMALLINT zeroBasedRecord = recordNumber - 1;
-  const DescriptorRecord& record = m_records[zeroBasedRecord];
-  switch (fieldIdentifier) {
+  bool length_in_bytes = true;
+  SQLSMALLINT zero_based_record = record_number - 1;
+  const DescriptorRecord& record = m_records[zero_based_record];
+  switch (field_identifier) {
     case SQL_DESC_BASE_COLUMN_NAME:
-      GetAttributeSQLWCHAR(record.m_baseColumnName, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_base_column_name, length_in_bytes, value,
+                           buffer_length, output_length, GetDiagnostics());
       break;
     case SQL_DESC_BASE_TABLE_NAME:
-      GetAttributeSQLWCHAR(record.m_baseTableName, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_base_table_name, length_in_bytes, value,
+                           buffer_length, output_length, GetDiagnostics());
       break;
     case SQL_DESC_CATALOG_NAME:
-      GetAttributeSQLWCHAR(record.m_catalogName, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_catalog_name, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_LABEL:
-      GetAttributeSQLWCHAR(record.m_label, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_label, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_LITERAL_PREFIX:
-      GetAttributeSQLWCHAR(record.m_literalPrefix, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_literal_prefix, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_LITERAL_SUFFIX:
-      GetAttributeSQLWCHAR(record.m_literalSuffix, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_literal_suffix, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_LOCAL_TYPE_NAME:
-      GetAttributeSQLWCHAR(record.m_localTypeName, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_local_type_name, length_in_bytes, value,
+                           buffer_length, output_length, GetDiagnostics());
       break;
     case SQL_DESC_NAME:
-      GetAttributeSQLWCHAR(record.m_name, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_name, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_SCHEMA_NAME:
-      GetAttributeSQLWCHAR(record.m_schemaName, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_schema_name, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_TABLE_NAME:
-      GetAttributeSQLWCHAR(record.m_tableName, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_table_name, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_TYPE_NAME:
-      GetAttributeSQLWCHAR(record.m_typeName, lengthInBytes, value, bufferLength,
-                           outputLength, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.m_type_name, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
 
     case SQL_DESC_DATA_PTR:
-      GetAttribute(record.m_dataPtr, value, bufferLength, outputLength);
+      GetAttribute(record.m_data_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_INDICATOR_PTR:
     case SQL_DESC_OCTET_LENGTH_PTR:
-      GetAttribute(record.m_indicatorPtr, value, bufferLength, outputLength);
+      GetAttribute(record.m_indicator_ptr, value, buffer_length, output_length);
       break;
     case SQL_COLUMN_LENGTH:  // ODBC 2.0
     case SQL_DESC_LENGTH:
-      GetAttribute(record.m_length, value, bufferLength, outputLength);
+      GetAttribute(record.m_length, value, buffer_length, output_length);
       break;
     case SQL_DESC_OCTET_LENGTH:
-      GetAttribute(record.m_octetLength, value, bufferLength, outputLength);
+      GetAttribute(record.m_octet_length, value, buffer_length, output_length);
       break;
 
     case SQL_DESC_AUTO_UNIQUE_VALUE:
-      GetAttribute(record.m_autoUniqueValue, value, bufferLength, outputLength);
+      GetAttribute(record.m_auto_unique_value, value, buffer_length, output_length);
       break;
     case SQL_DESC_CASE_SENSITIVE:
-      GetAttribute(record.m_caseSensitive, value, bufferLength, outputLength);
+      GetAttribute(record.m_case_sensitive, value, buffer_length, output_length);
       break;
     case SQL_DESC_DATETIME_INTERVAL_PRECISION:
-      GetAttribute(record.m_datetimeIntervalPrecision, value, bufferLength, outputLength);
+      GetAttribute(record.m_datetime_interval_precision, value, buffer_length,
+                   output_length);
       break;
     case SQL_DESC_NUM_PREC_RADIX:
-      GetAttribute(record.m_numPrecRadix, value, bufferLength, outputLength);
+      GetAttribute(record.m_num_prec_radix, value, buffer_length, output_length);
       break;
 
     case SQL_DESC_CONCISE_TYPE:
-      GetAttribute(record.m_conciseType, value, bufferLength, outputLength);
+      GetAttribute(record.m_concise_type, value, buffer_length, output_length);
       break;
     case SQL_DESC_DATETIME_INTERVAL_CODE:
-      GetAttribute(record.m_datetimeIntervalCode, value, bufferLength, outputLength);
+      GetAttribute(record.m_datetime_interval_code, value, buffer_length, output_length);
       break;
     case SQL_DESC_DISPLAY_SIZE:
-      GetAttribute(record.m_displaySize, value, bufferLength, outputLength);
+      GetAttribute(record.m_display_size, value, buffer_length, output_length);
       break;
     case SQL_DESC_FIXED_PREC_SCALE:
-      GetAttribute(record.m_fixedPrecScale, value, bufferLength, outputLength);
+      GetAttribute(record.m_fixed_prec_scale, value, buffer_length, output_length);
       break;
     case SQL_DESC_NULLABLE:
-      GetAttribute(record.m_nullable, value, bufferLength, outputLength);
+      GetAttribute(record.m_nullable, value, buffer_length, output_length);
       break;
     case SQL_DESC_PARAMETER_TYPE:
-      GetAttribute(record.m_paramType, value, bufferLength, outputLength);
+      GetAttribute(record.m_param_type, value, buffer_length, output_length);
       break;
     case SQL_COLUMN_PRECISION:  // ODBC 2.0
     case SQL_DESC_PRECISION:
-      GetAttribute(record.m_precision, value, bufferLength, outputLength);
+      GetAttribute(record.m_precision, value, buffer_length, output_length);
       break;
     case SQL_DESC_ROWVER:
-      GetAttribute(record.m_rowVer, value, bufferLength, outputLength);
+      GetAttribute(record.m_row_ver, value, buffer_length, output_length);
       break;
     case SQL_COLUMN_SCALE:  // ODBC 2.0
     case SQL_DESC_SCALE:
-      GetAttribute(record.m_scale, value, bufferLength, outputLength);
+      GetAttribute(record.m_scale, value, buffer_length, output_length);
       break;
     case SQL_DESC_SEARCHABLE:
-      GetAttribute(record.m_searchable, value, bufferLength, outputLength);
+      GetAttribute(record.m_searchable, value, buffer_length, output_length);
       break;
     case SQL_DESC_TYPE:
-      GetAttribute(record.m_type, value, bufferLength, outputLength);
+      GetAttribute(record.m_type, value, buffer_length, output_length);
       break;
     case SQL_DESC_UNNAMED:
-      GetAttribute(record.m_unnamed, value, bufferLength, outputLength);
+      GetAttribute(record.m_unnamed, value, buffer_length, output_length);
       break;
     case SQL_DESC_UNSIGNED:
-      GetAttribute(record.m_unsigned, value, bufferLength, outputLength);
+      GetAttribute(record.m_unsigned, value, buffer_length, output_length);
       break;
     case SQL_DESC_UPDATABLE:
-      GetAttribute(record.m_updatable, value, bufferLength, outputLength);
+      GetAttribute(record.m_updatable, value, buffer_length, output_length);
       break;
     default:
       throw DriverException("Invalid descriptor field", "HY091");
   }
 }
 
-SQLSMALLINT ODBCDescriptor::getAllocType() const {
-  return m_owningConnection != nullptr ? SQL_DESC_ALLOC_USER : SQL_DESC_ALLOC_AUTO;
+SQLSMALLINT ODBCDescriptor::GetAllocType() const {
+  return m_owning_connection != nullptr ? SQL_DESC_ALLOC_USER : SQL_DESC_ALLOC_AUTO;
 }
 
-bool ODBCDescriptor::IsAppDescriptor() const { return m_isAppDescriptor; }
+bool ODBCDescriptor::IsAppDescriptor() const { return m_is_app_descriptor; }
 
-void ODBCDescriptor::RegisterToStatement(ODBCStatement* statement, bool isApd) {
-  if (isApd) {
-    m_registeredOnStatementsAsApd.push_back(statement);
+void ODBCDescriptor::RegisterToStatement(ODBCStatement* statement, bool is_apd) {
+  if (is_apd) {
+    m_registered_on_statements_as_apd.push_back(statement);
   } else {
-    m_registeredOnStatementsAsArd.push_back(statement);
+    m_registered_on_statements_as_ard.push_back(statement);
   }
 }
 
-void ODBCDescriptor::DetachFromStatement(ODBCStatement* statement, bool isApd) {
-  auto& vectorToUpdate =
-      isApd ? m_registeredOnStatementsAsApd : m_registeredOnStatementsAsArd;
-  auto it = std::find(vectorToUpdate.begin(), vectorToUpdate.end(), statement);
-  if (it != vectorToUpdate.end()) {
-    vectorToUpdate.erase(it);
+void ODBCDescriptor::DetachFromStatement(ODBCStatement* statement, bool is_apd) {
+  auto& vector_to_update =
+      is_apd ? m_registered_on_statements_as_apd : m_registered_on_statements_as_ard;
+  auto it = std::find(vector_to_update.begin(), vector_to_update.end(), statement);
+  if (it != vector_to_update.end()) {
+    vector_to_update.erase(it);
   }
 }
 
 void ODBCDescriptor::ReleaseDescriptor() {
-  for (ODBCStatement* stmt : m_registeredOnStatementsAsApd) {
+  for (ODBCStatement* stmt : m_registered_on_statements_as_apd) {
     stmt->RevertAppDescriptor(true);
   }
 
-  for (ODBCStatement* stmt : m_registeredOnStatementsAsArd) {
+  for (ODBCStatement* stmt : m_registered_on_statements_as_ard) {
     stmt->RevertAppDescriptor(false);
   }
 
-  if (m_owningConnection) {
-    m_owningConnection->dropDescriptor(this);
+  if (m_owning_connection) {
+    m_owning_connection->DropDescriptor(this);
   }
 }
 
 void ODBCDescriptor::PopulateFromResultSetMetadata(ResultSetMetadata* rsmd) {
   m_records.assign(rsmd->GetColumnCount(), DescriptorRecord());
-  m_highestOneBasedBoundRecord = m_records.size() + 1;
+  m_highest_one_based_bound_record = m_records.size() + 1;
 
   for (size_t i = 0; i < m_records.size(); ++i) {
-    size_t oneBasedIndex = i + 1;
-    int16_t concise_type = rsmd->GetConciseType(oneBasedIndex);
+    size_t one_based_index = i + 1;
+    int16_t concise_type = rsmd->GetConciseType(one_based_index);
 
-    m_records[i].m_baseColumnName = rsmd->GetBaseColumnName(oneBasedIndex);
-    m_records[i].m_baseTableName = rsmd->GetBaseTableName(oneBasedIndex);
-    m_records[i].m_catalogName = rsmd->GetCatalogName(oneBasedIndex);
-    m_records[i].m_label = rsmd->GetColumnLabel(oneBasedIndex);
-    m_records[i].m_literalPrefix = rsmd->GetLiteralPrefix(oneBasedIndex);
-    m_records[i].m_literalSuffix = rsmd->GetLiteralSuffix(oneBasedIndex);
-    m_records[i].m_localTypeName = rsmd->GetLocalTypeName(oneBasedIndex);
-    m_records[i].m_name = rsmd->GetName(oneBasedIndex);
-    m_records[i].m_schemaName = rsmd->GetSchemaName(oneBasedIndex);
-    m_records[i].m_tableName = rsmd->GetTableName(oneBasedIndex);
-    m_records[i].m_typeName = rsmd->GetTypeName(oneBasedIndex, concise_type);
-    m_records[i].m_conciseType = GetSqlTypeForODBCVersion(concise_type, m_is2xConnection);
-    m_records[i].m_dataPtr = nullptr;
-    m_records[i].m_indicatorPtr = nullptr;
-    m_records[i].m_displaySize = rsmd->GetColumnDisplaySize(oneBasedIndex);
-    m_records[i].m_octetLength = rsmd->GetOctetLength(oneBasedIndex);
-    m_records[i].m_length = rsmd->GetLength(oneBasedIndex);
-    m_records[i].m_autoUniqueValue =
-        rsmd->IsAutoUnique(oneBasedIndex) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_caseSensitive =
-        rsmd->IsCaseSensitive(oneBasedIndex) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_datetimeIntervalPrecision;  // TODO - update when rsmd adds this
-    SQLINTEGER numPrecRadix = rsmd->GetNumPrecRadix(oneBasedIndex);
-    m_records[i].m_numPrecRadix = numPrecRadix > 0 ? numPrecRadix : 0;
-    m_records[i].m_datetimeIntervalCode;  // TODO
-    m_records[i].m_fixedPrecScale =
-        rsmd->IsFixedPrecScale(oneBasedIndex) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_nullable = rsmd->IsNullable(oneBasedIndex);
-    m_records[i].m_paramType = SQL_PARAM_INPUT;
-    m_records[i].m_precision = rsmd->GetPrecision(oneBasedIndex);
-    m_records[i].m_rowVer = SQL_FALSE;
-    m_records[i].m_scale = rsmd->GetScale(oneBasedIndex);
-    m_records[i].m_searchable = rsmd->IsSearchable(oneBasedIndex);
-    m_records[i].m_type = rsmd->GetDataType(oneBasedIndex);
+    m_records[i].m_base_column_name = rsmd->GetBaseColumnName(one_based_index);
+    m_records[i].m_base_table_name = rsmd->GetBaseTableName(one_based_index);
+    m_records[i].m_catalog_name = rsmd->GetCatalogName(one_based_index);
+    m_records[i].m_label = rsmd->GetColumnLabel(one_based_index);
+    m_records[i].m_literal_prefix = rsmd->GetLiteralPrefix(one_based_index);
+    m_records[i].m_literal_suffix = rsmd->GetLiteralSuffix(one_based_index);
+    m_records[i].m_local_type_name = rsmd->GetLocalTypeName(one_based_index);
+    m_records[i].m_name = rsmd->GetName(one_based_index);
+    m_records[i].m_schema_name = rsmd->GetSchemaName(one_based_index);
+    m_records[i].m_table_name = rsmd->GetTableName(one_based_index);
+    m_records[i].m_type_name = rsmd->GetTypeName(one_based_index, concise_type);
+    m_records[i].m_concise_type =
+        GetSqlTypeForODBCVersion(concise_type, m_is_2x_connection);
+    m_records[i].m_data_ptr = nullptr;
+    m_records[i].m_indicator_ptr = nullptr;
+    m_records[i].m_display_size = rsmd->GetColumnDisplaySize(one_based_index);
+    m_records[i].m_octet_length = rsmd->GetOctetLength(one_based_index);
+    m_records[i].m_length = rsmd->GetLength(one_based_index);
+    m_records[i].m_auto_unique_value =
+        rsmd->IsAutoUnique(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    m_records[i].m_case_sensitive =
+        rsmd->IsCaseSensitive(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    m_records[i].m_datetime_interval_precision;  // TODO - update when rsmd adds this
+    SQLINTEGER num_prec_radix = rsmd->GetNumPrecRadix(one_based_index);
+    m_records[i].m_num_prec_radix = num_prec_radix > 0 ? num_prec_radix : 0;
+    m_records[i].m_datetime_interval_code;  // TODO
+    m_records[i].m_fixed_prec_scale =
+        rsmd->IsFixedPrecScale(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    m_records[i].m_nullable = rsmd->IsNullable(one_based_index);
+    m_records[i].m_param_type = SQL_PARAM_INPUT;
+    m_records[i].m_precision = rsmd->GetPrecision(one_based_index);
+    m_records[i].m_row_ver = SQL_FALSE;
+    m_records[i].m_scale = rsmd->GetScale(one_based_index);
+    m_records[i].m_searchable = rsmd->IsSearchable(one_based_index);
+    m_records[i].m_type = rsmd->GetDataType(one_based_index);
     m_records[i].m_unnamed = m_records[i].m_name.empty() ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_unsigned = rsmd->IsUnsigned(oneBasedIndex) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_updatable = rsmd->GetUpdatable(oneBasedIndex);
+    m_records[i].m_unsigned = rsmd->IsUnsigned(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    m_records[i].m_updatable = rsmd->GetUpdatable(one_based_index);
   }
 }
 
@@ -530,50 +533,50 @@ const std::vector<DescriptorRecord>& ODBCDescriptor::GetRecords() const {
 
 std::vector<DescriptorRecord>& ODBCDescriptor::GetRecords() { return m_records; }
 
-void ODBCDescriptor::BindCol(SQLSMALLINT recordNumber, SQLSMALLINT cType,
-                             SQLPOINTER dataPtr, SQLLEN bufferLength,
-                             SQLLEN* indicatorPtr) {
-  assert(m_isAppDescriptor);
-  assert(m_isWritable);
+void ODBCDescriptor::BindCol(SQLSMALLINT record_number, SQLSMALLINT c_type,
+                             SQLPOINTER data_ptr, SQLLEN buffer_length,
+                             SQLLEN* indicator_ptr) {
+  assert(m_is_app_descriptor);
+  assert(m_is_writable);
 
   // The set of records auto-expands to the supplied record number.
-  if (m_records.size() < recordNumber) {
-    m_records.resize(recordNumber);
+  if (m_records.size() < record_number) {
+    m_records.resize(record_number);
   }
 
-  SQLSMALLINT zeroBasedRecordIndex = recordNumber - 1;
-  DescriptorRecord& record = m_records[zeroBasedRecordIndex];
+  SQLSMALLINT zero_based_record_index = record_number - 1;
+  DescriptorRecord& record = m_records[zero_based_record_index];
 
-  record.m_type = cType;
-  record.m_indicatorPtr = indicatorPtr;
-  record.m_length = bufferLength;
+  record.m_type = c_type;
+  record.m_indicator_ptr = indicator_ptr;
+  record.m_length = buffer_length;
 
   // Initialize default precision and scale for SQL_C_NUMERIC.
   if (record.m_type == SQL_C_NUMERIC) {
     record.m_precision = 38;
     record.m_scale = 0;
   }
-  SetDataPtrOnRecord(dataPtr, recordNumber);
+  SetDataPtrOnRecord(data_ptr, record_number);
 }
 
-void ODBCDescriptor::SetDataPtrOnRecord(SQLPOINTER dataPtr, SQLSMALLINT recordNumber) {
-  assert(recordNumber <= m_records.size());
-  DescriptorRecord& record = m_records[recordNumber - 1];
-  if (dataPtr) {
+void ODBCDescriptor::SetDataPtrOnRecord(SQLPOINTER data_ptr, SQLSMALLINT record_number) {
+  assert(record_number <= m_records.size());
+  DescriptorRecord& record = m_records[record_number - 1];
+  if (data_ptr) {
     record.CheckConsistency();
-    record.m_isBound = true;
+    record.m_is_bound = true;
   } else {
-    record.m_isBound = false;
+    record.m_is_bound = false;
   }
-  record.m_dataPtr = dataPtr;
+  record.m_data_ptr = data_ptr;
 
   // Bookkeeping on the highest bound record (used for returning SQL_DESC_COUNT)
-  if (m_highestOneBasedBoundRecord < recordNumber && dataPtr) {
-    m_highestOneBasedBoundRecord = recordNumber;
-  } else if (m_highestOneBasedBoundRecord == recordNumber && !dataPtr) {
-    m_highestOneBasedBoundRecord = CalculateHighestBoundRecord(m_records);
+  if (m_highest_one_based_bound_record < record_number && data_ptr) {
+    m_highest_one_based_bound_record = record_number;
+  } else if (m_highest_one_based_bound_record == record_number && !data_ptr) {
+    m_highest_one_based_bound_record = CalculateHighestBoundRecord(m_records);
   }
-  m_hasBindingsChanged = true;
+  m_has_bindings_changed = true;
 }
 
 void DescriptorRecord::CheckConsistency() {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_environment.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_environment.cc
@@ -41,13 +41,13 @@ ODBCEnvironment::ODBCEnvironment(std::shared_ptr<Driver> driver)
                                     m_driver->GetDiagnostics().GetDataSourceComponent(),
                                     driver::odbcabstraction::V_2)),
       m_version(SQL_OV_ODBC2),
-      m_connectionPooling(SQL_CP_OFF) {}
+      m_connection_pooling(SQL_CP_OFF) {}
 
-Diagnostics& ODBCEnvironment::GetDiagnostics_Impl() { return *m_diagnostics; }
+Diagnostics& ODBCEnvironment::GetDiagnosticsImpl() { return *m_diagnostics; }
 
-SQLINTEGER ODBCEnvironment::getODBCVersion() const { return m_version; }
+SQLINTEGER ODBCEnvironment::GetODBCVersion() const { return m_version; }
 
-void ODBCEnvironment::setODBCVersion(SQLINTEGER version) {
+void ODBCEnvironment::SetODBCVersion(SQLINTEGER version) {
   if (version != m_version) {
     m_version = version;
     m_diagnostics.reset(new Diagnostics(
@@ -57,20 +57,20 @@ void ODBCEnvironment::setODBCVersion(SQLINTEGER version) {
   }
 }
 
-SQLINTEGER ODBCEnvironment::getConnectionPooling() const { return m_connectionPooling; }
+SQLINTEGER ODBCEnvironment::GetConnectionPooling() const { return m_connection_pooling; }
 
-void ODBCEnvironment::setConnectionPooling(SQLINTEGER connectionPooling) {
-  m_connectionPooling = connectionPooling;
+void ODBCEnvironment::SetConnectionPooling(SQLINTEGER connection_pooling) {
+  m_connection_pooling = connection_pooling;
 }
 
 std::shared_ptr<ODBCConnection> ODBCEnvironment::CreateConnection() {
-  std::shared_ptr<Connection> spiConnection = m_driver->CreateConnection(
+  std::shared_ptr<Connection> spi_connection = m_driver->CreateConnection(
       m_version == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
                                 : driver::odbcabstraction::V_3);
-  std::shared_ptr<ODBCConnection> newConn =
-      std::make_shared<ODBCConnection>(*this, spiConnection);
-  m_connections.push_back(newConn);
-  return newConn;
+  std::shared_ptr<ODBCConnection> new_conn =
+      std::make_shared<ODBCConnection>(*this, spi_connection);
+  m_connections.push_back(new_conn);
+  return new_conn;
 }
 
 void ODBCEnvironment::DropConnection(ODBCConnection* conn) {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
@@ -44,13 +44,13 @@ using driver::odbcabstraction::Statement;
 
 namespace {
 void DescriptorToHandle(SQLPOINTER output, ODBCDescriptor* descriptor,
-                        SQLINTEGER* lenPtr) {
+                        SQLINTEGER* len_ptr) {
   if (output) {
-    SQLHANDLE* outputHandle = static_cast<SQLHANDLE*>(output);
-    *outputHandle = reinterpret_cast<SQLHANDLE>(descriptor);
+    SQLHANDLE* output_handle = static_cast<SQLHANDLE*>(output);
+    *output_handle = reinterpret_cast<SQLHANDLE>(descriptor);
   }
-  if (lenPtr) {
-    *lenPtr = sizeof(SQLHANDLE);
+  if (len_ptr) {
+    *len_ptr = sizeof(SQLHANDLE);
   }
 }
 
@@ -117,8 +117,8 @@ size_t GetLength(const DescriptorRecord& record) {
   }
 }
 
-SQLSMALLINT getCTypeForSQLType(const DescriptorRecord& record) {
-  switch (record.m_conciseType) {
+SQLSMALLINT getc_typeForSQLType(const DescriptorRecord& record) {
+  switch (record.m_concise_type) {
     case SQL_CHAR:
     case SQL_VARCHAR:
     case SQL_LONGVARCHAR:
@@ -203,16 +203,16 @@ SQLSMALLINT getCTypeForSQLType(const DescriptorRecord& record) {
       return SQL_C_INTERVAL_MONTH;
 
     default:
-      throw DriverException("Unknown SQL type: " + std::to_string(record.m_conciseType),
+      throw DriverException("Unknown SQL type: " + std::to_string(record.m_concise_type),
                             "HY003");
   }
 }
 
 void CopyAttribute(Statement& source, Statement& target,
-                   Statement::StatementAttributeId attributeId) {
-  auto optionalValue = source.GetAttribute(attributeId);
-  if (optionalValue) {
-    target.SetAttribute(attributeId, *optionalValue);
+                   Statement::StatementAttributeId attribute_id) {
+  auto optional_value = source.GetAttribute(attribute_id);
+  if (optional_value) {
+    target.SetAttribute(attribute_id, *optional_value);
   }
 }
 }  // namespace
@@ -221,36 +221,36 @@ void CopyAttribute(Statement& source, Statement& target,
 // =========================================================================================
 ODBCStatement::ODBCStatement(
     ODBCConnection& connection,
-    std::shared_ptr<driver::odbcabstraction::Statement> spiStatement)
+    std::shared_ptr<driver::odbcabstraction::Statement> spi_statement)
     : m_connection(connection),
-      m_spiStatement(std::move(spiStatement)),
-      m_diagnostics(&m_spiStatement->GetDiagnostics()),
-      m_builtInArd(std::make_shared<ODBCDescriptor>(m_spiStatement->GetDiagnostics(),
-                                                    nullptr, this, true, true,
-                                                    connection.IsOdbc2Connection())),
-      m_builtInApd(std::make_shared<ODBCDescriptor>(m_spiStatement->GetDiagnostics(),
-                                                    nullptr, this, true, true,
-                                                    connection.IsOdbc2Connection())),
-      m_ipd(std::make_shared<ODBCDescriptor>(m_spiStatement->GetDiagnostics(), nullptr,
+      m_spi_statement(std::move(spi_statement)),
+      m_diagnostics(&m_spi_statement->GetDiagnostics()),
+      m_built_in_ard(std::make_shared<ODBCDescriptor>(m_spi_statement->GetDiagnostics(),
+                                                      nullptr, this, true, true,
+                                                      connection.IsOdbc2Connection())),
+      m_built_in_apd(std::make_shared<ODBCDescriptor>(m_spi_statement->GetDiagnostics(),
+                                                      nullptr, this, true, true,
+                                                      connection.IsOdbc2Connection())),
+      m_ipd(std::make_shared<ODBCDescriptor>(m_spi_statement->GetDiagnostics(), nullptr,
                                              this, false, true,
                                              connection.IsOdbc2Connection())),
-      m_ird(std::make_shared<ODBCDescriptor>(m_spiStatement->GetDiagnostics(), nullptr,
+      m_ird(std::make_shared<ODBCDescriptor>(m_spi_statement->GetDiagnostics(), nullptr,
                                              this, false, false,
                                              connection.IsOdbc2Connection())),
-      m_currentArd(m_builtInApd.get()),
-      m_currentApd(m_builtInApd.get()),
-      m_rowNumber(0),
-      m_maxRows(0),
-      m_rowsetSize(1),
-      m_isPrepared(false),
-      m_hasReachedEndOfResult(false) {}
+      m_current_ard(m_built_in_apd.get()),
+      m_current_apd(m_built_in_apd.get()),
+      m_row_number(0),
+      m_max_rows(0),
+      m_rowset_size(1),
+      m_is_prepared(false),
+      m_has_reached_end_of_result(false) {}
 
 ODBCConnection& ODBCStatement::GetConnection() { return m_connection; }
 
 void ODBCStatement::CopyAttributesFromConnection(ODBCConnection& connection) {
-  ODBCStatement& trackingStatement = connection.GetTrackingStatement();
+  ODBCStatement& tracking_statement = connection.GetTrackingStatement();
 
-  // Get abstraction attributes and copy to this m_spiStatement.
+  // Get abstraction attributes and copy to this m_spi_statement.
   // Possible ODBC attributes are below, but many of these are not supported by warpdrive
   // or ODBCAbstaction:
   // SQL_ATTR_ASYNC_ENABLE:
@@ -265,180 +265,184 @@ void ODBCStatement::CopyAttributesFromConnection(ODBCConnection& connection) {
   // SQL_ATTR_RETRIEVE_DATA:
   // SQL_ATTR_SIMULATE_CURSOR:
   // SQL_ATTR_USE_BOOKMARKS:
-  CopyAttribute(*trackingStatement.m_spiStatement, *m_spiStatement,
+  CopyAttribute(*tracking_statement.m_spi_statement, *m_spi_statement,
                 Statement::METADATA_ID);
-  CopyAttribute(*trackingStatement.m_spiStatement, *m_spiStatement,
+  CopyAttribute(*tracking_statement.m_spi_statement, *m_spi_statement,
                 Statement::MAX_LENGTH);
-  CopyAttribute(*trackingStatement.m_spiStatement, *m_spiStatement, Statement::NOSCAN);
-  CopyAttribute(*trackingStatement.m_spiStatement, *m_spiStatement,
+  CopyAttribute(*tracking_statement.m_spi_statement, *m_spi_statement, Statement::NOSCAN);
+  CopyAttribute(*tracking_statement.m_spi_statement, *m_spi_statement,
                 Statement::QUERY_TIMEOUT);
 
   // SQL_ATTR_ROW_BIND_TYPE:
-  m_currentArd->SetHeaderField(
+  m_current_ard->SetHeaderField(
       SQL_DESC_BIND_TYPE,
       reinterpret_cast<SQLPOINTER>(
-          static_cast<SQLLEN>(trackingStatement.m_currentArd->GetBoundStructOffset())),
+          static_cast<SQLLEN>(tracking_statement.m_current_ard->GetBoundStructOffset())),
       0);
 }
 
-bool ODBCStatement::isPrepared() const { return m_isPrepared; }
+bool ODBCStatement::IsPrepared() const { return m_is_prepared; }
 
 void ODBCStatement::Prepare(const std::string& query) {
   boost::optional<std::shared_ptr<ResultSetMetadata> > metadata =
-      m_spiStatement->Prepare(query);
+      m_spi_statement->Prepare(query);
 
   if (metadata) {
     m_ird->PopulateFromResultSetMetadata(metadata->get());
   }
-  m_isPrepared = true;
+  m_is_prepared = true;
 }
 
 void ODBCStatement::ExecutePrepared() {
-  if (!m_isPrepared) {
+  if (!m_is_prepared) {
     throw DriverException("Function sequence error", "HY010");
   }
 
-  if (m_spiStatement->ExecutePrepared()) {
-    m_currenResult = m_spiStatement->GetResultSet();
+  if (m_spi_statement->ExecutePrepared()) {
+    m_current_result = m_spi_statement->GetResultSet();
     m_ird->PopulateFromResultSetMetadata(
-        m_spiStatement->GetResultSet()->GetMetadata().get());
-    m_hasReachedEndOfResult = false;
+        m_spi_statement->GetResultSet()->GetMetadata().get());
+    m_has_reached_end_of_result = false;
   }
 }
 
 void ODBCStatement::ExecuteDirect(const std::string& query) {
-  if (m_spiStatement->Execute(query)) {
-    m_currenResult = m_spiStatement->GetResultSet();
-    m_ird->PopulateFromResultSetMetadata(m_currenResult->GetMetadata().get());
-    m_hasReachedEndOfResult = false;
+  if (m_spi_statement->Execute(query)) {
+    m_current_result = m_spi_statement->GetResultSet();
+    m_ird->PopulateFromResultSetMetadata(m_current_result->GetMetadata().get());
+    m_has_reached_end_of_result = false;
   }
 
   // Direct execution wipes out the prepared state.
-  m_isPrepared = false;
+  m_is_prepared = false;
 }
 
-bool ODBCStatement::Fetch(size_t rows, SQLULEN* rowCountPtr,
-                          SQLUSMALLINT* rowStatusArray) {
-  if (m_hasReachedEndOfResult) {
+bool ODBCStatement::Fetch(size_t rows, SQLULEN* row_count_ptr,
+                          SQLUSMALLINT* row_status_array) {
+  if (m_has_reached_end_of_result) {
     m_ird->SetRowsProcessed(0);
     return false;
   }
 
-  if (m_maxRows) {
-    rows = std::min(rows, m_maxRows - m_rowNumber);
+  if (m_max_rows) {
+    rows = std::min(rows, m_max_rows - m_row_number);
   }
 
-  if (m_currentArd->HaveBindingsChanged()) {
-    // TODO: Deal handle when offset != bufferlength.
+  if (m_current_ard->HaveBindingsChanged()) {
+    // TODO: Deal handle when offset != buffer_length.
 
     // Wipe out all bindings in the ResultSet.
     // Note that the number of ARD records can both be more or less
     // than the number of columns.
     for (size_t i = 0; i < m_ird->GetRecords().size(); i++) {
-      if (i < m_currentArd->GetRecords().size() &&
-          m_currentArd->GetRecords()[i].m_isBound) {
-        const DescriptorRecord& ardRecord = m_currentArd->GetRecords()[i];
-        m_currenResult->BindColumn(i + 1, ardRecord.m_type, ardRecord.m_precision,
-                                   ardRecord.m_scale, ardRecord.m_dataPtr,
-                                   GetLength(ardRecord), ardRecord.m_indicatorPtr);
+      if (i < m_current_ard->GetRecords().size() &&
+          m_current_ard->GetRecords()[i].m_is_bound) {
+        const DescriptorRecord& ard_record = m_current_ard->GetRecords()[i];
+        m_current_result->BindColumn(i + 1, ard_record.m_type, ard_record.m_precision,
+                                     ard_record.m_scale, ard_record.m_data_ptr,
+                                     GetLength(ard_record), ard_record.m_indicator_ptr);
       } else {
-        m_currenResult->BindColumn(i + 1,
-                                   driver::odbcabstraction::CDataType_CHAR
-                                   /* arbitrary type, not used */,
-                                   0, 0, nullptr, 0, nullptr);
+        m_current_result->BindColumn(i + 1,
+                                     driver::odbcabstraction::CDataType_CHAR
+                                     /* arbitrary type, not used */,
+                                     0, 0, nullptr, 0, nullptr);
       }
     }
-    m_currentArd->NotifyBindingsHavePropagated();
+    m_current_ard->NotifyBindingsHavePropagated();
   }
 
-  uint16_t* arrayStatusPtr;
-  if (rowStatusArray) {
+  uint16_t* array_status_ptr;
+  if (row_status_array) {
     // For SQLExtendedFetch only
-    arrayStatusPtr = rowStatusArray;
+    array_status_ptr = row_status_array;
   } else {
-    arrayStatusPtr = m_ird->GetArrayStatusPtr();
+    array_status_ptr = m_ird->GetArrayStatusPtr();
   }
 
-  size_t rowsFetched =
-      m_currenResult->Move(rows, m_currentArd->GetBindOffset(),
-                           m_currentArd->GetBoundStructOffset(), arrayStatusPtr);
-  m_ird->SetRowsProcessed(static_cast<SQLULEN>(rowsFetched));
+  size_t rows_fetched =
+      m_current_result->Move(rows, m_current_ard->GetBindOffset(),
+                             m_current_ard->GetBoundStructOffset(), array_status_ptr);
+  m_ird->SetRowsProcessed(static_cast<SQLULEN>(rows_fetched));
 
-  if (rowCountPtr) {
+  if (row_count_ptr) {
     // For SQLExtendedFetch only
-    *rowCountPtr = rowsFetched;
+    *row_count_ptr = rows_fetched;
   }
 
-  m_rowNumber += rowsFetched;
-  m_hasReachedEndOfResult = rowsFetched != rows;
-  return rowsFetched != 0;
+  m_row_number += rows_fetched;
+  m_has_reached_end_of_result = rows_fetched != rows;
+  return rows_fetched != 0;
 }
 
-void ODBCStatement::GetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER output,
-                                SQLINTEGER bufferSize, SQLINTEGER* strLenPtr,
-                                bool isUnicode) {
+void ODBCStatement::GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER output,
+                                SQLINTEGER buffer_size, SQLINTEGER* str_len_ptr,
+                                bool is_unicode) {
   using driver::odbcabstraction::Statement;
-  boost::optional<Statement::Attribute> spiAttribute;
-  switch (statementAttribute) {
+  boost::optional<Statement::Attribute> spi_attribute;
+  switch (statement_attribute) {
     // Descriptor accessor attributes
     case SQL_ATTR_APP_PARAM_DESC:
-      DescriptorToHandle(output, m_currentApd, strLenPtr);
+      DescriptorToHandle(output, m_current_apd, str_len_ptr);
       return;
     case SQL_ATTR_APP_ROW_DESC:
-      DescriptorToHandle(output, m_currentArd, strLenPtr);
+      DescriptorToHandle(output, m_current_ard, str_len_ptr);
       return;
     case SQL_ATTR_IMP_PARAM_DESC:
-      DescriptorToHandle(output, m_ipd.get(), strLenPtr);
+      DescriptorToHandle(output, m_ipd.get(), str_len_ptr);
       return;
     case SQL_ATTR_IMP_ROW_DESC:
-      DescriptorToHandle(output, m_ird.get(), strLenPtr);
+      DescriptorToHandle(output, m_ird.get(), str_len_ptr);
       return;
 
     // Attributes that are descriptor fields
     case SQL_ATTR_PARAM_BIND_OFFSET_PTR:
-      m_currentApd->GetHeaderField(SQL_DESC_BIND_OFFSET_PTR, output, bufferSize,
-                                   strLenPtr);
+      m_current_apd->GetHeaderField(SQL_DESC_BIND_OFFSET_PTR, output, buffer_size,
+                                    str_len_ptr);
       return;
     case SQL_ATTR_PARAM_BIND_TYPE:
-      m_currentApd->GetHeaderField(SQL_DESC_BIND_TYPE, output, bufferSize, strLenPtr);
+      m_current_apd->GetHeaderField(SQL_DESC_BIND_TYPE, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_PARAM_OPERATION_PTR:
-      m_currentApd->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, bufferSize,
-                                   strLenPtr);
+      m_current_apd->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size,
+                                    str_len_ptr);
       return;
     case SQL_ATTR_PARAM_STATUS_PTR:
-      m_ipd->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, bufferSize, strLenPtr);
+      m_ipd->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_PARAMS_PROCESSED_PTR:
-      m_ipd->GetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, output, bufferSize, strLenPtr);
+      m_ipd->GetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, output, buffer_size,
+                            str_len_ptr);
       return;
     case SQL_ATTR_PARAMSET_SIZE:
-      m_currentApd->GetHeaderField(SQL_DESC_ARRAY_SIZE, output, bufferSize, strLenPtr);
+      m_current_apd->GetHeaderField(SQL_DESC_ARRAY_SIZE, output, buffer_size,
+                                    str_len_ptr);
       return;
     case SQL_ATTR_ROW_ARRAY_SIZE:
-      m_currentArd->GetHeaderField(SQL_DESC_ARRAY_SIZE, output, bufferSize, strLenPtr);
+      m_current_ard->GetHeaderField(SQL_DESC_ARRAY_SIZE, output, buffer_size,
+                                    str_len_ptr);
       return;
     case SQL_ATTR_ROW_BIND_OFFSET_PTR:
-      m_currentArd->GetHeaderField(SQL_DESC_BIND_OFFSET_PTR, output, bufferSize,
-                                   strLenPtr);
+      m_current_ard->GetHeaderField(SQL_DESC_BIND_OFFSET_PTR, output, buffer_size,
+                                    str_len_ptr);
       return;
     case SQL_ATTR_ROW_BIND_TYPE:
-      m_currentArd->GetHeaderField(SQL_DESC_BIND_TYPE, output, bufferSize, strLenPtr);
+      m_current_ard->GetHeaderField(SQL_DESC_BIND_TYPE, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_ROW_OPERATION_PTR:
-      m_currentArd->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, bufferSize,
-                                   strLenPtr);
+      m_current_ard->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size,
+                                    str_len_ptr);
       return;
     case SQL_ATTR_ROW_STATUS_PTR:
-      m_ird->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, bufferSize, strLenPtr);
+      m_ird->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_ROWS_FETCHED_PTR:
-      m_ird->GetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, output, bufferSize, strLenPtr);
+      m_ird->GetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, output, buffer_size,
+                            str_len_ptr);
       return;
 
     case SQL_ATTR_ASYNC_ENABLE:
-      GetAttribute(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), output, bufferSize,
-                   strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), output, buffer_size,
+                   str_len_ptr);
       return;
 
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
@@ -454,96 +458,97 @@ void ODBCStatement::GetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER output
       throw DriverException("Unsupported attribute", "HYC00");
 #endif
     case SQL_ATTR_CURSOR_SCROLLABLE:
-      GetAttribute(static_cast<SQLULEN>(SQL_NONSCROLLABLE), output, bufferSize,
-                   strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_NONSCROLLABLE), output, buffer_size,
+                   str_len_ptr);
       return;
 
     case SQL_ATTR_CURSOR_SENSITIVITY:
-      GetAttribute(static_cast<SQLULEN>(SQL_UNSPECIFIED), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_UNSPECIFIED), output, buffer_size,
+                   str_len_ptr);
       return;
 
     case SQL_ATTR_CURSOR_TYPE:
-      GetAttribute(static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY), output, bufferSize,
-                   strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY), output, buffer_size,
+                   str_len_ptr);
       return;
 
     case SQL_ATTR_ENABLE_AUTO_IPD:
-      GetAttribute(static_cast<SQLULEN>(SQL_FALSE), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_FALSE), output, buffer_size, str_len_ptr);
       return;
 
     case SQL_ATTR_FETCH_BOOKMARK_PTR:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), output, buffer_size, str_len_ptr);
       return;
 
     case SQL_ATTR_KEYSET_SIZE:
-      GetAttribute(static_cast<SQLULEN>(0), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(0), output, buffer_size, str_len_ptr);
       return;
 
     case SQL_ATTR_ROW_NUMBER:
-      GetAttribute(static_cast<SQLULEN>(m_rowNumber), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(m_row_number), output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_SIMULATE_CURSOR:
-      GetAttribute(static_cast<SQLULEN>(SQL_SC_UNIQUE), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_SC_UNIQUE), output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_USE_BOOKMARKS:
-      GetAttribute(static_cast<SQLULEN>(SQL_UB_OFF), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_UB_OFF), output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_CONCURRENCY:
-      GetAttribute(static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY), output, bufferSize,
-                   strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY), output, buffer_size,
+                   str_len_ptr);
       return;
     case SQL_ATTR_MAX_ROWS:
-      GetAttribute(static_cast<SQLULEN>(m_maxRows), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(m_max_rows), output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_RETRIEVE_DATA:
-      GetAttribute(static_cast<SQLULEN>(SQL_RD_ON), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(SQL_RD_ON), output, buffer_size, str_len_ptr);
       return;
     case SQL_ROWSET_SIZE:
-      GetAttribute(static_cast<SQLULEN>(m_rowsetSize), output, bufferSize, strLenPtr);
+      GetAttribute(static_cast<SQLULEN>(m_rowset_size), output, buffer_size, str_len_ptr);
       return;
 
     // Driver-level statement attributes. These are all SQLULEN attributes.
     case SQL_ATTR_MAX_LENGTH:
-      spiAttribute = m_spiStatement->GetAttribute(Statement::MAX_LENGTH);
+      spi_attribute = m_spi_statement->GetAttribute(Statement::MAX_LENGTH);
       break;
     case SQL_ATTR_METADATA_ID:
-      spiAttribute = m_spiStatement->GetAttribute(Statement::METADATA_ID);
+      spi_attribute = m_spi_statement->GetAttribute(Statement::METADATA_ID);
       break;
     case SQL_ATTR_NOSCAN:
-      spiAttribute = m_spiStatement->GetAttribute(Statement::NOSCAN);
+      spi_attribute = m_spi_statement->GetAttribute(Statement::NOSCAN);
       break;
     case SQL_ATTR_QUERY_TIMEOUT:
-      spiAttribute = m_spiStatement->GetAttribute(Statement::QUERY_TIMEOUT);
+      spi_attribute = m_spi_statement->GetAttribute(Statement::QUERY_TIMEOUT);
       break;
     default:
       throw DriverException(
-          "Invalid statement attribute: " + std::to_string(statementAttribute), "HY092");
+          "Invalid statement attribute: " + std::to_string(statement_attribute), "HY092");
   }
 
-  if (spiAttribute) {
-    GetAttribute(static_cast<SQLULEN>(boost::get<size_t>(*spiAttribute)), output,
-                 bufferSize, strLenPtr);
+  if (spi_attribute) {
+    GetAttribute(static_cast<SQLULEN>(boost::get<size_t>(*spi_attribute)), output,
+                 buffer_size, str_len_ptr);
     return;
   }
 
   throw DriverException(
-      "Invalid statement attribute: " + std::to_string(statementAttribute), "HY092");
+      "Invalid statement attribute: " + std::to_string(statement_attribute), "HY092");
 }
 
-void ODBCStatement::SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value,
-                                SQLINTEGER bufferSize, bool isUnicode) {
-  size_t attributeToWrite = 0;
+void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value,
+                                SQLINTEGER buffer_size, bool is_unicode) {
+  size_t attribute_to_write = 0;
   bool successfully_written = false;
 
-  switch (statementAttribute) {
+  switch (statement_attribute) {
     case SQL_ATTR_APP_PARAM_DESC: {
       ODBCDescriptor* desc = static_cast<ODBCDescriptor*>(value);
-      if (m_currentApd != desc) {
-        if (m_currentApd != m_builtInApd.get()) {
-          m_currentApd->DetachFromStatement(this, true);
+      if (m_current_apd != desc) {
+        if (m_current_apd != m_built_in_apd.get()) {
+          m_current_apd->DetachFromStatement(this, true);
         }
-        m_currentApd = desc;
-        if (m_currentApd != m_builtInApd.get()) {
+        m_current_apd = desc;
+        if (m_current_apd != m_built_in_apd.get()) {
           desc->RegisterToStatement(this, true);
         }
       }
@@ -551,12 +556,12 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value,
     }
     case SQL_ATTR_APP_ROW_DESC: {
       ODBCDescriptor* desc = static_cast<ODBCDescriptor*>(value);
-      if (m_currentArd != desc) {
-        if (m_currentArd != m_builtInArd.get()) {
-          m_currentArd->DetachFromStatement(this, false);
+      if (m_current_ard != desc) {
+        if (m_current_ard != m_built_in_ard.get()) {
+          m_current_ard->DetachFromStatement(this, false);
         }
-        m_currentArd = desc;
-        if (m_currentArd != m_builtInArd.get()) {
+        m_current_ard = desc;
+        if (m_current_ard != m_built_in_ard.get()) {
           desc->RegisterToStatement(this, false);
         }
       }
@@ -568,40 +573,40 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value,
       throw DriverException("Cannot assign implementation descriptor.", "HY017");
       // Attributes that are descriptor fields
     case SQL_ATTR_PARAM_BIND_OFFSET_PTR:
-      m_currentApd->SetHeaderField(SQL_DESC_BIND_OFFSET_PTR, value, bufferSize);
+      m_current_apd->SetHeaderField(SQL_DESC_BIND_OFFSET_PTR, value, buffer_size);
       return;
     case SQL_ATTR_PARAM_BIND_TYPE:
-      m_currentApd->SetHeaderField(SQL_DESC_BIND_TYPE, value, bufferSize);
+      m_current_apd->SetHeaderField(SQL_DESC_BIND_TYPE, value, buffer_size);
       return;
     case SQL_ATTR_PARAM_OPERATION_PTR:
-      m_currentApd->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, bufferSize);
+      m_current_apd->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
       return;
     case SQL_ATTR_PARAM_STATUS_PTR:
-      m_ipd->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, bufferSize);
+      m_ipd->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
       return;
     case SQL_ATTR_PARAMS_PROCESSED_PTR:
-      m_ipd->SetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, value, bufferSize);
+      m_ipd->SetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, value, buffer_size);
       return;
     case SQL_ATTR_PARAMSET_SIZE:
-      m_currentApd->SetHeaderField(SQL_DESC_ARRAY_SIZE, value, bufferSize);
+      m_current_apd->SetHeaderField(SQL_DESC_ARRAY_SIZE, value, buffer_size);
       return;
     case SQL_ATTR_ROW_ARRAY_SIZE:
-      m_currentArd->SetHeaderField(SQL_DESC_ARRAY_SIZE, value, bufferSize);
+      m_current_ard->SetHeaderField(SQL_DESC_ARRAY_SIZE, value, buffer_size);
       return;
     case SQL_ATTR_ROW_BIND_OFFSET_PTR:
-      m_currentArd->SetHeaderField(SQL_DESC_BIND_OFFSET_PTR, value, bufferSize);
+      m_current_ard->SetHeaderField(SQL_DESC_BIND_OFFSET_PTR, value, buffer_size);
       return;
     case SQL_ATTR_ROW_BIND_TYPE:
-      m_currentArd->SetHeaderField(SQL_DESC_BIND_TYPE, value, bufferSize);
+      m_current_ard->SetHeaderField(SQL_DESC_BIND_TYPE, value, buffer_size);
       return;
     case SQL_ATTR_ROW_OPERATION_PTR:
-      m_currentArd->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, bufferSize);
+      m_current_ard->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
       return;
     case SQL_ATTR_ROW_STATUS_PTR:
-      m_ird->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, bufferSize);
+      m_ird->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
       return;
     case SQL_ATTR_ROWS_FETCHED_PTR:
-      m_ird->SetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, value, bufferSize);
+      m_ird->SetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, value, buffer_size);
       return;
 
     case SQL_ATTR_ASYNC_ENABLE:
@@ -656,7 +661,7 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value,
       CheckIfAttributeIsSetToOnlyValidValue(value, static_cast<SQLULEN>(SQL_RD_ON));
       return;
     case SQL_ROWSET_SIZE:
-      SetAttribute(value, m_rowsetSize);
+      SetAttribute(value, m_rowset_size);
       return;
 
     case SQL_ATTR_MAX_ROWS:
@@ -664,27 +669,27 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value,
 
     // Driver-leve statement attributes. These are all size_t attributes
     case SQL_ATTR_MAX_LENGTH:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiStatement->SetAttribute(Statement::MAX_LENGTH, attributeToWrite);
+          m_spi_statement->SetAttribute(Statement::MAX_LENGTH, attribute_to_write);
       break;
     case SQL_ATTR_METADATA_ID:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiStatement->SetAttribute(Statement::METADATA_ID, attributeToWrite);
+          m_spi_statement->SetAttribute(Statement::METADATA_ID, attribute_to_write);
       break;
     case SQL_ATTR_NOSCAN:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiStatement->SetAttribute(Statement::NOSCAN, attributeToWrite);
+          m_spi_statement->SetAttribute(Statement::NOSCAN, attribute_to_write);
       break;
     case SQL_ATTR_QUERY_TIMEOUT:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiStatement->SetAttribute(Statement::QUERY_TIMEOUT, attributeToWrite);
+          m_spi_statement->SetAttribute(Statement::QUERY_TIMEOUT, attribute_to_write);
       break;
     default:
-      throw DriverException("Invalid attribute: " + std::to_string(attributeToWrite),
+      throw DriverException("Invalid attribute: " + std::to_string(attribute_to_write),
                             "HY092");
   }
   if (!successfully_written) {
@@ -695,147 +700,148 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value,
 
 void ODBCStatement::RevertAppDescriptor(bool isApd) {
   if (isApd) {
-    m_currentApd = m_builtInApd.get();
+    m_current_apd = m_built_in_apd.get();
   } else {
-    m_currentArd = m_builtInArd.get();
+    m_current_ard = m_built_in_ard.get();
   }
 }
 
-void ODBCStatement::closeCursor(bool suppressErrors) {
-  if (!suppressErrors && !m_currenResult) {
+void ODBCStatement::CloseCursor(bool suppress_errors) {
+  if (!suppress_errors && !m_current_result) {
     throw DriverException("Invalid cursor state", "24000");
   }
 
-  if (m_currenResult) {
-    m_currenResult->Close();
-    m_currenResult = nullptr;
+  if (m_current_result) {
+    m_current_result->Close();
+    m_current_result = nullptr;
   }
 
   // Reset the fetching state of this statement.
-  m_currentArd->NotifyBindingsHaveChanged();
-  m_rowNumber = 0;
-  m_hasReachedEndOfResult = false;
+  m_current_ard->NotifyBindingsHaveChanged();
+  m_row_number = 0;
+  m_has_reached_end_of_result = false;
 }
 
-SQLRETURN ODBCStatement::GetData(SQLSMALLINT recordNumber, SQLSMALLINT cType,
-                                 SQLPOINTER dataPtr, SQLLEN bufferLength,
-                                 SQLLEN* indicatorPtr) {
-  if (recordNumber == 0) {
+SQLRETURN ODBCStatement::GetData(SQLSMALLINT record_number, SQLSMALLINT c_type,
+                                 SQLPOINTER data_ptr, SQLLEN buffer_length,
+                                 SQLLEN* indicator_ptr) {
+  if (record_number == 0) {
     throw DriverException("Bookmarks are not supported", "07009");
-  } else if (recordNumber > m_ird->GetRecords().size()) {
-    throw DriverException("Invalid column index: " + std::to_string(recordNumber),
+  } else if (record_number > m_ird->GetRecords().size()) {
+    throw DriverException("Invalid column index: " + std::to_string(record_number),
                           "07009");
   }
 
-  SQLSMALLINT evaluatedCType = cType;
+  SQLSMALLINT evaluated_c_type = c_type;
 
   // TODO: Get proper default precision and scale from abstraction.
   int precision = 38;  // arrow::Decimal128Type::kMaxPrecision;
   int scale = 0;
 
-  if (cType == SQL_ARD_TYPE) {
-    if (recordNumber > m_currentArd->GetRecords().size()) {
-      throw DriverException("Invalid column index: " + std::to_string(recordNumber),
+  if (c_type == SQL_ARD_TYPE) {
+    if (record_number > m_current_ard->GetRecords().size()) {
+      throw DriverException("Invalid column index: " + std::to_string(record_number),
                             "07009");
     }
-    const DescriptorRecord& record = m_currentArd->GetRecords()[recordNumber - 1];
-    evaluatedCType = record.m_conciseType;
+    const DescriptorRecord& record = m_current_ard->GetRecords()[record_number - 1];
+    evaluated_c_type = record.m_concise_type;
     precision = record.m_precision;
     scale = record.m_scale;
   }
 
   // Note: this is intentionally not an else if, since the type can be SQL_C_DEFAULT in
   // the ARD.
-  if (evaluatedCType == SQL_C_DEFAULT) {
-    if (recordNumber <= m_currentArd->GetRecords().size()) {
-      const DescriptorRecord& ardRecord = m_currentArd->GetRecords()[recordNumber - 1];
-      precision = ardRecord.m_precision;
-      scale = ardRecord.m_scale;
+  if (evaluated_c_type == SQL_C_DEFAULT) {
+    if (record_number <= m_current_ard->GetRecords().size()) {
+      const DescriptorRecord& ard_record = m_current_ard->GetRecords()[record_number - 1];
+      precision = ard_record.m_precision;
+      scale = ard_record.m_scale;
     }
 
-    const DescriptorRecord& irdRecord = m_ird->GetRecords()[recordNumber - 1];
-    evaluatedCType = getCTypeForSQLType(irdRecord);
+    const DescriptorRecord& ird_record = m_ird->GetRecords()[record_number - 1];
+    evaluated_c_type = getc_typeForSQLType(ird_record);
   }
 
-  return m_currenResult->GetData(recordNumber, evaluatedCType, precision, scale, dataPtr,
-                                 bufferLength, indicatorPtr);
+  return m_current_result->GetData(record_number, evaluated_c_type, precision, scale,
+                                   data_ptr, buffer_length, indicator_ptr);
 }
 
-SQLRETURN ODBCStatement::getMoreResults() {
+SQLRETURN ODBCStatement::GetMoreResults() {
   // Multiple result sets are not supported.
-  if (m_currenResult) {
+  if (m_current_result) {
     return SQL_NO_DATA;
   } else {
     throw DriverException("Function sequence error", "HY010");
   }
 }
 
-void ODBCStatement::getColumnCount(SQLSMALLINT* columnCountPtr) {
-  if (!columnCountPtr) {
+void ODBCStatement::GetColumnCount(SQLSMALLINT* column_count_ptr) {
+  if (!column_count_ptr) {
     // columnCountPtr is not valid, do nothing as ODBC spec does not mention this as an
     // error
     return;
   }
-  size_t columnCount = m_ird->GetRecords().size();
-  *columnCountPtr = static_cast<SQLSMALLINT>(columnCount);
+  size_t column_count = m_ird->GetRecords().size();
+  *column_count_ptr = static_cast<SQLSMALLINT>(column_count);
 }
 
-void ODBCStatement::getRowCount(SQLLEN* rowCountPtr) {
-  if (!rowCountPtr) {
-    // rowCountPtr is not valid, do nothing as ODBC spec does not mention this as an error
+void ODBCStatement::GetRowCount(SQLLEN* row_count_ptr) {
+  if (!row_count_ptr) {
+    // row_count_ptr is not valid, do nothing as ODBC spec does not mention this as an
+    // error
     return;
   }
   // Will always be -1 (number of rows unknown) if only SELECT is supported
-  *rowCountPtr = -1;
+  *row_count_ptr = -1;
 }
 
-void ODBCStatement::releaseStatement() {
-  closeCursor(true);
-  m_connection.dropStatement(this);
+void ODBCStatement::ReleaseStatement() {
+  CloseCursor(true);
+  m_connection.DropStatement(this);
 }
 
 void ODBCStatement::GetTables(const std::string* catalog, const std::string* schema,
                               const std::string* table, const std::string* tableType) {
-  closeCursor(true);
+  CloseCursor(true);
   if (m_connection.IsOdbc2Connection()) {
-    m_currenResult = m_spiStatement->GetTables_V2(catalog, schema, table, tableType);
+    m_current_result = m_spi_statement->GetTables_V2(catalog, schema, table, tableType);
   } else {
-    m_currenResult = m_spiStatement->GetTables_V3(catalog, schema, table, tableType);
+    m_current_result = m_spi_statement->GetTables_V3(catalog, schema, table, tableType);
   }
-  m_ird->PopulateFromResultSetMetadata(m_currenResult->GetMetadata().get());
-  m_hasReachedEndOfResult = false;
+  m_ird->PopulateFromResultSetMetadata(m_current_result->GetMetadata().get());
+  m_has_reached_end_of_result = false;
 
   // Direct execution wipes out the prepared state.
-  m_isPrepared = false;
+  m_is_prepared = false;
 }
 
 void ODBCStatement::GetColumns(const std::string* catalog, const std::string* schema,
                                const std::string* table, const std::string* column) {
-  closeCursor(true);
+  CloseCursor(true);
   if (m_connection.IsOdbc2Connection()) {
-    m_currenResult = m_spiStatement->GetColumns_V2(catalog, schema, table, column);
+    m_current_result = m_spi_statement->GetColumns_V2(catalog, schema, table, column);
   } else {
-    m_currenResult = m_spiStatement->GetColumns_V3(catalog, schema, table, column);
+    m_current_result = m_spi_statement->GetColumns_V3(catalog, schema, table, column);
   }
-  m_ird->PopulateFromResultSetMetadata(m_currenResult->GetMetadata().get());
-  m_hasReachedEndOfResult = false;
+  m_ird->PopulateFromResultSetMetadata(m_current_result->GetMetadata().get());
+  m_has_reached_end_of_result = false;
 
   // Direct execution wipes out the prepared state.
-  m_isPrepared = false;
+  m_is_prepared = false;
 }
 
-void ODBCStatement::GetTypeInfo(SQLSMALLINT dataType) {
-  closeCursor(true);
+void ODBCStatement::GetTypeInfo(SQLSMALLINT data_type) {
+  CloseCursor(true);
   if (m_connection.IsOdbc2Connection()) {
-    m_currenResult = m_spiStatement->GetTypeInfo_V2(dataType);
+    m_current_result = m_spi_statement->GetTypeInfo_V2(data_type);
   } else {
-    m_currenResult = m_spiStatement->GetTypeInfo_V3(dataType);
+    m_current_result = m_spi_statement->GetTypeInfo_V3(data_type);
   }
-  m_ird->PopulateFromResultSetMetadata(m_currenResult->GetMetadata().get());
-  m_hasReachedEndOfResult = false;
+  m_ird->PopulateFromResultSetMetadata(m_current_result->GetMetadata().get());
+  m_has_reached_end_of_result = false;
 
   // Direct execution wipes out the prepared state.
-  m_isPrepared = false;
+  m_is_prepared = false;
 }
 
-void ODBCStatement::Cancel() { m_spiStatement->Cancel(); }
+void ODBCStatement::Cancel() { m_spi_statement->Cancel(); }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/utils.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/utils.cc
@@ -34,11 +34,11 @@ boost::optional<bool> AsBool(const std::string& value) {
   }
 }
 
-boost::optional<bool> AsBool(const Connection::ConnPropertyMap& connPropertyMap,
+boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
                              const std::string_view& property_name) {
-  auto extracted_property = connPropertyMap.find(std::string(property_name));
+  auto extracted_property = conn_property_map.find(std::string(property_name));
 
-  if (extracted_property != connPropertyMap.end()) {
+  if (extracted_property != conn_property_map.end()) {
     return AsBool(extracted_property->second);
   }
 
@@ -46,15 +46,15 @@ boost::optional<bool> AsBool(const Connection::ConnPropertyMap& connPropertyMap,
 }
 
 boost::optional<int32_t> AsInt32(int32_t min_value,
-                                 const Connection::ConnPropertyMap& connPropertyMap,
+                                 const Connection::ConnPropertyMap& conn_property_map,
                                  const std::string_view& property_name) {
-  auto extracted_property = connPropertyMap.find(std::string(property_name));
+  auto extracted_property = conn_property_map.find(std::string(property_name));
 
-  if (extracted_property != connPropertyMap.end()) {
-    const int32_t stringColumnLength = std::stoi(extracted_property->second);
+  if (extracted_property != conn_property_map.end()) {
+    const int32_t string_column_length = std::stoi(extracted_property->second);
 
-    if (stringColumnLength >= min_value && stringColumnLength <= INT32_MAX) {
-      return stringColumnLength;
+    if (string_column_length >= min_value && string_column_length <= INT32_MAX) {
+      return string_column_length;
     }
   }
   return boost::none;

--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -29,143 +29,152 @@
 namespace arrow::flight::sql::odbc {
 // Helper functions
 void checkSQLColumns(
-    SQLHSTMT stmt, const std::wstring& expectedTable, const std::wstring& expectedColumn,
-    const SQLINTEGER& expectedDataType, const std::wstring& expectedTypeName,
-    const SQLINTEGER& expectedColumnSize, const SQLINTEGER& expectedBufferLength,
-    const SQLSMALLINT& expectedDecimalDigits, const SQLSMALLINT& expectedNumPrecRadix,
-    const SQLSMALLINT& expectedNullable, const SQLSMALLINT& expectedSqlDataType,
-    const SQLSMALLINT& expectedDateTimeSub, const SQLINTEGER& expectedOctetCharLength,
-    const SQLINTEGER& expectedOrdinalPosition, const std::wstring& expectedIsNullable) {
-  CheckStringColumnW(stmt, 3, expectedTable);   // table name
-  CheckStringColumnW(stmt, 4, expectedColumn);  // column name
+    SQLHSTMT stmt, const std::wstring& expected_table,
+    const std::wstring& expected_column, const SQLINTEGER& expected_data_type,
+    const std::wstring& expected_type_name, const SQLINTEGER& expected_column_size,
+    const SQLINTEGER& expected_buffer_length, const SQLSMALLINT& expected_decimal_digits,
+    const SQLSMALLINT& expected_num_prec_radix, const SQLSMALLINT& expected_nullable,
+    const SQLSMALLINT& expected_sql_data_type, const SQLSMALLINT& expected_date_time_sub,
+    const SQLINTEGER& expected_octet_char_length,
+    const SQLINTEGER& expected_ordinal_position,
+    const std::wstring& expected_is_nullable) {
+  CheckStringColumnW(stmt, 3, expected_table);   // table name
+  CheckStringColumnW(stmt, 4, expected_column);  // column name
 
-  CheckIntColumn(stmt, 5, expectedDataType);  // data type
+  CheckIntColumn(stmt, 5, expected_data_type);  // data type
 
-  CheckStringColumnW(stmt, 6, expectedTypeName);  // type name
+  CheckStringColumnW(stmt, 6, expected_type_name);  // type name
 
-  CheckIntColumn(stmt, 7, expectedColumnSize);    // column size
-  CheckIntColumn(stmt, 8, expectedBufferLength);  // buffer length
+  CheckIntColumn(stmt, 7, expected_column_size);    // column size
+  CheckIntColumn(stmt, 8, expected_buffer_length);  // buffer length
 
-  CheckSmallIntColumn(stmt, 9, expectedDecimalDigits);  // decimal digits
-  CheckSmallIntColumn(stmt, 10, expectedNumPrecRadix);  // num prec radix
+  CheckSmallIntColumn(stmt, 9, expected_decimal_digits);   // decimal digits
+  CheckSmallIntColumn(stmt, 10, expected_num_prec_radix);  // num prec radix
   CheckSmallIntColumn(stmt, 11,
-                      expectedNullable);  // nullable
+                      expected_nullable);  // nullable
 
   CheckNullColumnW(stmt, 12);  // remarks
   CheckNullColumnW(stmt, 13);  // column def
 
-  CheckSmallIntColumn(stmt, 14, expectedSqlDataType);  // sql data type
-  CheckSmallIntColumn(stmt, 15, expectedDateTimeSub);  // sql date type sub
-  CheckIntColumn(stmt, 16, expectedOctetCharLength);   // char octet length
+  CheckSmallIntColumn(stmt, 14, expected_sql_data_type);  // sql data type
+  CheckSmallIntColumn(stmt, 15, expected_date_time_sub);  // sql date type sub
+  CheckIntColumn(stmt, 16, expected_octet_char_length);   // char octet length
   CheckIntColumn(stmt, 17,
-                 expectedOrdinalPosition);  // oridinal position
+                 expected_ordinal_position);  // oridinal position
 
-  CheckStringColumnW(stmt, 18, expectedIsNullable);  // is nullable
+  CheckStringColumnW(stmt, 18, expected_is_nullable);  // is nullable
 }
 
-void checkMockSQLColumns(
-    SQLHSTMT stmt, const std::wstring& expectedCatalog, const std::wstring& expectedTable,
-    const std::wstring& expectedColumn, const SQLINTEGER& expectedDataType,
-    const std::wstring& expectedTypeName, const SQLINTEGER& expectedColumnSize,
-    const SQLINTEGER& expectedBufferLength, const SQLSMALLINT& expectedDecimalDigits,
-    const SQLSMALLINT& expectedNumPrecRadix, const SQLSMALLINT& expectedNullable,
-    const SQLSMALLINT& expectedSqlDataType, const SQLSMALLINT& expectedDateTimeSub,
-    const SQLINTEGER& expectedOctetCharLength, const SQLINTEGER& expectedOrdinalPosition,
-    const std::wstring& expectedIsNullable) {
-  CheckStringColumnW(stmt, 1, expectedCatalog);  // catalog
-  CheckNullColumnW(stmt, 2);                     // schema
+void CheckMockSQLColumns(
+    SQLHSTMT stmt, const std::wstring& expected_catalog,
+    const std::wstring& expected_table, const std::wstring& expected_column,
+    const SQLINTEGER& expected_data_type, const std::wstring& expected_type_name,
+    const SQLINTEGER& expected_column_size, const SQLINTEGER& expected_buffer_length,
+    const SQLSMALLINT& expected_decimal_digits,
+    const SQLSMALLINT& expected_num_prec_radix, const SQLSMALLINT& expected_nullable,
+    const SQLSMALLINT& expected_sql_data_type, const SQLSMALLINT& expected_date_time_sub,
+    const SQLINTEGER& expected_octet_char_length,
+    const SQLINTEGER& expected_ordinal_position,
+    const std::wstring& expected_is_nullable) {
+  CheckStringColumnW(stmt, 1, expected_catalog);  // catalog
+  CheckNullColumnW(stmt, 2);                      // schema
 
-  checkSQLColumns(stmt, expectedTable, expectedColumn, expectedDataType, expectedTypeName,
-                  expectedColumnSize, expectedBufferLength, expectedDecimalDigits,
-                  expectedNumPrecRadix, expectedNullable, expectedSqlDataType,
-                  expectedDateTimeSub, expectedOctetCharLength, expectedOrdinalPosition,
-                  expectedIsNullable);
+  checkSQLColumns(stmt, expected_table, expected_column, expected_data_type,
+                  expected_type_name, expected_column_size, expected_buffer_length,
+                  expected_decimal_digits, expected_num_prec_radix, expected_nullable,
+                  expected_sql_data_type, expected_date_time_sub,
+                  expected_octet_char_length, expected_ordinal_position,
+                  expected_is_nullable);
 }
 
 void checkRemoteSQLColumns(
-    SQLHSTMT stmt, const std::wstring& expectedSchema, const std::wstring& expectedTable,
-    const std::wstring& expectedColumn, const SQLINTEGER& expectedDataType,
-    const std::wstring& expectedTypeName, const SQLINTEGER& expectedColumnSize,
-    const SQLINTEGER& expectedBufferLength, const SQLSMALLINT& expectedDecimalDigits,
-    const SQLSMALLINT& expectedNumPrecRadix, const SQLSMALLINT& expectedNullable,
-    const SQLSMALLINT& expectedSqlDataType, const SQLSMALLINT& expectedDateTimeSub,
-    const SQLINTEGER& expectedOctetCharLength, const SQLINTEGER& expectedOrdinalPosition,
-    const std::wstring& expectedIsNullable) {
-  CheckNullColumnW(stmt, 1);                    // catalog
-  CheckStringColumnW(stmt, 2, expectedSchema);  // schema
-  checkSQLColumns(stmt, expectedTable, expectedColumn, expectedDataType, expectedTypeName,
-                  expectedColumnSize, expectedBufferLength, expectedDecimalDigits,
-                  expectedNumPrecRadix, expectedNullable, expectedSqlDataType,
-                  expectedDateTimeSub, expectedOctetCharLength, expectedOrdinalPosition,
-                  expectedIsNullable);
+    SQLHSTMT stmt, const std::wstring& expected_schema,
+    const std::wstring& expected_table, const std::wstring& expected_column,
+    const SQLINTEGER& expected_data_type, const std::wstring& expected_type_name,
+    const SQLINTEGER& expected_column_size, const SQLINTEGER& expected_buffer_length,
+    const SQLSMALLINT& expected_decimal_digits,
+    const SQLSMALLINT& expected_num_prec_radix, const SQLSMALLINT& expected_nullable,
+    const SQLSMALLINT& expected_sql_data_type, const SQLSMALLINT& expected_date_time_sub,
+    const SQLINTEGER& expected_octet_char_length,
+    const SQLINTEGER& expected_ordinal_position,
+    const std::wstring& expected_is_nullable) {
+  CheckNullColumnW(stmt, 1);                     // catalog
+  CheckStringColumnW(stmt, 2, expected_schema);  // schema
+  checkSQLColumns(stmt, expected_table, expected_column, expected_data_type,
+                  expected_type_name, expected_column_size, expected_buffer_length,
+                  expected_decimal_digits, expected_num_prec_radix, expected_nullable,
+                  expected_sql_data_type, expected_date_time_sub,
+                  expected_octet_char_length, expected_ordinal_position,
+                  expected_is_nullable);
 }
 
-void checkSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
-                          const std::wstring& expectedColmnName, SQLLEN expectedDataType,
-                          SQLLEN expectedConciseType, SQLLEN expectedDisplaySize,
-                          SQLLEN expectedPrecScale, SQLLEN expectedLength,
-                          const std::wstring& expectedLiteralPrefix,
-                          const std::wstring& expectedLiteralSuffix,
-                          SQLLEN expectedColumnSize, SQLLEN expectedColumnScale,
-                          SQLLEN expectedColumnNullability, SQLLEN expectedNumPrecRadix,
-                          SQLLEN expectedOctetLength, SQLLEN expectedSearchable,
-                          SQLLEN expectedUnsignedColumn) {
+void CheckSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
+                          const std::wstring& expected_column_name,
+                          SQLLEN expected_data_type, SQLLEN expected_concise_type,
+                          SQLLEN expected_display_size, SQLLEN expected_prec_scale,
+                          SQLLEN expected_length,
+                          const std::wstring& expected_literal_prefix,
+                          const std::wstring& expected_literal_suffix,
+                          SQLLEN expected_column_size, SQLLEN expected_column_scale,
+                          SQLLEN expected_column_nullability,
+                          SQLLEN expected_num_prec_radix, SQLLEN expected_octet_length,
+                          SQLLEN expected_searchable, SQLLEN expected_unsigned_column) {
   std::vector<SQLWCHAR> name(ODBC_BUFFER_SIZE);
-  SQLSMALLINT nameLen = 0;
-  std::vector<SQLWCHAR> baseColumnName(ODBC_BUFFER_SIZE);
-  SQLSMALLINT columnNameLen = 0;
+  SQLSMALLINT name_len = 0;
+  std::vector<SQLWCHAR> base_column_name(ODBC_BUFFER_SIZE);
+  SQLSMALLINT column_name_len = 0;
   std::vector<SQLWCHAR> label(ODBC_BUFFER_SIZE);
-  SQLSMALLINT labelLen = 0;
+  SQLSMALLINT label_len = 0;
   std::vector<SQLWCHAR> prefix(ODBC_BUFFER_SIZE);
-  SQLSMALLINT prefixLen = 0;
+  SQLSMALLINT prefix_len = 0;
   std::vector<SQLWCHAR> suffix(ODBC_BUFFER_SIZE);
-  SQLSMALLINT suffixLen = 0;
-  SQLLEN dataType = 0;
-  SQLLEN conciseType = 0;
-  SQLLEN displaySize = 0;
-  SQLLEN precScale = 0;
+  SQLSMALLINT suffix_len = 0;
+  SQLLEN data_type = 0;
+  SQLLEN concise_type = 0;
+  SQLLEN display_size = 0;
+  SQLLEN prec_scale = 0;
   SQLLEN length = 0;
   SQLLEN size = 0;
   SQLLEN scale = 0;
   SQLLEN nullability = 0;
-  SQLLEN numPrecRadix = 0;
-  SQLLEN octetLength = 0;
+  SQLLEN num_prec_radix = 0;
+  SQLLEN octet_length = 0;
   SQLLEN searchable = 0;
-  SQLLEN unsignedCol = 0;
+  SQLLEN unsigned_col = 0;
 
   SQLRETURN ret = SQLColAttribute(stmt, idx, SQL_DESC_NAME, &name[0],
-                                  (SQLSMALLINT)name.size(), &nameLen, 0);
+                                  (SQLSMALLINT)name.size(), &name_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_DESC_BASE_COLUMN_NAME, &baseColumnName[0],
-                        (SQLSMALLINT)baseColumnName.size(), &columnNameLen, 0);
+  ret = SQLColAttribute(stmt, idx, SQL_DESC_BASE_COLUMN_NAME, &base_column_name[0],
+                        (SQLSMALLINT)base_column_name.size(), &column_name_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_LABEL, &label[0], (SQLSMALLINT)label.size(),
-                        &labelLen, 0);
+                        &label_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_DESC_TYPE, 0, 0, 0, &dataType);
+  ret = SQLColAttribute(stmt, idx, SQL_DESC_TYPE, 0, 0, 0, &data_type);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_DESC_CONCISE_TYPE, 0, 0, 0, &conciseType);
+  ret = SQLColAttribute(stmt, idx, SQL_DESC_CONCISE_TYPE, 0, 0, 0, &concise_type);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_DESC_DISPLAY_SIZE, 0, 0, 0, &displaySize);
+  ret = SQLColAttribute(stmt, idx, SQL_DESC_DISPLAY_SIZE, 0, 0, 0, &display_size);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_DESC_FIXED_PREC_SCALE, 0, 0, 0, &precScale);
+  ret = SQLColAttribute(stmt, idx, SQL_DESC_FIXED_PREC_SCALE, 0, 0, 0, &prec_scale);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_LENGTH, 0, 0, 0, &length);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_LITERAL_PREFIX, &prefix[0],
-                        (SQLSMALLINT)prefix.size(), &prefixLen, 0);
+                        (SQLSMALLINT)prefix.size(), &prefix_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_LITERAL_SUFFIX, &suffix[0],
-                        (SQLSMALLINT)suffix.size(), &suffixLen, 0);
+                        (SQLSMALLINT)suffix.size(), &suffix_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_PRECISION, 0, 0, 0, &size);
@@ -177,77 +186,78 @@ void checkSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
   ret = SQLColAttribute(stmt, idx, SQL_DESC_NULLABLE, 0, 0, 0, &nullability);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_DESC_NUM_PREC_RADIX, 0, 0, 0, &numPrecRadix);
+  ret = SQLColAttribute(stmt, idx, SQL_DESC_NUM_PREC_RADIX, 0, 0, 0, &num_prec_radix);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_DESC_OCTET_LENGTH, 0, 0, 0, &octetLength);
+  ret = SQLColAttribute(stmt, idx, SQL_DESC_OCTET_LENGTH, 0, 0, 0, &octet_length);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_SEARCHABLE, 0, 0, 0, &searchable);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_DESC_UNSIGNED, 0, 0, 0, &unsignedCol);
+  ret = SQLColAttribute(stmt, idx, SQL_DESC_UNSIGNED, 0, 0, 0, &unsigned_col);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  std::wstring nameStr = ConvertToWString(name, nameLen);
-  std::wstring baseColumnNameStr = ConvertToWString(baseColumnName, columnNameLen);
-  std::wstring labelStr = ConvertToWString(label, labelLen);
-  std::wstring prefixStr = ConvertToWString(prefix, prefixLen);
+  std::wstring name_str = ConvertToWString(name, name_len);
+  std::wstring base_column_name_str = ConvertToWString(base_column_name, column_name_len);
+  std::wstring label_str = ConvertToWString(label, label_len);
+  std::wstring prefixStr = ConvertToWString(prefix, prefix_len);
 
   // Assume column name, base column name, and label are equivalent in the result set
-  EXPECT_EQ(nameStr, expectedColmnName);
-  EXPECT_EQ(baseColumnNameStr, expectedColmnName);
-  EXPECT_EQ(labelStr, expectedColmnName);
-  EXPECT_EQ(dataType, expectedDataType);
-  EXPECT_EQ(conciseType, expectedConciseType);
-  EXPECT_EQ(displaySize, expectedDisplaySize);
-  EXPECT_EQ(precScale, expectedPrecScale);
-  EXPECT_EQ(length, expectedLength);
-  EXPECT_EQ(prefixStr, expectedLiteralPrefix);
-  EXPECT_EQ(size, expectedColumnSize);
-  EXPECT_EQ(scale, expectedColumnScale);
-  EXPECT_EQ(nullability, expectedColumnNullability);
-  EXPECT_EQ(numPrecRadix, expectedNumPrecRadix);
-  EXPECT_EQ(octetLength, expectedOctetLength);
-  EXPECT_EQ(searchable, expectedSearchable);
-  EXPECT_EQ(unsignedCol, expectedUnsignedColumn);
+  EXPECT_EQ(name_str, expected_column_name);
+  EXPECT_EQ(base_column_name_str, expected_column_name);
+  EXPECT_EQ(label_str, expected_column_name);
+  EXPECT_EQ(data_type, expected_data_type);
+  EXPECT_EQ(concise_type, expected_concise_type);
+  EXPECT_EQ(display_size, expected_display_size);
+  EXPECT_EQ(prec_scale, expected_prec_scale);
+  EXPECT_EQ(length, expected_length);
+  EXPECT_EQ(prefixStr, expected_literal_prefix);
+  EXPECT_EQ(size, expected_column_size);
+  EXPECT_EQ(scale, expected_column_scale);
+  EXPECT_EQ(nullability, expected_column_nullability);
+  EXPECT_EQ(num_prec_radix, expected_num_prec_radix);
+  EXPECT_EQ(octet_length, expected_octet_length);
+  EXPECT_EQ(searchable, expected_searchable);
+  EXPECT_EQ(unsigned_col, expected_unsigned_column);
 }
 
-void checkSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
-                           const std::wstring& expectedColmnName, SQLLEN expectedDataType,
-                           SQLLEN expectedDisplaySize, SQLLEN expectedPrecScale,
-                           SQLLEN expectedLength, SQLLEN expectedColumnSize,
-                           SQLLEN expectedColumnScale, SQLLEN expectedColumnNullability,
-                           SQLLEN expectedSearchable, SQLLEN expectedUnsignedColumn) {
+void CheckSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
+                           const std::wstring& expected_column_name,
+                           SQLLEN expected_data_type, SQLLEN expected_display_size,
+                           SQLLEN expected_prec_scale, SQLLEN expected_length,
+                           SQLLEN expected_column_size, SQLLEN expected_column_scale,
+                           SQLLEN expected_column_nullability, SQLLEN expected_searchable,
+                           SQLLEN expected_unsigned_column) {
   std::vector<SQLWCHAR> name(ODBC_BUFFER_SIZE);
-  SQLSMALLINT nameLen = 0;
+  SQLSMALLINT name_len = 0;
   std::vector<SQLWCHAR> label(ODBC_BUFFER_SIZE);
-  SQLSMALLINT labelLen = 0;
-  SQLLEN dataType = 0;
-  SQLLEN displaySize = 0;
-  SQLLEN precScale = 0;
+  SQLSMALLINT label_len = 0;
+  SQLLEN data_type = 0;
+  SQLLEN display_size = 0;
+  SQLLEN prec_scale = 0;
   SQLLEN length = 0;
   SQLLEN size = 0;
   SQLLEN scale = 0;
   SQLLEN nullability = 0;
   SQLLEN searchable = 0;
-  SQLLEN unsignedCol = 0;
+  SQLLEN unsigned_col = 0;
 
   SQLRETURN ret = SQLColAttributes(stmt, idx, SQL_COLUMN_NAME, &name[0],
-                                   (SQLSMALLINT)name.size(), &nameLen, 0);
+                                   (SQLSMALLINT)name.size(), &name_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_LABEL, &label[0],
-                         (SQLSMALLINT)label.size(), &labelLen, 0);
+                         (SQLSMALLINT)label.size(), &label_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttributes(stmt, idx, SQL_COLUMN_TYPE, 0, 0, 0, &dataType);
+  ret = SQLColAttributes(stmt, idx, SQL_COLUMN_TYPE, 0, 0, 0, &data_type);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttributes(stmt, idx, SQL_COLUMN_DISPLAY_SIZE, 0, 0, 0, &displaySize);
+  ret = SQLColAttributes(stmt, idx, SQL_COLUMN_DISPLAY_SIZE, 0, 0, 0, &display_size);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttribute(stmt, idx, SQL_COLUMN_MONEY, 0, 0, 0, &precScale);
+  ret = SQLColAttribute(stmt, idx, SQL_COLUMN_MONEY, 0, 0, 0, &prec_scale);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_LENGTH, 0, 0, 0, &length);
@@ -265,27 +275,27 @@ void checkSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_SEARCHABLE, 0, 0, 0, &searchable);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLColAttributes(stmt, idx, SQL_COLUMN_UNSIGNED, 0, 0, 0, &unsignedCol);
+  ret = SQLColAttributes(stmt, idx, SQL_COLUMN_UNSIGNED, 0, 0, 0, &unsigned_col);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  std::wstring nameStr = ConvertToWString(name, nameLen);
-  std::wstring labelStr = ConvertToWString(label, labelLen);
+  std::wstring name_str = ConvertToWString(name, name_len);
+  std::wstring label_str = ConvertToWString(label, label_len);
 
-  EXPECT_EQ(nameStr, expectedColmnName);
-  EXPECT_EQ(labelStr, expectedColmnName);
-  EXPECT_EQ(dataType, expectedDataType);
-  EXPECT_EQ(displaySize, expectedDisplaySize);
-  EXPECT_EQ(length, expectedLength);
-  EXPECT_EQ(size, expectedColumnSize);
-  EXPECT_EQ(scale, expectedColumnScale);
-  EXPECT_EQ(nullability, expectedColumnNullability);
-  EXPECT_EQ(searchable, expectedSearchable);
-  EXPECT_EQ(unsignedCol, expectedUnsignedColumn);
+  EXPECT_EQ(name_str, expected_column_name);
+  EXPECT_EQ(label_str, expected_column_name);
+  EXPECT_EQ(data_type, expected_data_type);
+  EXPECT_EQ(display_size, expected_display_size);
+  EXPECT_EQ(length, expected_length);
+  EXPECT_EQ(size, expected_column_size);
+  EXPECT_EQ(scale, expected_column_scale);
+  EXPECT_EQ(nullability, expected_column_nullability);
+  EXPECT_EQ(searchable, expected_searchable);
+  EXPECT_EQ(unsigned_col, expected_unsigned_column);
 }
 
-void checkSQLColAttributeString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMALLINT idx,
-                                SQLUSMALLINT fieldIdentifier,
-                                const std::wstring& expectedAttrString) {
+void CheckSQLColAttributeString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMALLINT idx,
+                                SQLUSMALLINT field_identifier,
+                                const std::wstring& expected_attr_string) {
   SQLRETURN ret;
   if (!wsql.empty()) {
     // Execute query
@@ -298,20 +308,20 @@ void checkSQLColAttributeString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMA
   }
 
   // check SQLColAttribute string attribute
-  std::vector<SQLWCHAR> strVal(ODBC_BUFFER_SIZE);
-  SQLSMALLINT strLen = 0;
+  std::vector<SQLWCHAR> str_val(ODBC_BUFFER_SIZE);
+  SQLSMALLINT str_len = 0;
 
-  ret = SQLColAttribute(stmt, idx, fieldIdentifier, &strVal[0],
-                        (SQLSMALLINT)strVal.size(), &strLen, 0);
+  ret = SQLColAttribute(stmt, idx, field_identifier, &str_val[0],
+                        (SQLSMALLINT)str_val.size(), &str_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  std::wstring attrStr = ConvertToWString(strVal, strLen);
-  EXPECT_EQ(attrStr, expectedAttrString);
+  std::wstring attr_str = ConvertToWString(str_val, str_len);
+  EXPECT_EQ(attr_str, expected_attr_string);
 }
 
-void checkSQLColAttributeNumeric(SQLHSTMT stmt, const std::wstring& wsql,
-                                 SQLUSMALLINT idx, SQLUSMALLINT fieldIdentifier,
-                                 SQLLEN expectedAttrNumeric) {
+void CheckSQLColAttributeNumeric(SQLHSTMT stmt, const std::wstring& wsql,
+                                 SQLUSMALLINT idx, SQLUSMALLINT field_identifier,
+                                 SQLLEN expected_attr_numeric) {
   // Execute query and check SQLColAttribute numeric attribute
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
   SQLRETURN ret = SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
@@ -320,16 +330,16 @@ void checkSQLColAttributeNumeric(SQLHSTMT stmt, const std::wstring& wsql,
   ret = SQLFetch(stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  SQLLEN numVal = 0;
-  ret = SQLColAttribute(stmt, idx, fieldIdentifier, 0, 0, 0, &numVal);
+  SQLLEN num_val = 0;
+  ret = SQLColAttribute(stmt, idx, field_identifier, 0, 0, 0, &num_val);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(numVal, expectedAttrNumeric);
+  EXPECT_EQ(num_val, expected_attr_numeric);
 }
 
-void checkSQLColAttributesString(SQLHSTMT stmt, const std::wstring& wsql,
-                                 SQLUSMALLINT idx, SQLUSMALLINT fieldIdentifier,
-                                 const std::wstring& expectedAttrString) {
+void CheckSQLColAttributesString(SQLHSTMT stmt, const std::wstring& wsql,
+                                 SQLUSMALLINT idx, SQLUSMALLINT field_identifier,
+                                 const std::wstring& expected_attr_string) {
   SQLRETURN ret;
   if (!wsql.empty()) {
     // Execute query
@@ -342,20 +352,20 @@ void checkSQLColAttributesString(SQLHSTMT stmt, const std::wstring& wsql,
   }
 
   // check ODBC 2.0 API SQLColAttributes string attribute
-  std::vector<SQLWCHAR> strVal(ODBC_BUFFER_SIZE);
-  SQLSMALLINT strLen = 0;
+  std::vector<SQLWCHAR> str_val(ODBC_BUFFER_SIZE);
+  SQLSMALLINT str_len = 0;
 
-  ret = SQLColAttributes(stmt, idx, fieldIdentifier, &strVal[0],
-                         (SQLSMALLINT)strVal.size(), &strLen, 0);
+  ret = SQLColAttributes(stmt, idx, field_identifier, &str_val[0],
+                         (SQLSMALLINT)str_val.size(), &str_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  std::wstring attrStr = ConvertToWString(strVal, strLen);
-  EXPECT_EQ(attrStr, expectedAttrString);
+  std::wstring attrStr = ConvertToWString(str_val, str_len);
+  EXPECT_EQ(attrStr, expected_attr_string);
 }
 
-void checkSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql,
-                                  SQLUSMALLINT idx, SQLUSMALLINT fieldIdentifier,
-                                  SQLLEN expectedAttrNumeric) {
+void CheckSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql,
+                                  SQLUSMALLINT idx, SQLUSMALLINT field_identifier,
+                                  SQLLEN expected_attr_numeric) {
   // Execute query and check ODBC 2.0 API SQLColAttributes numeric attribute
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
   SQLRETURN ret = SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
@@ -364,41 +374,41 @@ void checkSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql,
   ret = SQLFetch(stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  SQLLEN numVal = 0;
-  ret = SQLColAttributes(stmt, idx, fieldIdentifier, 0, 0, 0, &numVal);
+  SQLLEN num_val = 0;
+  ret = SQLColAttributes(stmt, idx, field_identifier, 0, 0, 0, &num_val);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(numVal, expectedAttrNumeric);
+  EXPECT_EQ(num_val, expected_attr_numeric);
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsTestInputData) {
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR catalogName[] = L"";
-  SQLWCHAR schemaName[] = L"";
-  SQLWCHAR tableName[] = L"";
-  SQLWCHAR columnName[] = L"";
+  SQLWCHAR catalog_name[] = L"";
+  SQLWCHAR schema_name[] = L"";
+  SQLWCHAR table_name[] = L"";
+  SQLWCHAR column_name[] = L"";
 
   // All values populated
-  SQLRETURN ret = SQLColumns(this->stmt, catalogName, sizeof(catalogName), schemaName,
-                             sizeof(schemaName), tableName, sizeof(tableName), columnName,
-                             sizeof(columnName));
+  SQLRETURN ret = SQLColumns(this->stmt, catalog_name, sizeof(catalog_name), schema_name,
+                             sizeof(schema_name), table_name, sizeof(table_name),
+                             column_name, sizeof(column_name));
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
   // Sizes are nulls
-  ret =
-      SQLColumns(this->stmt, catalogName, 0, schemaName, 0, tableName, 0, columnName, 0);
+  ret = SQLColumns(this->stmt, catalog_name, 0, schema_name, 0, table_name, 0,
+                   column_name, 0);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
   // Values are nulls
-  ret = SQLColumns(this->stmt, 0, sizeof(catalogName), 0, sizeof(schemaName), 0,
-                   sizeof(tableName), 0, sizeof(columnName));
+  ret = SQLColumns(this->stmt, 0, sizeof(catalog_name), 0, sizeof(schema_name), 0,
+                   sizeof(table_name), 0, sizeof(column_name));
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -413,19 +423,19 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsTestInputData) {
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
   // Check table pattern and column pattern returns all columns
-  this->connect();
+  this->Connect();
 
   // Attempt to get all columns
-  SQLWCHAR tablePattern[] = L"%";
-  SQLWCHAR columnPattern[] = L"%";
+  SQLWCHAR table_pattern[] = L"%";
+  SQLWCHAR column_pattern[] = L"%";
 
-  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, tablePattern,
-                             SQL_NTS, columnPattern, SQL_NTS);
+  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                             table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -437,152 +447,152 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
   // DECIMAL_DIGITS should be 0 for bigint type since it is exact
   // mock limitation: SQLite mock server returns 10 for bigint decimal digits when spec
   // indicates should be 0
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),          // expectedCatalog
-                      std::wstring(L"foreignTable"),  // expectedTable
-                      std::wstring(L"id"),            // expectedColumn
-                      SQL_BIGINT,                     // expectedDataType
-                      std::wstring(L"BIGINT"),        // expectedTypeName
-                      10,  // expectedColumnSize (mock returns 10 instead of 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock returns 15 instead of 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      1,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),          // expected_catalog
+                      std::wstring(L"foreignTable"),  // expected_table
+                      std::wstring(L"id"),            // expected_column
+                      SQL_BIGINT,                     // expected_data_type
+                      std::wstring(L"BIGINT"),        // expected_type_name
+                      10,  // expected_column_size (mock returns 10 instead of 19)
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock returns 15 instead of 0)
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      1,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),          // expectedCatalog
-                      std::wstring(L"foreignTable"),  // expectedTable
-                      std::wstring(L"foreignName"),   // expectedColumn
-                      SQL_WVARCHAR,                   // expectedDataType
-                      std::wstring(L"WVARCHAR"),      // expectedTypeName
-                      0,   // expectedColumnSize (mock server limitation: returns 0 for
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),          // expected_catalog
+                      std::wstring(L"foreignTable"),  // expected_table
+                      std::wstring(L"foreignName"),   // expected_column
+                      SQL_WVARCHAR,                   // expected_data_type
+                      std::wstring(L"WVARCHAR"),      // expected_type_name
+                      0,   // expected_column_size (mock server limitation: returns 0 for
                            // varchar(100), the ODBC spec expects 100)
-                      0,   // expectedBufferLength
-                      15,  // expectedDecimalDigits
-                      0,   // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_WVARCHAR,           // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      0,                      // expectedOctetCharLength
-                      2,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+                      0,   // expected_buffer_length
+                      15,  // expected_decimal_digits
+                      0,   // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_WVARCHAR,           // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_octet_char_length
+                      2,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),          // expectedCatalog
-                      std::wstring(L"foreignTable"),  // expectedTable
-                      std::wstring(L"value"),         // expectedColumn
-                      SQL_BIGINT,                     // expectedDataType
-                      std::wstring(L"BIGINT"),        // expectedTypeName
-                      10,  // expectedColumnSize (mock returns 10 instead of 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock returns 15 instead of 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      3,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),          // expected_catalog
+                      std::wstring(L"foreignTable"),  // expected_table
+                      std::wstring(L"value"),         // expected_column
+                      SQL_BIGINT,                     // expected_data_type
+                      std::wstring(L"BIGINT"),        // expected_type_name
+                      10,  // expected_column_size (mock returns 10 instead of 19)
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock returns 15 instead of 0)
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      3,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 4th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),      // expectedCatalog
-                      std::wstring(L"intTable"),  // expectedTable
-                      std::wstring(L"id"),        // expectedColumn
-                      SQL_BIGINT,                 // expectedDataType
-                      std::wstring(L"BIGINT"),    // expectedTypeName
-                      10,  // expectedColumnSize (mock returns 10 instead of 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock returns 15 instead of 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      1,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),      // expected_catalog
+                      std::wstring(L"intTable"),  // expected_table
+                      std::wstring(L"id"),        // expected_column
+                      SQL_BIGINT,                 // expected_data_type
+                      std::wstring(L"BIGINT"),    // expected_type_name
+                      10,  // expected_column_size (mock returns 10 instead of 19)
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock returns 15 instead of 0)
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      1,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),      // expectedCatalog
-                      std::wstring(L"intTable"),  // expectedTable
-                      std::wstring(L"keyName"),   // expectedColumn
-                      SQL_WVARCHAR,               // expectedDataType
-                      std::wstring(L"WVARCHAR"),  // expectedTypeName
-                      0,   // expectedColumnSize (mock server limitation: returns 0 for
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),      // expected_catalog
+                      std::wstring(L"intTable"),  // expected_table
+                      std::wstring(L"keyName"),   // expected_column
+                      SQL_WVARCHAR,               // expected_data_type
+                      std::wstring(L"WVARCHAR"),  // expected_type_name
+                      0,   // expected_column_size (mock server limitation: returns 0 for
                            // varchar(100), the ODBC spec expects 100)
-                      0,   // expectedBufferLength
-                      15,  // expectedDecimalDigits
-                      0,   // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_WVARCHAR,           // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      0,                      // expectedOctetCharLength
-                      2,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+                      0,   // expected_buffer_length
+                      15,  // expected_decimal_digits
+                      0,   // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_WVARCHAR,           // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_octet_char_length
+                      2,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),      // expectedCatalog
-                      std::wstring(L"intTable"),  // expectedTable
-                      std::wstring(L"value"),     // expectedColumn
-                      SQL_BIGINT,                 // expectedDataType
-                      std::wstring(L"BIGINT"),    // expectedTypeName
-                      10,  // expectedColumnSize (mock returns 10 instead of 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock returns 15 instead of 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      3,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),      // expected_catalog
+                      std::wstring(L"intTable"),  // expected_table
+                      std::wstring(L"value"),     // expected_column
+                      SQL_BIGINT,                 // expected_data_type
+                      std::wstring(L"BIGINT"),    // expected_type_name
+                      10,  // expected_column_size (mock returns 10 instead of 19)
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock returns 15 instead of 0)
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      3,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 7th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),       // expectedCatalog
-                      std::wstring(L"intTable"),   // expectedTable
-                      std::wstring(L"foreignId"),  // expectedColumn
-                      SQL_BIGINT,                  // expectedDataType
-                      std::wstring(L"BIGINT"),     // expectedTypeName
-                      10,  // expectedColumnSize (mock returns 10 instead of 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock returns 15 instead of 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      4,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),       // expected_catalog
+                      std::wstring(L"intTable"),   // expected_table
+                      std::wstring(L"foreignId"),  // expected_column
+                      SQL_BIGINT,                  // expected_data_type
+                      std::wstring(L"BIGINT"),     // expected_type_name
+                      10,  // expected_column_size (mock returns 10 instead of 19)
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock returns 15 instead of 0)
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      4,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllTypes) {
@@ -591,15 +601,15 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllTypes) {
   // octet length from column size.
 
   // Checks filtering table with table name pattern
-  this->connect();
+  this->Connect();
   this->CreateTableAllDataType();
 
   // Attempt to get all columns from AllTypesTable
-  SQLWCHAR tablePattern[] = L"AllTypesTable";
-  SQLWCHAR columnPattern[] = L"%";
+  SQLWCHAR table_pattern[] = L"AllTypesTable";
+  SQLWCHAR column_pattern[] = L"%";
 
-  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, tablePattern,
-                             SQL_NTS, columnPattern, SQL_NTS);
+  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                             table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -607,110 +617,110 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllTypes) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),           // expectedCatalog
-                      std::wstring(L"AllTypesTable"),  // expectedTable
-                      std::wstring(L"bigint_col"),     // expectedColumn
-                      SQL_BIGINT,                      // expectedDataType
-                      std::wstring(L"BIGINT"),         // expectedTypeName
-                      10,  // expectedColumnSize (mock server limitation: returns 10,
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),           // expected_catalog
+                      std::wstring(L"AllTypesTable"),  // expected_table
+                      std::wstring(L"bigint_col"),     // expected_column
+                      SQL_BIGINT,                      // expected_data_type
+                      std::wstring(L"BIGINT"),         // expected_type_name
+                      10,  // expected_column_size (mock server limitation: returns 10,
                            // the ODBC spec expects 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock server limitation: returns 15,
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock server limitation: returns 15,
                            // the ODBC spec expects 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      1,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      1,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 2nd column in AllTypesTable
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),           // expectedCatalog
-                      std::wstring(L"AllTypesTable"),  // expectedTable
-                      std::wstring(L"char_col"),       // expectedColumn
-                      SQL_WVARCHAR,                    // expectedDataType
-                      std::wstring(L"WVARCHAR"),       // expectedTypeName
-                      0,   // expectedColumnSize (mock server limitation: returns 0 for
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),           // expected_catalog
+                      std::wstring(L"AllTypesTable"),  // expected_table
+                      std::wstring(L"char_col"),       // expected_column
+                      SQL_WVARCHAR,                    // expected_data_type
+                      std::wstring(L"WVARCHAR"),       // expected_type_name
+                      0,   // expected_column_size (mock server limitation: returns 0 for
                            // varchar(100), the ODBC spec expects 100)
-                      0,   // expectedBufferLength
-                      15,  // expectedDecimalDigits
-                      0,   // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_WVARCHAR,           // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      0,                      // expectedOctetCharLength
-                      2,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+                      0,   // expected_buffer_length
+                      15,  // expected_decimal_digits
+                      0,   // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_WVARCHAR,           // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_octet_char_length
+                      2,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 3rd column in AllTypesTable
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),           // expectedCatalog
-                      std::wstring(L"AllTypesTable"),  // expectedTable
-                      std::wstring(L"varbinary_col"),  // expectedColumn
-                      SQL_BINARY,                      // expectedDataType
-                      std::wstring(L"BINARY"),         // expectedTypeName
-                      0,   // expectedColumnSize (mock server limitation: returns 0 for
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),           // expected_catalog
+                      std::wstring(L"AllTypesTable"),  // expected_table
+                      std::wstring(L"varbinary_col"),  // expected_column
+                      SQL_BINARY,                      // expected_data_type
+                      std::wstring(L"BINARY"),         // expected_type_name
+                      0,   // expected_column_size (mock server limitation: returns 0 for
                            // BLOB column, spec expects binary data limit)
-                      0,   // expectedBufferLength
-                      15,  // expectedDecimalDigits
-                      0,   // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BINARY,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      0,                      // expectedOctetCharLength
-                      3,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+                      0,   // expected_buffer_length
+                      15,  // expected_decimal_digits
+                      0,   // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BINARY,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_octet_char_length
+                      3,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 4th column in AllTypesTable
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),           // expectedCatalog
-                      std::wstring(L"AllTypesTable"),  // expectedTable
-                      std::wstring(L"double_col"),     // expectedColumn
-                      SQL_DOUBLE,                      // expectedDataType
-                      std::wstring(L"DOUBLE"),         // expectedTypeName
-                      15,                              // expectedColumnSize
-                      8,                               // expectedBufferLength
-                      15,                              // expectedDecimalDigits
-                      2,                               // expectedNumPrecRadix
-                      SQL_NULLABLE,                    // expectedNullable
-                      SQL_DOUBLE,                      // expectedSqlDataType
-                      NULL,                            // expectedDateTimeSub
-                      8,                               // expectedOctetCharLength
-                      4,                               // expectedOrdinalPosition
-                      std::wstring(L"YES"));           // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),           // expected_catalog
+                      std::wstring(L"AllTypesTable"),  // expected_table
+                      std::wstring(L"double_col"),     // expected_column
+                      SQL_DOUBLE,                      // expected_data_type
+                      std::wstring(L"DOUBLE"),         // expected_type_name
+                      15,                              // expected_column_size
+                      8,                               // expected_buffer_length
+                      15,                              // expected_decimal_digits
+                      2,                               // expected_num_prec_radix
+                      SQL_NULLABLE,                    // expected_nullable
+                      SQL_DOUBLE,                      // expected_sql_data_type
+                      NULL,                            // expected_date_time_sub
+                      8,                               // expected_octet_char_length
+                      4,                               // expected_ordinal_position
+                      std::wstring(L"YES"));           // expected_is_nullable
 
   // There should be no more column data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsUnicode) {
   // Limitation: Mock server returns incorrect values for column size for some columns.
   // For character and binary type columns, the driver calculates buffer length and char
   // octet length from column size.
-  this->connect();
+  this->Connect();
   this->CreateUnicodeTable();
 
   // Attempt to get all columns
-  SQLWCHAR tablePattern[] = L"数据";
-  SQLWCHAR columnPattern[] = L"%";
+  SQLWCHAR table_pattern[] = L"数据";
+  SQLWCHAR column_pattern[] = L"%";
 
-  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, tablePattern,
-                             SQL_NTS, columnPattern, SQL_NTS);
+  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                             table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -718,41 +728,41 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsUnicode) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),      // expectedCatalog
-                      std::wstring(L"数据"),      // expectedTable
-                      std::wstring(L"资料"),      // expectedColumn
-                      SQL_WVARCHAR,               // expectedDataType
-                      std::wstring(L"WVARCHAR"),  // expectedTypeName
-                      0,   // expectedColumnSize (mock server limitation: returns 0 for
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),      // expected_catalog
+                      std::wstring(L"数据"),      // expected_table
+                      std::wstring(L"资料"),      // expected_column
+                      SQL_WVARCHAR,               // expected_data_type
+                      std::wstring(L"WVARCHAR"),  // expected_type_name
+                      0,   // expected_column_size (mock server limitation: returns 0 for
                            // varchar(100), spec expects 100)
-                      0,   // expectedBufferLength
-                      15,  // expectedDecimalDigits
-                      0,   // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_WVARCHAR,           // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      0,                      // expectedOctetCharLength
-                      1,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+                      0,   // expected_buffer_length
+                      15,  // expected_decimal_digits
+                      0,   // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_WVARCHAR,           // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_octet_char_length
+                      1,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // There should be no more column data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
   // GH-47159: Return NUM_PREC_RADIX based on whether COLUMN_SIZE contains number of
   // digits or bits
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR tablePattern[] = L"ODBCTest";
-  SQLWCHAR columnPattern[] = L"%";
+  SQLWCHAR table_pattern[] = L"ODBCTest";
+  SQLWCHAR column_pattern[] = L"%";
 
-  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, tablePattern,
-                             SQL_NTS, columnPattern, SQL_NTS);
+  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                             table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -760,128 +770,130 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),      // expectedSchema
-                        std::wstring(L"ODBCTest"),      // expectedTable
-                        std::wstring(L"sinteger_max"),  // expectedColumn
-                        SQL_INTEGER,                    // expectedDataType
-                        std::wstring(L"INTEGER"),       // expectedTypeName
-                        32,  // expectedColumnSize (remote server returns number of bits)
-                        4,   // expectedBufferLength
-                        0,   // expectedDecimalDigits
-                        10,  // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_INTEGER,            // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        4,                      // expectedOctetCharLength
-                        1,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+  checkRemoteSQLColumns(
+      this->stmt,
+      std::wstring(L"$scratch"),      // expected_schema
+      std::wstring(L"ODBCTest"),      // expected_table
+      std::wstring(L"sinteger_max"),  // expected_column
+      SQL_INTEGER,                    // expected_data_type
+      std::wstring(L"INTEGER"),       // expected_type_name
+      32,            // expected_column_size (remote server returns number of bits)
+      4,             // expected_buffer_length
+      0,             // expected_decimal_digits
+      10,            // expected_num_prec_radix
+      SQL_NULLABLE,  // expected_nullable
+      SQL_INTEGER,   // expected_sql_data_type
+      NULL,          // expected_date_time_sub
+      4,             // expected_octet_char_length
+      1,             // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),     // expectedSchema
-                        std::wstring(L"ODBCTest"),     // expectedTable
-                        std::wstring(L"sbigint_max"),  // expectedColumn
-                        SQL_BIGINT,                    // expectedDataType
-                        std::wstring(L"BIGINT"),       // expectedTypeName
-                        64,  // expectedColumnSize (remote server returns number of bits)
-                        8,   // expectedBufferLength
-                        0,   // expectedDecimalDigits
-                        10,  // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_BIGINT,             // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        8,                      // expectedOctetCharLength
-                        2,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+  checkRemoteSQLColumns(
+      this->stmt,
+      std::wstring(L"$scratch"),     // expected_schema
+      std::wstring(L"ODBCTest"),     // expected_table
+      std::wstring(L"sbigint_max"),  // expected_column
+      SQL_BIGINT,                    // expected_data_type
+      std::wstring(L"BIGINT"),       // expected_type_name
+      64,            // expected_column_size (remote server returns number of bits)
+      8,             // expected_buffer_length
+      0,             // expected_decimal_digits
+      10,            // expected_num_prec_radix
+      SQL_NULLABLE,  // expected_nullable
+      SQL_BIGINT,    // expected_sql_data_type
+      NULL,          // expected_date_time_sub
+      8,             // expected_octet_char_length
+      2,             // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),          // expectedSchema
-                        std::wstring(L"ODBCTest"),          // expectedTable
-                        std::wstring(L"decimal_positive"),  // expectedColumn
-                        SQL_DECIMAL,                        // expectedDataType
-                        std::wstring(L"DECIMAL"),           // expectedTypeName
-                        38,                                 // expectedColumnSize
-                        19,                                 // expectedBufferLength
-                        0,                                  // expectedDecimalDigits
-                        10,                                 // expectedNumPrecRadix
-                        SQL_NULLABLE,                       // expectedNullable
-                        SQL_DECIMAL,                        // expectedSqlDataType
-                        NULL,                               // expectedDateTimeSub
-                        2,                                  // expectedOctetCharLength
-                        3,                                  // expectedOrdinalPosition
-                        std::wstring(L"YES"));              // expectedIsNullable
+                        std::wstring(L"$scratch"),          // expected_schema
+                        std::wstring(L"ODBCTest"),          // expected_table
+                        std::wstring(L"decimal_positive"),  // expected_column
+                        SQL_DECIMAL,                        // expected_data_type
+                        std::wstring(L"DECIMAL"),           // expected_type_name
+                        38,                                 // expected_column_size
+                        19,                                 // expected_buffer_length
+                        0,                                  // expected_decimal_digits
+                        10,                                 // expected_num_prec_radix
+                        SQL_NULLABLE,                       // expected_nullable
+                        SQL_DECIMAL,                        // expected_sql_data_type
+                        NULL,                               // expected_date_time_sub
+                        2,                                  // expected_octet_char_length
+                        3,                                  // expected_ordinal_position
+                        std::wstring(L"YES"));              // expected_is_nullable
 
   // Check 4th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),   // expectedSchema
-                        std::wstring(L"ODBCTest"),   // expectedTable
-                        std::wstring(L"float_max"),  // expectedColumn
-                        SQL_FLOAT,                   // expectedDataType
-                        std::wstring(L"FLOAT"),      // expectedTypeName
-                        24,  // expectedColumnSize (precision bits from IEEE 754)
-                        8,   // expectedBufferLength
-                        0,   // expectedDecimalDigits
-                        2,   // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_FLOAT,              // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        8,                      // expectedOctetCharLength
-                        4,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+                        std::wstring(L"$scratch"),   // expected_schema
+                        std::wstring(L"ODBCTest"),   // expected_table
+                        std::wstring(L"float_max"),  // expected_column
+                        SQL_FLOAT,                   // expected_data_type
+                        std::wstring(L"FLOAT"),      // expected_type_name
+                        24,  // expected_column_size (precision bits from IEEE 754)
+                        8,   // expected_buffer_length
+                        0,   // expected_decimal_digits
+                        2,   // expected_num_prec_radix
+                        SQL_NULLABLE,           // expected_nullable
+                        SQL_FLOAT,              // expected_sql_data_type
+                        NULL,                   // expected_date_time_sub
+                        8,                      // expected_octet_char_length
+                        4,                      // expected_ordinal_position
+                        std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),    // expectedSchema
-                        std::wstring(L"ODBCTest"),    // expectedTable
-                        std::wstring(L"double_max"),  // expectedColumn
-                        SQL_DOUBLE,                   // expectedDataType
-                        std::wstring(L"DOUBLE"),      // expectedTypeName
-                        53,  // expectedColumnSize (precision bits from IEEE 754)
-                        8,   // expectedBufferLength
-                        0,   // expectedDecimalDigits
-                        2,   // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_DOUBLE,             // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        8,                      // expectedOctetCharLength
-                        5,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+                        std::wstring(L"$scratch"),    // expected_schema
+                        std::wstring(L"ODBCTest"),    // expected_table
+                        std::wstring(L"double_max"),  // expected_column
+                        SQL_DOUBLE,                   // expected_data_type
+                        std::wstring(L"DOUBLE"),      // expected_type_name
+                        53,  // expected_column_size (precision bits from IEEE 754)
+                        8,   // expected_buffer_length
+                        0,   // expected_decimal_digits
+                        2,   // expected_num_prec_radix
+                        SQL_NULLABLE,           // expected_nullable
+                        SQL_DOUBLE,             // expected_sql_data_type
+                        NULL,                   // expected_date_time_sub
+                        8,                      // expected_octet_char_length
+                        5,                      // expected_ordinal_position
+                        std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),  // expectedSchema
-                        std::wstring(L"ODBCTest"),  // expectedTable
-                        std::wstring(L"bit_true"),  // expectedColumn
-                        SQL_BIT,                    // expectedDataType
-                        std::wstring(L"BOOLEAN"),   // expectedTypeName
-                        0,  // expectedColumnSize (limitation: remote server remote server
-                            // returns 0, should be 1)
-                        1,  // expectedBufferLength
-                        0,  // expectedDecimalDigits
-                        0,  // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_BIT,                // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        1,                      // expectedOctetCharLength
-                        6,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+                        std::wstring(L"$scratch"),  // expected_schema
+                        std::wstring(L"ODBCTest"),  // expected_table
+                        std::wstring(L"bit_true"),  // expected_column
+                        SQL_BIT,                    // expected_data_type
+                        std::wstring(L"BOOLEAN"),   // expected_type_name
+                        0,  // expected_column_size (limitation: remote server remote
+                            // server returns 0, should be 1)
+                        1,  // expected_buffer_length
+                        0,  // expected_decimal_digits
+                        0,  // expected_num_prec_radix
+                        SQL_NULLABLE,           // expected_nullable
+                        SQL_BIT,                // expected_sql_data_type
+                        NULL,                   // expected_date_time_sub
+                        1,                      // expected_octet_char_length
+                        6,                      // expected_ordinal_position
+                        std::wstring(L"YES"));  // expected_is_nullable
 
   // ODBC ver 3 returns SQL_TYPE_DATE, SQL_TYPE_TIME, and SQL_TYPE_TIMESTAMP in the
   // DATA_TYPE field
@@ -892,21 +904,21 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   checkRemoteSQLColumns(
       this->stmt,
-      std::wstring(L"$scratch"),  // expectedSchema
-      std::wstring(L"ODBCTest"),  // expectedTable
-      std::wstring(L"date_max"),  // expectedColumn
-      SQL_TYPE_DATE,              // expectedDataType
-      std::wstring(L"DATE"),      // expectedTypeName
-      0,   // expectedColumnSize (limitation: remote server returns 0, should be 10)
-      10,  // expectedBufferLength
-      0,   // expectedDecimalDigits
-      0,   // expectedNumPrecRadix
-      SQL_NULLABLE,           // expectedNullable
-      SQL_DATETIME,           // expectedSqlDataType
-      SQL_CODE_DATE,          // expectedDateTimeSub
-      6,                      // expectedOctetCharLength
-      7,                      // expectedOrdinalPosition
-      std::wstring(L"YES"));  // expectedIsNullable
+      std::wstring(L"$scratch"),  // expected_schema
+      std::wstring(L"ODBCTest"),  // expected_table
+      std::wstring(L"date_max"),  // expected_column
+      SQL_TYPE_DATE,              // expected_data_type
+      std::wstring(L"DATE"),      // expected_type_name
+      0,   // expected_column_size (limitation: remote server returns 0, should be 10)
+      10,  // expected_buffer_length
+      0,   // expected_decimal_digits
+      0,   // expected_num_prec_radix
+      SQL_NULLABLE,           // expected_nullable
+      SQL_DATETIME,           // expected_sql_data_type
+      SQL_CODE_DATE,          // expected_date_time_sub
+      6,                      // expected_octet_char_length
+      7,                      // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 8th Column
   ret = SQLFetch(this->stmt);
@@ -914,21 +926,21 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   checkRemoteSQLColumns(
       this->stmt,
-      std::wstring(L"$scratch"),  // expectedSchema
-      std::wstring(L"ODBCTest"),  // expectedTable
-      std::wstring(L"time_max"),  // expectedColumn
-      SQL_TYPE_TIME,              // expectedDataType
-      std::wstring(L"TIME"),      // expectedTypeName
-      3,              // expectedColumnSize (limitation: should be 9+fractional digits)
-      12,             // expectedBufferLength
-      0,              // expectedDecimalDigits
-      0,              // expectedNumPrecRadix
-      SQL_NULLABLE,   // expectedNullable
-      SQL_DATETIME,   // expectedSqlDataType
-      SQL_CODE_TIME,  // expectedDateTimeSub
-      6,              // expectedOctetCharLength
-      8,              // expectedOrdinalPosition
-      std::wstring(L"YES"));  // expectedIsNullable
+      std::wstring(L"$scratch"),  // expected_schema
+      std::wstring(L"ODBCTest"),  // expected_table
+      std::wstring(L"time_max"),  // expected_column
+      SQL_TYPE_TIME,              // expected_data_type
+      std::wstring(L"TIME"),      // expected_type_name
+      3,              // expected_column_size (limitation: should be 9+fractional digits)
+      12,             // expected_buffer_length
+      0,              // expected_decimal_digits
+      0,              // expected_num_prec_radix
+      SQL_NULLABLE,   // expected_nullable
+      SQL_DATETIME,   // expected_sql_data_type
+      SQL_CODE_TIME,  // expected_date_time_sub
+      6,              // expected_octet_char_length
+      8,              // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 9th Column
   ret = SQLFetch(this->stmt);
@@ -936,39 +948,39 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   checkRemoteSQLColumns(
       this->stmt,
-      std::wstring(L"$scratch"),       // expectedSchema
-      std::wstring(L"ODBCTest"),       // expectedTable
-      std::wstring(L"timestamp_max"),  // expectedColumn
-      SQL_TYPE_TIMESTAMP,              // expectedDataType
-      std::wstring(L"TIMESTAMP"),      // expectedTypeName
-      3,             // expectedColumnSize (limitation: should be 20+fractional digits)
-      23,            // expectedBufferLength
-      0,             // expectedDecimalDigits
-      0,             // expectedNumPrecRadix
-      SQL_NULLABLE,  // expectedNullable
-      SQL_DATETIME,  // expectedSqlDataType
-      SQL_CODE_TIMESTAMP,     // expectedDateTimeSub
-      16,                     // expectedOctetCharLength
-      9,                      // expectedOrdinalPosition
-      std::wstring(L"YES"));  // expectedIsNullable
+      std::wstring(L"$scratch"),       // expected_schema
+      std::wstring(L"ODBCTest"),       // expected_table
+      std::wstring(L"timestamp_max"),  // expected_column
+      SQL_TYPE_TIMESTAMP,              // expected_data_type
+      std::wstring(L"TIMESTAMP"),      // expected_type_name
+      3,             // expected_column_size (limitation: should be 20+fractional digits)
+      23,            // expected_buffer_length
+      0,             // expected_decimal_digits
+      0,             // expected_num_prec_radix
+      SQL_NULLABLE,  // expected_nullable
+      SQL_DATETIME,  // expected_sql_data_type
+      SQL_CODE_TIMESTAMP,     // expected_date_time_sub
+      16,                     // expected_octet_char_length
+      9,                      // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
   // GH-47159: Return NUM_PREC_RADIX based on whether COLUMN_SIZE contains number of
   // digits or bits
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
-  SQLWCHAR tablePattern[] = L"ODBCTest";
-  SQLWCHAR columnPattern[] = L"%";
+  SQLWCHAR table_pattern[] = L"ODBCTest";
+  SQLWCHAR column_pattern[] = L"%";
 
-  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, tablePattern,
-                             SQL_NTS, columnPattern, SQL_NTS);
+  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                             table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -976,128 +988,130 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),      // expectedSchema
-                        std::wstring(L"ODBCTest"),      // expectedTable
-                        std::wstring(L"sinteger_max"),  // expectedColumn
-                        SQL_INTEGER,                    // expectedDataType
-                        std::wstring(L"INTEGER"),       // expectedTypeName
-                        32,  // expectedColumnSize (remote server returns number of bits)
-                        4,   // expectedBufferLength
-                        0,   // expectedDecimalDigits
-                        10,  // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_INTEGER,            // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        4,                      // expectedOctetCharLength
-                        1,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+  checkRemoteSQLColumns(
+      this->stmt,
+      std::wstring(L"$scratch"),      // expected_schema
+      std::wstring(L"ODBCTest"),      // expected_table
+      std::wstring(L"sinteger_max"),  // expected_column
+      SQL_INTEGER,                    // expected_data_type
+      std::wstring(L"INTEGER"),       // expected_type_name
+      32,            // expected_column_size (remote server returns number of bits)
+      4,             // expected_buffer_length
+      0,             // expected_decimal_digits
+      10,            // expected_num_prec_radix
+      SQL_NULLABLE,  // expected_nullable
+      SQL_INTEGER,   // expected_sql_data_type
+      NULL,          // expected_date_time_sub
+      4,             // expected_octet_char_length
+      1,             // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),     // expectedSchema
-                        std::wstring(L"ODBCTest"),     // expectedTable
-                        std::wstring(L"sbigint_max"),  // expectedColumn
-                        SQL_BIGINT,                    // expectedDataType
-                        std::wstring(L"BIGINT"),       // expectedTypeName
-                        64,  // expectedColumnSize (remote server returns number of bits)
-                        8,   // expectedBufferLength
-                        0,   // expectedDecimalDigits
-                        10,  // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_BIGINT,             // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        8,                      // expectedOctetCharLength
-                        2,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+  checkRemoteSQLColumns(
+      this->stmt,
+      std::wstring(L"$scratch"),     // expected_schema
+      std::wstring(L"ODBCTest"),     // expected_table
+      std::wstring(L"sbigint_max"),  // expected_column
+      SQL_BIGINT,                    // expected_data_type
+      std::wstring(L"BIGINT"),       // expected_type_name
+      64,            // expected_column_size (remote server returns number of bits)
+      8,             // expected_buffer_length
+      0,             // expected_decimal_digits
+      10,            // expected_num_prec_radix
+      SQL_NULLABLE,  // expected_nullable
+      SQL_BIGINT,    // expected_sql_data_type
+      NULL,          // expected_date_time_sub
+      8,             // expected_octet_char_length
+      2,             // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),          // expectedSchema
-                        std::wstring(L"ODBCTest"),          // expectedTable
-                        std::wstring(L"decimal_positive"),  // expectedColumn
-                        SQL_DECIMAL,                        // expectedDataType
-                        std::wstring(L"DECIMAL"),           // expectedTypeName
-                        38,                                 // expectedColumnSize
-                        19,                                 // expectedBufferLength
-                        0,                                  // expectedDecimalDigits
-                        10,                                 // expectedNumPrecRadix
-                        SQL_NULLABLE,                       // expectedNullable
-                        SQL_DECIMAL,                        // expectedSqlDataType
-                        NULL,                               // expectedDateTimeSub
-                        2,                                  // expectedOctetCharLength
-                        3,                                  // expectedOrdinalPosition
-                        std::wstring(L"YES"));              // expectedIsNullable
+                        std::wstring(L"$scratch"),          // expected_schema
+                        std::wstring(L"ODBCTest"),          // expected_table
+                        std::wstring(L"decimal_positive"),  // expected_column
+                        SQL_DECIMAL,                        // expected_data_type
+                        std::wstring(L"DECIMAL"),           // expected_type_name
+                        38,                                 // expected_column_size
+                        19,                                 // expected_buffer_length
+                        0,                                  // expected_decimal_digits
+                        10,                                 // expected_num_prec_radix
+                        SQL_NULLABLE,                       // expected_nullable
+                        SQL_DECIMAL,                        // expected_sql_data_type
+                        NULL,                               // expected_date_time_sub
+                        2,                                  // expected_octet_char_length
+                        3,                                  // expected_ordinal_position
+                        std::wstring(L"YES"));              // expected_is_nullable
 
   // Check 4th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),   // expectedSchema
-                        std::wstring(L"ODBCTest"),   // expectedTable
-                        std::wstring(L"float_max"),  // expectedColumn
-                        SQL_FLOAT,                   // expectedDataType
-                        std::wstring(L"FLOAT"),      // expectedTypeName
-                        24,  // expectedColumnSize (precision bits from IEEE 754)
-                        8,   // expectedBufferLength
-                        0,   // expectedDecimalDigits
-                        2,   // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_FLOAT,              // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        8,                      // expectedOctetCharLength
-                        4,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+                        std::wstring(L"$scratch"),   // expected_schema
+                        std::wstring(L"ODBCTest"),   // expected_table
+                        std::wstring(L"float_max"),  // expected_column
+                        SQL_FLOAT,                   // expected_data_type
+                        std::wstring(L"FLOAT"),      // expected_type_name
+                        24,  // expected_column_size (precision bits from IEEE 754)
+                        8,   // expected_buffer_length
+                        0,   // expected_decimal_digits
+                        2,   // expected_num_prec_radix
+                        SQL_NULLABLE,           // expected_nullable
+                        SQL_FLOAT,              // expected_sql_data_type
+                        NULL,                   // expected_date_time_sub
+                        8,                      // expected_octet_char_length
+                        4,                      // expected_ordinal_position
+                        std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),    // expectedSchema
-                        std::wstring(L"ODBCTest"),    // expectedTable
-                        std::wstring(L"double_max"),  // expectedColumn
-                        SQL_DOUBLE,                   // expectedDataType
-                        std::wstring(L"DOUBLE"),      // expectedTypeName
-                        53,  // expectedColumnSize (precision bits from IEEE 754)
-                        8,   // expectedBufferLength
-                        0,   // expectedDecimalDigits
-                        2,   // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_DOUBLE,             // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        8,                      // expectedOctetCharLength
-                        5,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+                        std::wstring(L"$scratch"),    // expected_schema
+                        std::wstring(L"ODBCTest"),    // expected_table
+                        std::wstring(L"double_max"),  // expected_column
+                        SQL_DOUBLE,                   // expected_data_type
+                        std::wstring(L"DOUBLE"),      // expected_type_name
+                        53,  // expected_column_size (precision bits from IEEE 754)
+                        8,   // expected_buffer_length
+                        0,   // expected_decimal_digits
+                        2,   // expected_num_prec_radix
+                        SQL_NULLABLE,           // expected_nullable
+                        SQL_DOUBLE,             // expected_sql_data_type
+                        NULL,                   // expected_date_time_sub
+                        8,                      // expected_octet_char_length
+                        5,                      // expected_ordinal_position
+                        std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   checkRemoteSQLColumns(this->stmt,
-                        std::wstring(L"$scratch"),  // expectedSchema
-                        std::wstring(L"ODBCTest"),  // expectedTable
-                        std::wstring(L"bit_true"),  // expectedColumn
-                        SQL_BIT,                    // expectedDataType
-                        std::wstring(L"BOOLEAN"),   // expectedTypeName
-                        0,  // expectedColumnSize (limitation: remote server remote server
-                            // returns 0, should be 1)
-                        1,  // expectedBufferLength
-                        0,  // expectedDecimalDigits
-                        0,  // expectedNumPrecRadix
-                        SQL_NULLABLE,           // expectedNullable
-                        SQL_BIT,                // expectedSqlDataType
-                        NULL,                   // expectedDateTimeSub
-                        1,                      // expectedOctetCharLength
-                        6,                      // expectedOrdinalPosition
-                        std::wstring(L"YES"));  // expectedIsNullable
+                        std::wstring(L"$scratch"),  // expected_schema
+                        std::wstring(L"ODBCTest"),  // expected_table
+                        std::wstring(L"bit_true"),  // expected_column
+                        SQL_BIT,                    // expected_data_type
+                        std::wstring(L"BOOLEAN"),   // expected_type_name
+                        0,  // expected_column_size (limitation: remote server remote
+                            // server returns 0, should be 1)
+                        1,  // expected_buffer_length
+                        0,  // expected_decimal_digits
+                        0,  // expected_num_prec_radix
+                        SQL_NULLABLE,           // expected_nullable
+                        SQL_BIT,                // expected_sql_data_type
+                        NULL,                   // expected_date_time_sub
+                        1,                      // expected_octet_char_length
+                        6,                      // expected_ordinal_position
+                        std::wstring(L"YES"));  // expected_is_nullable
 
   // ODBC ver 2 returns SQL_DATE, SQL_TIME, and SQL_TIMESTAMP in the DATA_TYPE field
 
@@ -1107,21 +1121,21 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   checkRemoteSQLColumns(
       this->stmt,
-      std::wstring(L"$scratch"),  // expectedSchema
-      std::wstring(L"ODBCTest"),  // expectedTable
-      std::wstring(L"date_max"),  // expectedColumn
-      SQL_DATE,                   // expectedDataType
-      std::wstring(L"DATE"),      // expectedTypeName
-      0,   // expectedColumnSize (limitation: remote server returns 0, should be 10)
-      10,  // expectedBufferLength
-      0,   // expectedDecimalDigits
-      0,   // expectedNumPrecRadix
-      SQL_NULLABLE,           // expectedNullable
-      SQL_DATETIME,           // expectedSqlDataType
-      SQL_CODE_DATE,          // expectedDateTimeSub
-      6,                      // expectedOctetCharLength
-      7,                      // expectedOrdinalPosition
-      std::wstring(L"YES"));  // expectedIsNullable
+      std::wstring(L"$scratch"),  // expected_schema
+      std::wstring(L"ODBCTest"),  // expected_table
+      std::wstring(L"date_max"),  // expected_column
+      SQL_DATE,                   // expected_data_type
+      std::wstring(L"DATE"),      // expected_type_name
+      0,   // expected_column_size (limitation: remote server returns 0, should be 10)
+      10,  // expected_buffer_length
+      0,   // expected_decimal_digits
+      0,   // expected_num_prec_radix
+      SQL_NULLABLE,           // expected_nullable
+      SQL_DATETIME,           // expected_sql_data_type
+      SQL_CODE_DATE,          // expected_date_time_sub
+      6,                      // expected_octet_char_length
+      7,                      // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 8th Column
   ret = SQLFetch(this->stmt);
@@ -1129,21 +1143,21 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   checkRemoteSQLColumns(
       this->stmt,
-      std::wstring(L"$scratch"),  // expectedSchema
-      std::wstring(L"ODBCTest"),  // expectedTable
-      std::wstring(L"time_max"),  // expectedColumn
-      SQL_TIME,                   // expectedDataType
-      std::wstring(L"TIME"),      // expectedTypeName
-      3,              // expectedColumnSize (limitation: should be 9+fractional digits)
-      12,             // expectedBufferLength
-      0,              // expectedDecimalDigits
-      0,              // expectedNumPrecRadix
-      SQL_NULLABLE,   // expectedNullable
-      SQL_DATETIME,   // expectedSqlDataType
-      SQL_CODE_TIME,  // expectedDateTimeSub
-      6,              // expectedOctetCharLength
-      8,              // expectedOrdinalPosition
-      std::wstring(L"YES"));  // expectedIsNullable
+      std::wstring(L"$scratch"),  // expected_schema
+      std::wstring(L"ODBCTest"),  // expected_table
+      std::wstring(L"time_max"),  // expected_column
+      SQL_TIME,                   // expected_data_type
+      std::wstring(L"TIME"),      // expected_type_name
+      3,              // expected_column_size (limitation: should be 9+fractional digits)
+      12,             // expected_buffer_length
+      0,              // expected_decimal_digits
+      0,              // expected_num_prec_radix
+      SQL_NULLABLE,   // expected_nullable
+      SQL_DATETIME,   // expected_sql_data_type
+      SQL_CODE_TIME,  // expected_date_time_sub
+      6,              // expected_octet_char_length
+      8,              // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 9th Column
   ret = SQLFetch(this->stmt);
@@ -1151,39 +1165,39 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   checkRemoteSQLColumns(
       this->stmt,
-      std::wstring(L"$scratch"),       // expectedSchema
-      std::wstring(L"ODBCTest"),       // expectedTable
-      std::wstring(L"timestamp_max"),  // expectedColumn
-      SQL_TIMESTAMP,                   // expectedDataType
-      std::wstring(L"TIMESTAMP"),      // expectedTypeName
-      3,             // expectedColumnSize (limitation: should be 20+fractional digits)
-      23,            // expectedBufferLength
-      0,             // expectedDecimalDigits
-      0,             // expectedNumPrecRadix
-      SQL_NULLABLE,  // expectedNullable
-      SQL_DATETIME,  // expectedSqlDataType
-      SQL_CODE_TIMESTAMP,     // expectedDateTimeSub
-      16,                     // expectedOctetCharLength
-      9,                      // expectedOrdinalPosition
-      std::wstring(L"YES"));  // expectedIsNullable
+      std::wstring(L"$scratch"),       // expected_schema
+      std::wstring(L"ODBCTest"),       // expected_table
+      std::wstring(L"timestamp_max"),  // expected_column
+      SQL_TIMESTAMP,                   // expected_data_type
+      std::wstring(L"TIMESTAMP"),      // expected_type_name
+      3,             // expected_column_size (limitation: should be 20+fractional digits)
+      23,            // expected_buffer_length
+      0,             // expected_decimal_digits
+      0,             // expected_num_prec_radix
+      SQL_NULLABLE,  // expected_nullable
+      SQL_DATETIME,  // expected_sql_data_type
+      SQL_CODE_TIMESTAMP,     // expected_date_time_sub
+      16,                     // expected_octet_char_length
+      9,                      // expected_ordinal_position
+      std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsColumnPattern) {
+TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnscolumn_pattern) {
   // Checks filtering table with column name pattern.
   // Only check table and column name
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR tablePattern[] = L"%";
-  SQLWCHAR columnPattern[] = L"id";
+  SQLWCHAR table_pattern[] = L"%";
+  SQLWCHAR column_pattern[] = L"id";
 
-  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, tablePattern,
-                             SQL_NTS, columnPattern, SQL_NTS);
+  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                             table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -1191,61 +1205,61 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsColumnPattern) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),          // expectedCatalog
-                      std::wstring(L"foreignTable"),  // expectedTable
-                      std::wstring(L"id"),            // expectedColumn
-                      SQL_BIGINT,                     // expectedDataType
-                      std::wstring(L"BIGINT"),        // expectedTypeName
-                      10,  // expectedColumnSize (mock returns 10 instead of 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock returns 15 instead of 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      1,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),          // expected_catalog
+                      std::wstring(L"foreignTable"),  // expected_table
+                      std::wstring(L"id"),            // expected_column
+                      SQL_BIGINT,                     // expected_data_type
+                      std::wstring(L"BIGINT"),        // expected_type_name
+                      10,  // expected_column_size (mock returns 10 instead of 19)
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock returns 15 instead of 0)
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      1,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),      // expectedCatalog
-                      std::wstring(L"intTable"),  // expectedTable
-                      std::wstring(L"id"),        // expectedColumn
-                      SQL_BIGINT,                 // expectedDataType
-                      std::wstring(L"BIGINT"),    // expectedTypeName
-                      10,  // expectedColumnSize (mock returns 10 instead of 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock returns 15 instead of 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      1,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),      // expected_catalog
+                      std::wstring(L"intTable"),  // expected_table
+                      std::wstring(L"id"),        // expected_column
+                      SQL_BIGINT,                 // expected_data_type
+                      std::wstring(L"BIGINT"),    // expected_type_name
+                      10,  // expected_column_size (mock returns 10 instead of 19)
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock returns 15 instead of 0)
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      1,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsTableColumnPattern) {
+TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsTablecolumn_pattern) {
   // Checks filtering table with table and column name pattern.
   // Only check table and column name
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR tablePattern[] = L"foreignTable";
-  SQLWCHAR columnPattern[] = L"id";
+  SQLWCHAR table_pattern[] = L"foreignTable";
+  SQLWCHAR column_pattern[] = L"id";
 
-  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, tablePattern,
-                             SQL_NTS, columnPattern, SQL_NTS);
+  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                             table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -1253,38 +1267,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsTableColumnPattern) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkMockSQLColumns(this->stmt,
-                      std::wstring(L"main"),          // expectedCatalog
-                      std::wstring(L"foreignTable"),  // expectedTable
-                      std::wstring(L"id"),            // expectedColumn
-                      SQL_BIGINT,                     // expectedDataType
-                      std::wstring(L"BIGINT"),        // expectedTypeName
-                      10,  // expectedColumnSize (mock returns 10 instead of 19)
-                      8,   // expectedBufferLength
-                      15,  // expectedDecimalDigits (mock returns 15 instead of 0)
-                      10,  // expectedNumPrecRadix
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_BIGINT,             // expectedSqlDataType
-                      NULL,                   // expectedDateTimeSub
-                      8,                      // expectedOctetCharLength
-                      1,                      // expectedOrdinalPosition
-                      std::wstring(L"YES"));  // expectedIsNullable
+  CheckMockSQLColumns(this->stmt,
+                      std::wstring(L"main"),          // expected_catalog
+                      std::wstring(L"foreignTable"),  // expected_table
+                      std::wstring(L"id"),            // expected_column
+                      SQL_BIGINT,                     // expected_data_type
+                      std::wstring(L"BIGINT"),        // expected_type_name
+                      10,  // expected_column_size (mock returns 10 instead of 19)
+                      8,   // expected_buffer_length
+                      15,  // expected_decimal_digits (mock returns 15 instead of 0)
+                      10,  // expected_num_prec_radix
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_BIGINT,             // expected_sql_data_type
+                      NULL,                   // expected_date_time_sub
+                      8,                      // expected_octet_char_length
+                      1,                      // expected_ordinal_position
+                      std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsInvalidTablePattern) {
-  this->connect();
+TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsInvalidtable_pattern) {
+  this->Connect();
 
-  SQLWCHAR tablePattern[] = L"non-existent-table";
-  SQLWCHAR columnPattern[] = L"%";
+  SQLWCHAR table_pattern[] = L"non-existent-table";
+  SQLWCHAR column_pattern[] = L"%";
 
-  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, tablePattern,
-                             SQL_NTS, columnPattern, SQL_NTS);
+  SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                             table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -1292,11 +1306,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsInvalidTablePattern) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeTestInputData) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1 as col1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1309,17 +1323,17 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeTestInputData) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   SQLUSMALLINT idx = 1;
-  std::vector<SQLWCHAR> characterAttr(ODBC_BUFFER_SIZE);
-  SQLSMALLINT characterAttrLen = 0;
-  SQLLEN numericAttr = 0;
+  std::vector<SQLWCHAR> character_attr(ODBC_BUFFER_SIZE);
+  SQLSMALLINT character_attr_len = 0;
+  SQLLEN numeric_attr = 0;
 
   // All character values populated
-  ret = SQLColAttribute(this->stmt, idx, SQL_DESC_NAME, &characterAttr[0],
-                        (SQLSMALLINT)characterAttr.size(), &characterAttrLen, 0);
+  ret = SQLColAttribute(this->stmt, idx, SQL_DESC_NAME, &character_attr[0],
+                        (SQLSMALLINT)character_attr.size(), &character_attr_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // All numeric values populated
-  ret = SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, 0, &numericAttr);
+  ret = SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, 0, &numeric_attr);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -1330,11 +1344,11 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeTestInputData) {
   ret = SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, 0, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeGetCharacterLen) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1 as col1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1346,20 +1360,20 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeGetCharacterLen) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  SQLSMALLINT characterAttrLen = 0;
+  SQLSMALLINT character_attr_len = 0;
 
   // Check length of character attribute
-  ret = SQLColAttribute(this->stmt, 1, SQL_DESC_BASE_COLUMN_NAME, 0, 0, &characterAttrLen,
-                        0);
+  ret = SQLColAttribute(this->stmt, 1, SQL_DESC_BASE_COLUMN_NAME, 0, 0,
+                        &character_attr_len, 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(characterAttrLen, 4 * ODBC::GetSqlWCharSize());
+  EXPECT_EQ(character_attr_len, 4 * ODBC::GetSqlWCharSize());
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeInvalidFieldId) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1 as col1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1371,23 +1385,23 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeInvalidFieldId) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  SQLUSMALLINT invalidFieldId = -100;
+  SQLUSMALLINT invalid_field_id = -100;
   SQLUSMALLINT idx = 1;
-  std::vector<SQLWCHAR> characterAttr(ODBC_BUFFER_SIZE);
-  SQLSMALLINT characterAttrLen = 0;
-  SQLLEN numericAttr = 0;
+  std::vector<SQLWCHAR> character_attr(ODBC_BUFFER_SIZE);
+  SQLSMALLINT character_attr_len = 0;
+  SQLLEN numeric_attr = 0;
 
-  ret = SQLColAttribute(this->stmt, idx, invalidFieldId, &characterAttr[0],
-                        (SQLSMALLINT)characterAttr.size(), &characterAttrLen, 0);
+  ret = SQLColAttribute(this->stmt, idx, invalid_field_id, &character_attr[0],
+                        (SQLSMALLINT)character_attr.size(), &character_attr_len, 0);
   EXPECT_EQ(ret, SQL_ERROR);
   // Verify invalid descriptor field identifier error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY091);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeInvalidColId) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1 as col1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1399,23 +1413,22 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeInvalidColId) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  SQLUSMALLINT invalidColId = 2;
-  std::vector<SQLWCHAR> characterAttr(ODBC_BUFFER_SIZE);
-  SQLSMALLINT characterAttrLen = 0;
-  SQLLEN numericAttr = 0;
+  SQLUSMALLINT invalid_col_id = 2;
+  std::vector<SQLWCHAR> character_attr(ODBC_BUFFER_SIZE);
+  SQLSMALLINT character_attr_len = 0;
 
-  ret = SQLColAttribute(this->stmt, invalidColId, SQL_DESC_BASE_COLUMN_NAME,
-                        &characterAttr[0], (SQLSMALLINT)characterAttr.size(),
-                        &characterAttrLen, 0);
+  ret = SQLColAttribute(this->stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME,
+                        &character_attr[0], (SQLSMALLINT)character_attr.size(),
+                        &character_attr_len, 0);
   EXPECT_EQ(ret, SQL_ERROR);
   // Verify invalid descriptor index error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_07009);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeAllTypes) {
-  this->connect();
+  this->Connect();
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
@@ -1428,80 +1441,80 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeAllTypes) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLColAttribute(this->stmt, 1,
-                       std::wstring(L"bigint_col"),  // expectedColmnName
-                       SQL_BIGINT,                   // expectedDataType
-                       SQL_BIGINT,                   // expectedConciseType
-                       20,                           // expectedDisplaySize
-                       SQL_FALSE,                    // expectedPrecScale
-                       8,                            // expectedLength
-                       std::wstring(L""),            // expectedLiteralPrefix
-                       std::wstring(L""),            // expectedLiteralSuffix
-                       8,                            // expectedColumnSize
-                       0,                            // expectedColumnScale
-                       SQL_NULLABLE,                 // expectedColumnNullability
-                       10,                           // expectedNumPrecRadix
-                       8,                            // expectedOctetLength
-                       SQL_PRED_NONE,                // expectedSearchable
-                       SQL_FALSE);                   // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 1,
+                       std::wstring(L"bigint_col"),  // expected_column_name
+                       SQL_BIGINT,                   // expected_data_type
+                       SQL_BIGINT,                   // expected_concise_type
+                       20,                           // expected_display_size
+                       SQL_FALSE,                    // expected_prec_scale
+                       8,                            // expected_length
+                       std::wstring(L""),            // expected_literal_prefix
+                       std::wstring(L""),            // expected_literal_suffix
+                       8,                            // expected_column_size
+                       0,                            // expected_column_scale
+                       SQL_NULLABLE,                 // expected_column_nullability
+                       10,                           // expected_num_prec_radix
+                       8,                            // expected_octet_length
+                       SQL_PRED_NONE,                // expected_searchable
+                       SQL_FALSE);                   // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 2,
-                       std::wstring(L"char_col"),  // expectedColmnName
-                       SQL_WVARCHAR,               // expectedDataType
-                       SQL_WVARCHAR,               // expectedConciseType
-                       0,                          // expectedDisplaySize
-                       SQL_FALSE,                  // expectedPrecScale
-                       0,                          // expectedLength
-                       std::wstring(L""),          // expectedLiteralPrefix
-                       std::wstring(L""),          // expectedLiteralSuffix
-                       0,                          // expectedColumnSize
-                       0,                          // expectedColumnScale
-                       SQL_NULLABLE,               // expectedColumnNullability
-                       0,                          // expectedNumPrecRadix
-                       0,                          // expectedOctetLength
-                       SQL_PRED_NONE,              // expectedSearchable
-                       SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 2,
+                       std::wstring(L"char_col"),  // expected_column_name
+                       SQL_WVARCHAR,               // expected_data_type
+                       SQL_WVARCHAR,               // expected_concise_type
+                       0,                          // expected_display_size
+                       SQL_FALSE,                  // expected_prec_scale
+                       0,                          // expected_length
+                       std::wstring(L""),          // expected_literal_prefix
+                       std::wstring(L""),          // expected_literal_suffix
+                       0,                          // expected_column_size
+                       0,                          // expected_column_scale
+                       SQL_NULLABLE,               // expected_column_nullability
+                       0,                          // expected_num_prec_radix
+                       0,                          // expected_octet_length
+                       SQL_PRED_NONE,              // expected_searchable
+                       SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 3,
-                       std::wstring(L"varbinary_col"),  // expectedColmnName
-                       SQL_BINARY,                      // expectedDataType
-                       SQL_BINARY,                      // expectedConciseType
-                       0,                               // expectedDisplaySize
-                       SQL_FALSE,                       // expectedPrecScale
-                       0,                               // expectedLength
-                       std::wstring(L""),               // expectedLiteralPrefix
-                       std::wstring(L""),               // expectedLiteralSuffix
-                       0,                               // expectedColumnSize
-                       0,                               // expectedColumnScale
-                       SQL_NULLABLE,                    // expectedColumnNullability
-                       0,                               // expectedNumPrecRadix
-                       0,                               // expectedOctetLength
-                       SQL_PRED_NONE,                   // expectedSearchable
-                       SQL_TRUE);                       // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 3,
+                       std::wstring(L"varbinary_col"),  // expected_column_name
+                       SQL_BINARY,                      // expected_data_type
+                       SQL_BINARY,                      // expected_concise_type
+                       0,                               // expected_display_size
+                       SQL_FALSE,                       // expected_prec_scale
+                       0,                               // expected_length
+                       std::wstring(L""),               // expected_literal_prefix
+                       std::wstring(L""),               // expected_literal_suffix
+                       0,                               // expected_column_size
+                       0,                               // expected_column_scale
+                       SQL_NULLABLE,                    // expected_column_nullability
+                       0,                               // expected_num_prec_radix
+                       0,                               // expected_octet_length
+                       SQL_PRED_NONE,                   // expected_searchable
+                       SQL_TRUE);                       // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 4,
-                       std::wstring(L"double_col"),  // expectedColmnName
-                       SQL_DOUBLE,                   // expectedDataType
-                       SQL_DOUBLE,                   // expectedConciseType
-                       24,                           // expectedDisplaySize
-                       SQL_FALSE,                    // expectedPrecScale
-                       8,                            // expectedLength
-                       std::wstring(L""),            // expectedLiteralPrefix
-                       std::wstring(L""),            // expectedLiteralSuffix
-                       8,                            // expectedColumnSize
-                       0,                            // expectedColumnScale
-                       SQL_NULLABLE,                 // expectedColumnNullability
-                       2,                            // expectedNumPrecRadix
-                       8,                            // expectedOctetLength
-                       SQL_PRED_NONE,                // expectedSearchable
-                       SQL_FALSE);                   // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 4,
+                       std::wstring(L"double_col"),  // expected_column_name
+                       SQL_DOUBLE,                   // expected_data_type
+                       SQL_DOUBLE,                   // expected_concise_type
+                       24,                           // expected_display_size
+                       SQL_FALSE,                    // expected_prec_scale
+                       8,                            // expected_length
+                       std::wstring(L""),            // expected_literal_prefix
+                       std::wstring(L""),            // expected_literal_suffix
+                       8,                            // expected_column_size
+                       0,                            // expected_column_scale
+                       SQL_NULLABLE,                 // expected_column_nullability
+                       2,                            // expected_num_prec_radix
+                       8,                            // expected_octet_length
+                       SQL_PRED_NONE,                // expected_searchable
+                       SQL_FALSE);                   // expected_unsigned_column
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributesAllTypesODBCVer2) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
@@ -1513,60 +1526,60 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributesAllTypesODBCVer2) {
 
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
-  checkSQLColAttributes(this->stmt, 1,
-                        std::wstring(L"bigint_col"),  // expectedColmnName
-                        SQL_BIGINT,                   // expectedDataType
-                        20,                           // expectedDisplaySize
-                        SQL_FALSE,                    // expectedPrecScale
-                        8,                            // expectedLength
-                        8,                            // expectedColumnSize
-                        0,                            // expectedColumnScale
-                        SQL_NULLABLE,                 // expectedColumnNullability
-                        SQL_PRED_NONE,                // expectedSearchable
-                        SQL_FALSE);                   // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 1,
+                        std::wstring(L"bigint_col"),  // expected_column_name
+                        SQL_BIGINT,                   // expected_data_type
+                        20,                           // expected_display_size
+                        SQL_FALSE,                    // expected_prec_scale
+                        8,                            // expected_length
+                        8,                            // expected_column_size
+                        0,                            // expected_column_scale
+                        SQL_NULLABLE,                 // expected_column_nullability
+                        SQL_PRED_NONE,                // expected_searchable
+                        SQL_FALSE);                   // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 2,
-                        std::wstring(L"char_col"),  // expectedColmnName
-                        SQL_WVARCHAR,               // expectedDataType
-                        0,                          // expectedDisplaySize
-                        SQL_FALSE,                  // expectedPrecScale
-                        0,                          // expectedLength
-                        0,                          // expectedColumnSize
-                        0,                          // expectedColumnScale
-                        SQL_NULLABLE,               // expectedColumnNullability
-                        SQL_PRED_NONE,              // expectedSearchable
-                        SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 2,
+                        std::wstring(L"char_col"),  // expected_column_name
+                        SQL_WVARCHAR,               // expected_data_type
+                        0,                          // expected_display_size
+                        SQL_FALSE,                  // expected_prec_scale
+                        0,                          // expected_length
+                        0,                          // expected_column_size
+                        0,                          // expected_column_scale
+                        SQL_NULLABLE,               // expected_column_nullability
+                        SQL_PRED_NONE,              // expected_searchable
+                        SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 3,
-                        std::wstring(L"varbinary_col"),  // expectedColmnName
-                        SQL_BINARY,                      // expectedDataType
-                        0,                               // expectedDisplaySize
-                        SQL_FALSE,                       // expectedPrecScale
-                        0,                               // expectedLength
-                        0,                               // expectedColumnSize
-                        0,                               // expectedColumnScale
-                        SQL_NULLABLE,                    // expectedColumnNullability
-                        SQL_PRED_NONE,                   // expectedSearchable
-                        SQL_TRUE);                       // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 3,
+                        std::wstring(L"varbinary_col"),  // expected_column_name
+                        SQL_BINARY,                      // expected_data_type
+                        0,                               // expected_display_size
+                        SQL_FALSE,                       // expected_prec_scale
+                        0,                               // expected_length
+                        0,                               // expected_column_size
+                        0,                               // expected_column_scale
+                        SQL_NULLABLE,                    // expected_column_nullability
+                        SQL_PRED_NONE,                   // expected_searchable
+                        SQL_TRUE);                       // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 4,
-                        std::wstring(L"double_col"),  // expectedColmnName
-                        SQL_DOUBLE,                   // expectedDataType
-                        24,                           // expectedDisplaySize
-                        SQL_FALSE,                    // expectedPrecScale
-                        8,                            // expectedLength
-                        8,                            // expectedColumnSize
-                        0,                            // expectedColumnScale
-                        SQL_NULLABLE,                 // expectedColumnNullability
-                        SQL_PRED_NONE,                // expectedSearchable
-                        SQL_FALSE);                   // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 4,
+                        std::wstring(L"double_col"),  // expected_column_name
+                        SQL_DOUBLE,                   // expected_data_type
+                        24,                           // expected_display_size
+                        SQL_FALSE,                    // expected_prec_scale
+                        8,                            // expected_length
+                        8,                            // expected_column_size
+                        0,                            // expected_column_scale
+                        SQL_NULLABLE,                 // expected_column_nullability
+                        SQL_PRED_NONE,                // expected_searchable
+                        SQL_FALSE);                   // expected_unsigned_column
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeAllTypes) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1578,165 +1591,165 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeAllTypes) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLColAttribute(this->stmt, 1,
-                       std::wstring(L"sinteger_max"),  // expectedColmnName
-                       SQL_INTEGER,                    // expectedDataType
-                       SQL_INTEGER,                    // expectedConciseType
-                       11,                             // expectedDisplaySize
-                       SQL_FALSE,                      // expectedPrecScale
-                       4,                              // expectedLength
-                       std::wstring(L""),              // expectedLiteralPrefix
-                       std::wstring(L""),              // expectedLiteralSuffix
-                       4,                              // expectedColumnSize
-                       0,                              // expectedColumnScale
-                       SQL_NULLABLE,                   // expectedColumnNullability
-                       10,                             // expectedNumPrecRadix
-                       4,                              // expectedOctetLength
-                       SQL_SEARCHABLE,                 // expectedSearchable
-                       SQL_FALSE);                     // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 1,
+                       std::wstring(L"sinteger_max"),  // expected_column_name
+                       SQL_INTEGER,                    // expected_data_type
+                       SQL_INTEGER,                    // expected_concise_type
+                       11,                             // expected_display_size
+                       SQL_FALSE,                      // expected_prec_scale
+                       4,                              // expected_length
+                       std::wstring(L""),              // expected_literal_prefix
+                       std::wstring(L""),              // expected_literal_suffix
+                       4,                              // expected_column_size
+                       0,                              // expected_column_scale
+                       SQL_NULLABLE,                   // expected_column_nullability
+                       10,                             // expected_num_prec_radix
+                       4,                              // expected_octet_length
+                       SQL_SEARCHABLE,                 // expected_searchable
+                       SQL_FALSE);                     // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 2,
-                       std::wstring(L"sbigint_max"),  // expectedColmnName
-                       SQL_BIGINT,                    // expectedDataType
-                       SQL_BIGINT,                    // expectedConciseType
-                       20,                            // expectedDisplaySize
-                       SQL_FALSE,                     // expectedPrecScale
-                       8,                             // expectedLength
-                       std::wstring(L""),             // expectedLiteralPrefix
-                       std::wstring(L""),             // expectedLiteralSuffix
-                       8,                             // expectedColumnSize
-                       0,                             // expectedColumnScale
-                       SQL_NULLABLE,                  // expectedColumnNullability
-                       10,                            // expectedNumPrecRadix
-                       8,                             // expectedOctetLength
-                       SQL_SEARCHABLE,                // expectedSearchable
-                       SQL_FALSE);                    // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 2,
+                       std::wstring(L"sbigint_max"),  // expected_column_name
+                       SQL_BIGINT,                    // expected_data_type
+                       SQL_BIGINT,                    // expected_concise_type
+                       20,                            // expected_display_size
+                       SQL_FALSE,                     // expected_prec_scale
+                       8,                             // expected_length
+                       std::wstring(L""),             // expected_literal_prefix
+                       std::wstring(L""),             // expected_literal_suffix
+                       8,                             // expected_column_size
+                       0,                             // expected_column_scale
+                       SQL_NULLABLE,                  // expected_column_nullability
+                       10,                            // expected_num_prec_radix
+                       8,                             // expected_octet_length
+                       SQL_SEARCHABLE,                // expected_searchable
+                       SQL_FALSE);                    // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 3,
-                       std::wstring(L"decimal_positive"),  // expectedColmnName
-                       SQL_DECIMAL,                        // expectedDataType
-                       SQL_DECIMAL,                        // expectedConciseType
-                       40,                                 // expectedDisplaySize
-                       SQL_FALSE,                          // expectedPrecScale
-                       19,                                 // expectedLength
-                       std::wstring(L""),                  // expectedLiteralPrefix
-                       std::wstring(L""),                  // expectedLiteralSuffix
-                       19,                                 // expectedColumnSize
-                       0,                                  // expectedColumnScale
-                       SQL_NULLABLE,                       // expectedColumnNullability
-                       10,                                 // expectedNumPrecRadix
-                       40,                                 // expectedOctetLength
-                       SQL_SEARCHABLE,                     // expectedSearchable
-                       SQL_FALSE);                         // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 3,
+                       std::wstring(L"decimal_positive"),  // expected_column_name
+                       SQL_DECIMAL,                        // expected_data_type
+                       SQL_DECIMAL,                        // expected_concise_type
+                       40,                                 // expected_display_size
+                       SQL_FALSE,                          // expected_prec_scale
+                       19,                                 // expected_length
+                       std::wstring(L""),                  // expected_literal_prefix
+                       std::wstring(L""),                  // expected_literal_suffix
+                       19,                                 // expected_column_size
+                       0,                                  // expected_column_scale
+                       SQL_NULLABLE,                       // expected_column_nullability
+                       10,                                 // expected_num_prec_radix
+                       40,                                 // expected_octet_length
+                       SQL_SEARCHABLE,                     // expected_searchable
+                       SQL_FALSE);                         // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 4,
-                       std::wstring(L"float_max"),  // expectedColmnName
-                       SQL_FLOAT,                   // expectedDataType
-                       SQL_FLOAT,                   // expectedConciseType
-                       24,                          // expectedDisplaySize
-                       SQL_FALSE,                   // expectedPrecScale
-                       8,                           // expectedLength
-                       std::wstring(L""),           // expectedLiteralPrefix
-                       std::wstring(L""),           // expectedLiteralSuffix
-                       8,                           // expectedColumnSize
-                       0,                           // expectedColumnScale
-                       SQL_NULLABLE,                // expectedColumnNullability
-                       2,                           // expectedNumPrecRadix
-                       8,                           // expectedOctetLength
-                       SQL_SEARCHABLE,              // expectedSearchable
-                       SQL_FALSE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 4,
+                       std::wstring(L"float_max"),  // expected_column_name
+                       SQL_FLOAT,                   // expected_data_type
+                       SQL_FLOAT,                   // expected_concise_type
+                       24,                          // expected_display_size
+                       SQL_FALSE,                   // expected_prec_scale
+                       8,                           // expected_length
+                       std::wstring(L""),           // expected_literal_prefix
+                       std::wstring(L""),           // expected_literal_suffix
+                       8,                           // expected_column_size
+                       0,                           // expected_column_scale
+                       SQL_NULLABLE,                // expected_column_nullability
+                       2,                           // expected_num_prec_radix
+                       8,                           // expected_octet_length
+                       SQL_SEARCHABLE,              // expected_searchable
+                       SQL_FALSE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 5,
-                       std::wstring(L"double_max"),  // expectedColmnName
-                       SQL_DOUBLE,                   // expectedDataType
-                       SQL_DOUBLE,                   // expectedConciseType
-                       24,                           // expectedDisplaySize
-                       SQL_FALSE,                    // expectedPrecScale
-                       8,                            // expectedLength
-                       std::wstring(L""),            // expectedLiteralPrefix
-                       std::wstring(L""),            // expectedLiteralSuffix
-                       8,                            // expectedColumnSize
-                       0,                            // expectedColumnScale
-                       SQL_NULLABLE,                 // expectedColumnNullability
-                       2,                            // expectedNumPrecRadix
-                       8,                            // expectedOctetLength
-                       SQL_SEARCHABLE,               // expectedSearchable
-                       SQL_FALSE);                   // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 5,
+                       std::wstring(L"double_max"),  // expected_column_name
+                       SQL_DOUBLE,                   // expected_data_type
+                       SQL_DOUBLE,                   // expected_concise_type
+                       24,                           // expected_display_size
+                       SQL_FALSE,                    // expected_prec_scale
+                       8,                            // expected_length
+                       std::wstring(L""),            // expected_literal_prefix
+                       std::wstring(L""),            // expected_literal_suffix
+                       8,                            // expected_column_size
+                       0,                            // expected_column_scale
+                       SQL_NULLABLE,                 // expected_column_nullability
+                       2,                            // expected_num_prec_radix
+                       8,                            // expected_octet_length
+                       SQL_SEARCHABLE,               // expected_searchable
+                       SQL_FALSE);                   // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 6,
-                       std::wstring(L"bit_true"),  // expectedColmnName
-                       SQL_BIT,                    // expectedDataType
-                       SQL_BIT,                    // expectedConciseType
-                       1,                          // expectedDisplaySize
-                       SQL_FALSE,                  // expectedPrecScale
-                       1,                          // expectedLength
-                       std::wstring(L""),          // expectedLiteralPrefix
-                       std::wstring(L""),          // expectedLiteralSuffix
-                       1,                          // expectedColumnSize
-                       0,                          // expectedColumnScale
-                       SQL_NULLABLE,               // expectedColumnNullability
-                       0,                          // expectedNumPrecRadix
-                       1,                          // expectedOctetLength
-                       SQL_SEARCHABLE,             // expectedSearchable
-                       SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 6,
+                       std::wstring(L"bit_true"),  // expected_column_name
+                       SQL_BIT,                    // expected_data_type
+                       SQL_BIT,                    // expected_concise_type
+                       1,                          // expected_display_size
+                       SQL_FALSE,                  // expected_prec_scale
+                       1,                          // expected_length
+                       std::wstring(L""),          // expected_literal_prefix
+                       std::wstring(L""),          // expected_literal_suffix
+                       1,                          // expected_column_size
+                       0,                          // expected_column_scale
+                       SQL_NULLABLE,               // expected_column_nullability
+                       0,                          // expected_num_prec_radix
+                       1,                          // expected_octet_length
+                       SQL_SEARCHABLE,             // expected_searchable
+                       SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 7,
-                       std::wstring(L"date_max"),  // expectedColmnName
-                       SQL_DATETIME,               // expectedDataType
-                       SQL_TYPE_DATE,              // expectedConciseType
-                       10,                         // expectedDisplaySize
-                       SQL_FALSE,                  // expectedPrecScale
-                       10,                         // expectedLength
-                       std::wstring(L""),          // expectedLiteralPrefix
-                       std::wstring(L""),          // expectedLiteralSuffix
-                       10,                         // expectedColumnSize
-                       0,                          // expectedColumnScale
-                       SQL_NULLABLE,               // expectedColumnNullability
-                       0,                          // expectedNumPrecRadix
-                       6,                          // expectedOctetLength
-                       SQL_SEARCHABLE,             // expectedSearchable
-                       SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 7,
+                       std::wstring(L"date_max"),  // expected_column_name
+                       SQL_DATETIME,               // expected_data_type
+                       SQL_TYPE_DATE,              // expected_concise_type
+                       10,                         // expected_display_size
+                       SQL_FALSE,                  // expected_prec_scale
+                       10,                         // expected_length
+                       std::wstring(L""),          // expected_literal_prefix
+                       std::wstring(L""),          // expected_literal_suffix
+                       10,                         // expected_column_size
+                       0,                          // expected_column_scale
+                       SQL_NULLABLE,               // expected_column_nullability
+                       0,                          // expected_num_prec_radix
+                       6,                          // expected_octet_length
+                       SQL_SEARCHABLE,             // expected_searchable
+                       SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 8,
-                       std::wstring(L"time_max"),  // expectedColmnName
-                       SQL_DATETIME,               // expectedDataType
-                       SQL_TYPE_TIME,              // expectedConciseType
-                       12,                         // expectedDisplaySize
-                       SQL_FALSE,                  // expectedPrecScale
-                       12,                         // expectedLength
-                       std::wstring(L""),          // expectedLiteralPrefix
-                       std::wstring(L""),          // expectedLiteralSuffix
-                       12,                         // expectedColumnSize
-                       3,                          // expectedColumnScale
-                       SQL_NULLABLE,               // expectedColumnNullability
-                       0,                          // expectedNumPrecRadix
-                       6,                          // expectedOctetLength
-                       SQL_SEARCHABLE,             // expectedSearchable
-                       SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 8,
+                       std::wstring(L"time_max"),  // expected_column_name
+                       SQL_DATETIME,               // expected_data_type
+                       SQL_TYPE_TIME,              // expected_concise_type
+                       12,                         // expected_display_size
+                       SQL_FALSE,                  // expected_prec_scale
+                       12,                         // expected_length
+                       std::wstring(L""),          // expected_literal_prefix
+                       std::wstring(L""),          // expected_literal_suffix
+                       12,                         // expected_column_size
+                       3,                          // expected_column_scale
+                       SQL_NULLABLE,               // expected_column_nullability
+                       0,                          // expected_num_prec_radix
+                       6,                          // expected_octet_length
+                       SQL_SEARCHABLE,             // expected_searchable
+                       SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 9,
-                       std::wstring(L"timestamp_max"),  // expectedColmnName
-                       SQL_DATETIME,                    // expectedDataType
-                       SQL_TYPE_TIMESTAMP,              // expectedConciseType
-                       23,                              // expectedDisplaySize
-                       SQL_FALSE,                       // expectedPrecScale
-                       23,                              // expectedLength
-                       std::wstring(L""),               // expectedLiteralPrefix
-                       std::wstring(L""),               // expectedLiteralSuffix
-                       23,                              // expectedColumnSize
-                       3,                               // expectedColumnScale
-                       SQL_NULLABLE,                    // expectedColumnNullability
-                       0,                               // expectedNumPrecRadix
-                       16,                              // expectedOctetLength
-                       SQL_SEARCHABLE,                  // expectedSearchable
-                       SQL_TRUE);                       // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 9,
+                       std::wstring(L"timestamp_max"),  // expected_column_name
+                       SQL_DATETIME,                    // expected_data_type
+                       SQL_TYPE_TIMESTAMP,              // expected_concise_type
+                       23,                              // expected_display_size
+                       SQL_FALSE,                       // expected_prec_scale
+                       23,                              // expected_length
+                       std::wstring(L""),               // expected_literal_prefix
+                       std::wstring(L""),               // expected_literal_suffix
+                       23,                              // expected_column_size
+                       3,                               // expected_column_scale
+                       SQL_NULLABLE,                    // expected_column_nullability
+                       0,                               // expected_num_prec_radix
+                       16,                              // expected_octet_length
+                       SQL_SEARCHABLE,                  // expected_searchable
+                       SQL_TRUE);                       // expected_unsigned_column
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeAllTypesODBCVer2) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1748,166 +1761,166 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeAllTypesODBCVer2) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLColAttribute(this->stmt, 1,
-                       std::wstring(L"sinteger_max"),  // expectedColmnName
-                       SQL_INTEGER,                    // expectedDataType
-                       SQL_INTEGER,                    // expectedConciseType
-                       11,                             // expectedDisplaySize
-                       SQL_FALSE,                      // expectedPrecScale
-                       4,                              // expectedLength
-                       std::wstring(L""),              // expectedLiteralPrefix
-                       std::wstring(L""),              // expectedLiteralSuffix
-                       4,                              // expectedColumnSize
-                       0,                              // expectedColumnScale
-                       SQL_NULLABLE,                   // expectedColumnNullability
-                       10,                             // expectedNumPrecRadix
-                       4,                              // expectedOctetLength
-                       SQL_SEARCHABLE,                 // expectedSearchable
-                       SQL_FALSE);                     // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 1,
+                       std::wstring(L"sinteger_max"),  // expected_column_name
+                       SQL_INTEGER,                    // expected_data_type
+                       SQL_INTEGER,                    // expected_concise_type
+                       11,                             // expected_display_size
+                       SQL_FALSE,                      // expected_prec_scale
+                       4,                              // expected_length
+                       std::wstring(L""),              // expected_literal_prefix
+                       std::wstring(L""),              // expected_literal_suffix
+                       4,                              // expected_column_size
+                       0,                              // expected_column_scale
+                       SQL_NULLABLE,                   // expected_column_nullability
+                       10,                             // expected_num_prec_radix
+                       4,                              // expected_octet_length
+                       SQL_SEARCHABLE,                 // expected_searchable
+                       SQL_FALSE);                     // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 2,
-                       std::wstring(L"sbigint_max"),  // expectedColmnName
-                       SQL_BIGINT,                    // expectedDataType
-                       SQL_BIGINT,                    // expectedConciseType
-                       20,                            // expectedDisplaySize
-                       SQL_FALSE,                     // expectedPrecScale
-                       8,                             // expectedLength
-                       std::wstring(L""),             // expectedLiteralPrefix
-                       std::wstring(L""),             // expectedLiteralSuffix
-                       8,                             // expectedColumnSize
-                       0,                             // expectedColumnScale
-                       SQL_NULLABLE,                  // expectedColumnNullability
-                       10,                            // expectedNumPrecRadix
-                       8,                             // expectedOctetLength
-                       SQL_SEARCHABLE,                // expectedSearchable
-                       SQL_FALSE);                    // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 2,
+                       std::wstring(L"sbigint_max"),  // expected_column_name
+                       SQL_BIGINT,                    // expected_data_type
+                       SQL_BIGINT,                    // expected_concise_type
+                       20,                            // expected_display_size
+                       SQL_FALSE,                     // expected_prec_scale
+                       8,                             // expected_length
+                       std::wstring(L""),             // expected_literal_prefix
+                       std::wstring(L""),             // expected_literal_suffix
+                       8,                             // expected_column_size
+                       0,                             // expected_column_scale
+                       SQL_NULLABLE,                  // expected_column_nullability
+                       10,                            // expected_num_prec_radix
+                       8,                             // expected_octet_length
+                       SQL_SEARCHABLE,                // expected_searchable
+                       SQL_FALSE);                    // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 3,
-                       std::wstring(L"decimal_positive"),  // expectedColmnName
-                       SQL_DECIMAL,                        // expectedDataType
-                       SQL_DECIMAL,                        // expectedConciseType
-                       40,                                 // expectedDisplaySize
-                       SQL_FALSE,                          // expectedPrecScale
-                       19,                                 // expectedLength
-                       std::wstring(L""),                  // expectedLiteralPrefix
-                       std::wstring(L""),                  // expectedLiteralSuffix
-                       19,                                 // expectedColumnSize
-                       0,                                  // expectedColumnScale
-                       SQL_NULLABLE,                       // expectedColumnNullability
-                       10,                                 // expectedNumPrecRadix
-                       40,                                 // expectedOctetLength
-                       SQL_SEARCHABLE,                     // expectedSearchable
-                       SQL_FALSE);                         // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 3,
+                       std::wstring(L"decimal_positive"),  // expected_column_name
+                       SQL_DECIMAL,                        // expected_data_type
+                       SQL_DECIMAL,                        // expected_concise_type
+                       40,                                 // expected_display_size
+                       SQL_FALSE,                          // expected_prec_scale
+                       19,                                 // expected_length
+                       std::wstring(L""),                  // expected_literal_prefix
+                       std::wstring(L""),                  // expected_literal_suffix
+                       19,                                 // expected_column_size
+                       0,                                  // expected_column_scale
+                       SQL_NULLABLE,                       // expected_column_nullability
+                       10,                                 // expected_num_prec_radix
+                       40,                                 // expected_octet_length
+                       SQL_SEARCHABLE,                     // expected_searchable
+                       SQL_FALSE);                         // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 4,
-                       std::wstring(L"float_max"),  // expectedColmnName
-                       SQL_FLOAT,                   // expectedDataType
-                       SQL_FLOAT,                   // expectedConciseType
-                       24,                          // expectedDisplaySize
-                       SQL_FALSE,                   // expectedPrecScale
-                       8,                           // expectedLength
-                       std::wstring(L""),           // expectedLiteralPrefix
-                       std::wstring(L""),           // expectedLiteralSuffix
-                       8,                           // expectedColumnSize
-                       0,                           // expectedColumnScale
-                       SQL_NULLABLE,                // expectedColumnNullability
-                       2,                           // expectedNumPrecRadix
-                       8,                           // expectedOctetLength
-                       SQL_SEARCHABLE,              // expectedSearchable
-                       SQL_FALSE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 4,
+                       std::wstring(L"float_max"),  // expected_column_name
+                       SQL_FLOAT,                   // expected_data_type
+                       SQL_FLOAT,                   // expected_concise_type
+                       24,                          // expected_display_size
+                       SQL_FALSE,                   // expected_prec_scale
+                       8,                           // expected_length
+                       std::wstring(L""),           // expected_literal_prefix
+                       std::wstring(L""),           // expected_literal_suffix
+                       8,                           // expected_column_size
+                       0,                           // expected_column_scale
+                       SQL_NULLABLE,                // expected_column_nullability
+                       2,                           // expected_num_prec_radix
+                       8,                           // expected_octet_length
+                       SQL_SEARCHABLE,              // expected_searchable
+                       SQL_FALSE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 5,
-                       std::wstring(L"double_max"),  // expectedColmnName
-                       SQL_DOUBLE,                   // expectedDataType
-                       SQL_DOUBLE,                   // expectedConciseType
-                       24,                           // expectedDisplaySize
-                       SQL_FALSE,                    // expectedPrecScale
-                       8,                            // expectedLength
-                       std::wstring(L""),            // expectedLiteralPrefix
-                       std::wstring(L""),            // expectedLiteralSuffix
-                       8,                            // expectedColumnSize
-                       0,                            // expectedColumnScale
-                       SQL_NULLABLE,                 // expectedColumnNullability
-                       2,                            // expectedNumPrecRadix
-                       8,                            // expectedOctetLength
-                       SQL_SEARCHABLE,               // expectedSearchable
-                       SQL_FALSE);                   // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 5,
+                       std::wstring(L"double_max"),  // expected_column_name
+                       SQL_DOUBLE,                   // expected_data_type
+                       SQL_DOUBLE,                   // expected_concise_type
+                       24,                           // expected_display_size
+                       SQL_FALSE,                    // expected_prec_scale
+                       8,                            // expected_length
+                       std::wstring(L""),            // expected_literal_prefix
+                       std::wstring(L""),            // expected_literal_suffix
+                       8,                            // expected_column_size
+                       0,                            // expected_column_scale
+                       SQL_NULLABLE,                 // expected_column_nullability
+                       2,                            // expected_num_prec_radix
+                       8,                            // expected_octet_length
+                       SQL_SEARCHABLE,               // expected_searchable
+                       SQL_FALSE);                   // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 6,
-                       std::wstring(L"bit_true"),  // expectedColmnName
-                       SQL_BIT,                    // expectedDataType
-                       SQL_BIT,                    // expectedConciseType
-                       1,                          // expectedDisplaySize
-                       SQL_FALSE,                  // expectedPrecScale
-                       1,                          // expectedLength
-                       std::wstring(L""),          // expectedLiteralPrefix
-                       std::wstring(L""),          // expectedLiteralSuffix
-                       1,                          // expectedColumnSize
-                       0,                          // expectedColumnScale
-                       SQL_NULLABLE,               // expectedColumnNullability
-                       0,                          // expectedNumPrecRadix
-                       1,                          // expectedOctetLength
-                       SQL_SEARCHABLE,             // expectedSearchable
-                       SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 6,
+                       std::wstring(L"bit_true"),  // expected_column_name
+                       SQL_BIT,                    // expected_data_type
+                       SQL_BIT,                    // expected_concise_type
+                       1,                          // expected_display_size
+                       SQL_FALSE,                  // expected_prec_scale
+                       1,                          // expected_length
+                       std::wstring(L""),          // expected_literal_prefix
+                       std::wstring(L""),          // expected_literal_suffix
+                       1,                          // expected_column_size
+                       0,                          // expected_column_scale
+                       SQL_NULLABLE,               // expected_column_nullability
+                       0,                          // expected_num_prec_radix
+                       1,                          // expected_octet_length
+                       SQL_SEARCHABLE,             // expected_searchable
+                       SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 7,
-                       std::wstring(L"date_max"),  // expectedColmnName
-                       SQL_DATETIME,               // expectedDataType
-                       SQL_DATE,                   // expectedConciseType
-                       10,                         // expectedDisplaySize
-                       SQL_FALSE,                  // expectedPrecScale
-                       10,                         // expectedLength
-                       std::wstring(L""),          // expectedLiteralPrefix
-                       std::wstring(L""),          // expectedLiteralSuffix
-                       10,                         // expectedColumnSize
-                       0,                          // expectedColumnScale
-                       SQL_NULLABLE,               // expectedColumnNullability
-                       0,                          // expectedNumPrecRadix
-                       6,                          // expectedOctetLength
-                       SQL_SEARCHABLE,             // expectedSearchable
-                       SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 7,
+                       std::wstring(L"date_max"),  // expected_column_name
+                       SQL_DATETIME,               // expected_data_type
+                       SQL_DATE,                   // expected_concise_type
+                       10,                         // expected_display_size
+                       SQL_FALSE,                  // expected_prec_scale
+                       10,                         // expected_length
+                       std::wstring(L""),          // expected_literal_prefix
+                       std::wstring(L""),          // expected_literal_suffix
+                       10,                         // expected_column_size
+                       0,                          // expected_column_scale
+                       SQL_NULLABLE,               // expected_column_nullability
+                       0,                          // expected_num_prec_radix
+                       6,                          // expected_octet_length
+                       SQL_SEARCHABLE,             // expected_searchable
+                       SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 8,
-                       std::wstring(L"time_max"),  // expectedColmnName
-                       SQL_DATETIME,               // expectedDataType
-                       SQL_TIME,                   // expectedConciseType
-                       12,                         // expectedDisplaySize
-                       SQL_FALSE,                  // expectedPrecScale
-                       12,                         // expectedLength
-                       std::wstring(L""),          // expectedLiteralPrefix
-                       std::wstring(L""),          // expectedLiteralSuffix
-                       12,                         // expectedColumnSize
-                       3,                          // expectedColumnScale
-                       SQL_NULLABLE,               // expectedColumnNullability
-                       0,                          // expectedNumPrecRadix
-                       6,                          // expectedOctetLength
-                       SQL_SEARCHABLE,             // expectedSearchable
-                       SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 8,
+                       std::wstring(L"time_max"),  // expected_column_name
+                       SQL_DATETIME,               // expected_data_type
+                       SQL_TIME,                   // expected_concise_type
+                       12,                         // expected_display_size
+                       SQL_FALSE,                  // expected_prec_scale
+                       12,                         // expected_length
+                       std::wstring(L""),          // expected_literal_prefix
+                       std::wstring(L""),          // expected_literal_suffix
+                       12,                         // expected_column_size
+                       3,                          // expected_column_scale
+                       SQL_NULLABLE,               // expected_column_nullability
+                       0,                          // expected_num_prec_radix
+                       6,                          // expected_octet_length
+                       SQL_SEARCHABLE,             // expected_searchable
+                       SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttribute(this->stmt, 9,
-                       std::wstring(L"timestamp_max"),  // expectedColmnName
-                       SQL_DATETIME,                    // expectedDataType
-                       SQL_TIMESTAMP,                   // expectedConciseType
-                       23,                              // expectedDisplaySize
-                       SQL_FALSE,                       // expectedPrecScale
-                       23,                              // expectedLength
-                       std::wstring(L""),               // expectedLiteralPrefix
-                       std::wstring(L""),               // expectedLiteralSuffix
-                       23,                              // expectedColumnSize
-                       3,                               // expectedColumnScale
-                       SQL_NULLABLE,                    // expectedColumnNullability
-                       0,                               // expectedNumPrecRadix
-                       16,                              // expectedOctetLength
-                       SQL_SEARCHABLE,                  // expectedSearchable
-                       SQL_TRUE);                       // expectedUnsignedColumn
+  CheckSQLColAttribute(this->stmt, 9,
+                       std::wstring(L"timestamp_max"),  // expected_column_name
+                       SQL_DATETIME,                    // expected_data_type
+                       SQL_TIMESTAMP,                   // expected_concise_type
+                       23,                              // expected_display_size
+                       SQL_FALSE,                       // expected_prec_scale
+                       23,                              // expected_length
+                       std::wstring(L""),               // expected_literal_prefix
+                       std::wstring(L""),               // expected_literal_suffix
+                       23,                              // expected_column_size
+                       3,                               // expected_column_scale
+                       SQL_NULLABLE,                    // expected_column_nullability
+                       0,                               // expected_num_prec_radix
+                       16,                              // expected_octet_length
+                       SQL_SEARCHABLE,                  // expected_searchable
+                       SQL_TRUE);                       // expected_unsigned_column
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributesAllTypesODBCVer2) {
   // Tests ODBC 2.0 API SQLColAttributes
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1919,481 +1932,478 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributesAllTypesODBCVer2) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLColAttributes(this->stmt, 1,
-                        std::wstring(L"sinteger_max"),  // expectedColmnName
-                        SQL_INTEGER,                    // expectedDataType
-                        11,                             // expectedDisplaySize
-                        SQL_FALSE,                      // expectedPrecScale
-                        4,                              // expectedLength
-                        4,                              // expectedColumnSize
-                        0,                              // expectedColumnScale
-                        SQL_NULLABLE,                   // expectedColumnNullability
-                        SQL_SEARCHABLE,                 // expectedSearchable
-                        SQL_FALSE);                     // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 1,
+                        std::wstring(L"sinteger_max"),  // expected_column_name
+                        SQL_INTEGER,                    // expected_data_type
+                        11,                             // expected_display_size
+                        SQL_FALSE,                      // expected_prec_scale
+                        4,                              // expected_length
+                        4,                              // expected_column_size
+                        0,                              // expected_column_scale
+                        SQL_NULLABLE,                   // expected_column_nullability
+                        SQL_SEARCHABLE,                 // expected_searchable
+                        SQL_FALSE);                     // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 2,
-                        std::wstring(L"sbigint_max"),  // expectedColmnName
-                        SQL_BIGINT,                    // expectedDataType
-                        20,                            // expectedDisplaySize
-                        SQL_FALSE,                     // expectedPrecScale
-                        8,                             // expectedLength
-                        8,                             // expectedColumnSize
-                        0,                             // expectedColumnScale
-                        SQL_NULLABLE,                  // expectedColumnNullability
-                        SQL_SEARCHABLE,                // expectedSearchable
-                        SQL_FALSE);                    // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 2,
+                        std::wstring(L"sbigint_max"),  // expected_column_name
+                        SQL_BIGINT,                    // expected_data_type
+                        20,                            // expected_display_size
+                        SQL_FALSE,                     // expected_prec_scale
+                        8,                             // expected_length
+                        8,                             // expected_column_size
+                        0,                             // expected_column_scale
+                        SQL_NULLABLE,                  // expected_column_nullability
+                        SQL_SEARCHABLE,                // expected_searchable
+                        SQL_FALSE);                    // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 3,
-                        std::wstring(L"decimal_positive"),  // expectedColmnName
-                        SQL_DECIMAL,                        // expectedDataType
-                        40,                                 // expectedDisplaySize
-                        SQL_FALSE,                          // expectedPrecScale
-                        19,                                 // expectedLength
-                        19,                                 // expectedColumnSize
-                        0,                                  // expectedColumnScale
-                        SQL_NULLABLE,                       // expectedColumnNullability
-                        SQL_SEARCHABLE,                     // expectedSearchable
-                        SQL_FALSE);                         // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 3,
+                        std::wstring(L"decimal_positive"),  // expected_column_name
+                        SQL_DECIMAL,                        // expected_data_type
+                        40,                                 // expected_display_size
+                        SQL_FALSE,                          // expected_prec_scale
+                        19,                                 // expected_length
+                        19,                                 // expected_column_size
+                        0,                                  // expected_column_scale
+                        SQL_NULLABLE,                       // expected_column_nullability
+                        SQL_SEARCHABLE,                     // expected_searchable
+                        SQL_FALSE);                         // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 4,
-                        std::wstring(L"float_max"),  // expectedColmnName
-                        SQL_FLOAT,                   // expectedDataType
-                        24,                          // expectedDisplaySize
-                        SQL_FALSE,                   // expectedPrecScale
-                        8,                           // expectedLength
-                        8,                           // expectedColumnSize
-                        0,                           // expectedColumnScale
-                        SQL_NULLABLE,                // expectedColumnNullability
-                        SQL_SEARCHABLE,              // expectedSearchable
-                        SQL_FALSE);                  // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 4,
+                        std::wstring(L"float_max"),  // expected_column_name
+                        SQL_FLOAT,                   // expected_data_type
+                        24,                          // expected_display_size
+                        SQL_FALSE,                   // expected_prec_scale
+                        8,                           // expected_length
+                        8,                           // expected_column_size
+                        0,                           // expected_column_scale
+                        SQL_NULLABLE,                // expected_column_nullability
+                        SQL_SEARCHABLE,              // expected_searchable
+                        SQL_FALSE);                  // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 5,
-                        std::wstring(L"double_max"),  // expectedColmnName
-                        SQL_DOUBLE,                   // expectedDataType
-                        24,                           // expectedDisplaySize
-                        SQL_FALSE,                    // expectedPrecScale
-                        8,                            // expectedLength
-                        8,                            // expectedColumnSize
-                        0,                            // expectedColumnScale
-                        SQL_NULLABLE,                 // expectedColumnNullability
-                        SQL_SEARCHABLE,               // expectedSearchable
-                        SQL_FALSE);                   // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 5,
+                        std::wstring(L"double_max"),  // expected_column_name
+                        SQL_DOUBLE,                   // expected_data_type
+                        24,                           // expected_display_size
+                        SQL_FALSE,                    // expected_prec_scale
+                        8,                            // expected_length
+                        8,                            // expected_column_size
+                        0,                            // expected_column_scale
+                        SQL_NULLABLE,                 // expected_column_nullability
+                        SQL_SEARCHABLE,               // expected_searchable
+                        SQL_FALSE);                   // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 6,
-                        std::wstring(L"bit_true"),  // expectedColmnName
-                        SQL_BIT,                    // expectedDataType
-                        1,                          // expectedDisplaySize
-                        SQL_FALSE,                  // expectedPrecScale
-                        1,                          // expectedLength
-                        1,                          // expectedColumnSize
-                        0,                          // expectedColumnScale
-                        SQL_NULLABLE,               // expectedColumnNullability
-                        SQL_SEARCHABLE,             // expectedSearchable
-                        SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 6,
+                        std::wstring(L"bit_true"),  // expected_column_name
+                        SQL_BIT,                    // expected_data_type
+                        1,                          // expected_display_size
+                        SQL_FALSE,                  // expected_prec_scale
+                        1,                          // expected_length
+                        1,                          // expected_column_size
+                        0,                          // expected_column_scale
+                        SQL_NULLABLE,               // expected_column_nullability
+                        SQL_SEARCHABLE,             // expected_searchable
+                        SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 7,
-                        std::wstring(L"date_max"),  // expectedColmnName
-                        SQL_DATE,                   // expectedDataType
-                        10,                         // expectedDisplaySize
-                        SQL_FALSE,                  // expectedPrecScale
-                        10,                         // expectedLength
-                        10,                         // expectedColumnSize
-                        0,                          // expectedColumnScale
-                        SQL_NULLABLE,               // expectedColumnNullability
-                        SQL_SEARCHABLE,             // expectedSearchable
-                        SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 7,
+                        std::wstring(L"date_max"),  // expected_column_name
+                        SQL_DATE,                   // expected_data_type
+                        10,                         // expected_display_size
+                        SQL_FALSE,                  // expected_prec_scale
+                        10,                         // expected_length
+                        10,                         // expected_column_size
+                        0,                          // expected_column_scale
+                        SQL_NULLABLE,               // expected_column_nullability
+                        SQL_SEARCHABLE,             // expected_searchable
+                        SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 8,
-                        std::wstring(L"time_max"),  // expectedColmnName
-                        SQL_TIME,                   // expectedDataType
-                        12,                         // expectedDisplaySize
-                        SQL_FALSE,                  // expectedPrecScale
-                        12,                         // expectedLength
-                        12,                         // expectedColumnSize
-                        3,                          // expectedColumnScale
-                        SQL_NULLABLE,               // expectedColumnNullability
-                        SQL_SEARCHABLE,             // expectedSearchable
-                        SQL_TRUE);                  // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 8,
+                        std::wstring(L"time_max"),  // expected_column_name
+                        SQL_TIME,                   // expected_data_type
+                        12,                         // expected_display_size
+                        SQL_FALSE,                  // expected_prec_scale
+                        12,                         // expected_length
+                        12,                         // expected_column_size
+                        3,                          // expected_column_scale
+                        SQL_NULLABLE,               // expected_column_nullability
+                        SQL_SEARCHABLE,             // expected_searchable
+                        SQL_TRUE);                  // expected_unsigned_column
 
-  checkSQLColAttributes(this->stmt, 9,
-                        std::wstring(L"timestamp_max"),  // expectedColmnName
-                        SQL_TIMESTAMP,                   // expectedDataType
-                        23,                              // expectedDisplaySize
-                        SQL_FALSE,                       // expectedPrecScale
-                        23,                              // expectedLength
-                        23,                              // expectedColumnSize
-                        3,                               // expectedColumnScale
-                        SQL_NULLABLE,                    // expectedColumnNullability
-                        SQL_SEARCHABLE,                  // expectedSearchable
-                        SQL_TRUE);                       // expectedUnsignedColumn
+  CheckSQLColAttributes(this->stmt, 9,
+                        std::wstring(L"timestamp_max"),  // expected_column_name
+                        SQL_TIMESTAMP,                   // expected_data_type
+                        23,                              // expected_display_size
+                        SQL_FALSE,                       // expected_prec_scale
+                        23,                              // expected_length
+                        23,                              // expected_column_size
+                        3,                               // expected_column_scale
+                        SQL_NULLABLE,                    // expected_column_nullability
+                        SQL_SEARCHABLE,                  // expected_searchable
+                        SQL_TRUE);                       // expected_unsigned_column
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLColAttributeCaseSensitive) {
   // Arrow limitation: returns SQL_FALSE for case sensitive column
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   // Int column
-  checkSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_CASE_SENSITIVE, SQL_FALSE);
+  CheckSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_CASE_SENSITIVE, SQL_FALSE);
   SQLFreeStmt(this->stmt, SQL_CLOSE);
   // Varchar column
-  checkSQLColAttributeNumeric(this->stmt, wsql, 28, SQL_DESC_CASE_SENSITIVE, SQL_FALSE);
+  CheckSQLColAttributeNumeric(this->stmt, wsql, 28, SQL_DESC_CASE_SENSITIVE, SQL_FALSE);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLColAttributesCaseSensitive) {
   // Arrow limitation: returns SQL_FALSE for case sensitive column
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   // Int column
-  checkSQLColAttributesNumeric(this->stmt, wsql, 1, SQL_COLUMN_CASE_SENSITIVE, SQL_FALSE);
+  CheckSQLColAttributesNumeric(this->stmt, wsql, 1, SQL_COLUMN_CASE_SENSITIVE, SQL_FALSE);
   SQLFreeStmt(this->stmt, SQL_CLOSE);
   // Varchar column
-  checkSQLColAttributesNumeric(this->stmt, wsql, 28, SQL_COLUMN_CASE_SENSITIVE,
+  CheckSQLColAttributesNumeric(this->stmt, wsql, 28, SQL_COLUMN_CASE_SENSITIVE,
                                SQL_FALSE);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeUniqueValue) {
   // Mock server limitation: returns false for auto-increment column
-  this->connect();
+  this->Connect();
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
-  checkSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_AUTO_UNIQUE_VALUE, SQL_FALSE);
+  CheckSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_AUTO_UNIQUE_VALUE, SQL_FALSE);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributesAutoIncrement) {
   // Tests ODBC 2.0 API SQLColAttributes
   // Mock server limitation: returns false for auto-increment column
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
-  checkSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_COLUMN_AUTO_INCREMENT, SQL_FALSE);
+  CheckSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_COLUMN_AUTO_INCREMENT, SQL_FALSE);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeBaseTableName) {
-  this->connect();
+TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeBasetable_name) {
+  this->Connect();
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_BASE_TABLE_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_BASE_TABLE_NAME,
                              std::wstring(L"AllTypesTable"));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributesTableName) {
+TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributestable_name) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
-  checkSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TABLE_NAME,
+  CheckSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TABLE_NAME,
                               std::wstring(L"AllTypesTable"));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeCatalogName) {
+TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributecatalog_name) {
   // Mock server limitattion: mock doesn't return catalog for result metadata,
   // and the defautl catalog should be 'main'
-  this->connect();
+  this->Connect();
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_CATALOG_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_CATALOG_NAME,
                              std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeCatalogName) {
+TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributecatalog_name) {
   // Remote server does not have catalogs
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_CATALOG_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_CATALOG_NAME,
                              std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributesQualifierName) {
   // Mock server limitattion: mock doesn't return catalog for result metadata,
   // and the defautl catalog should be 'main'
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME,
                              std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributesQualifierName) {
   // Remote server does not have catalogs
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME,
                              std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLColAttributeCount) {
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   // Pass 0 as column number, driver should ignore it
-  checkSQLColAttributeNumeric(this->stmt, wsql, 0, SQL_DESC_COUNT, 32);
+  CheckSQLColAttributeNumeric(this->stmt, wsql, 0, SQL_DESC_COUNT, 32);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeLocalTypeName) {
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server doesn't have local type name
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME,
                              std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeLocalTypeName) {
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME,
+  std::wstring wsql = this->GetQueryAllDataTypes();
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME,
                              std::wstring(L"INTEGER"));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeSchemaName) {
-  this->connect();
+TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeschema_name) {
+  this->Connect();
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't have schemas
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_SCHEMA_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_SCHEMA_NAME,
                              std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeSchemaName) {
+TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeschema_name) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   // Remote server limitation: doesn't return schema name, expected schema name is
   // $scratch
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_SCHEMA_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_SCHEMA_NAME,
                              std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributesOwnerName) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't have schemas
-  checkSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_OWNER_NAME,
+  CheckSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_OWNER_NAME,
                               std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributesOwnerName) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   // Remote server limitation: doesn't return schema name, expected schema name is
   // $scratch
-  checkSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_OWNER_NAME,
+  CheckSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_OWNER_NAME,
                               std::wstring(L""));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
-TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeTableName) {
-  this->connect();
+TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributetable_name) {
+  this->Connect();
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TABLE_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TABLE_NAME,
                              std::wstring(L"AllTypesTable"));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeTypeName) {
-  this->connect();
+  this->Connect();
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TYPE_NAME,
                              std::wstring(L"BIGINT"));
-  checkSQLColAttributeString(this->stmt, L"", 2, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 2, SQL_DESC_TYPE_NAME,
                              std::wstring(L"WVARCHAR"));
-  checkSQLColAttributeString(this->stmt, L"", 3, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 3, SQL_DESC_TYPE_NAME,
                              std::wstring(L"BINARY"));
-  checkSQLColAttributeString(this->stmt, L"", 4, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 4, SQL_DESC_TYPE_NAME,
                              std::wstring(L"DOUBLE"));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeTypeName) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
-  checkSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TYPE_NAME,
                              std::wstring(L"INTEGER"));
-  checkSQLColAttributeString(this->stmt, L"", 2, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 2, SQL_DESC_TYPE_NAME,
                              std::wstring(L"BIGINT"));
-  checkSQLColAttributeString(this->stmt, L"", 3, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 3, SQL_DESC_TYPE_NAME,
                              std::wstring(L"DECIMAL"));
-  checkSQLColAttributeString(this->stmt, L"", 4, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 4, SQL_DESC_TYPE_NAME,
                              std::wstring(L"FLOAT"));
-  checkSQLColAttributeString(this->stmt, L"", 5, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 5, SQL_DESC_TYPE_NAME,
                              std::wstring(L"DOUBLE"));
-  checkSQLColAttributeString(this->stmt, L"", 6, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 6, SQL_DESC_TYPE_NAME,
                              std::wstring(L"BOOLEAN"));
-  checkSQLColAttributeString(this->stmt, L"", 7, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 7, SQL_DESC_TYPE_NAME,
                              std::wstring(L"DATE"));
-  checkSQLColAttributeString(this->stmt, L"", 8, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 8, SQL_DESC_TYPE_NAME,
                              std::wstring(L"TIME"));
-  checkSQLColAttributeString(this->stmt, L"", 9, SQL_DESC_TYPE_NAME,
+  CheckSQLColAttributeString(this->stmt, L"", 9, SQL_DESC_TYPE_NAME,
                              std::wstring(L"TIMESTAMP"));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributesTypeName) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
   this->CreateTableAllDataType();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't return data source-dependent data type name
-  checkSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"BIGINT"));
-  checkSQLColAttributesString(this->stmt, L"", 2, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 2, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"WVARCHAR"));
-  checkSQLColAttributesString(this->stmt, L"", 3, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 3, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"BINARY"));
-  checkSQLColAttributesString(this->stmt, L"", 4, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 4, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"DOUBLE"));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributesTypeName) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
-  checkSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"INTEGER"));
-  checkSQLColAttributesString(this->stmt, L"", 2, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 2, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"BIGINT"));
-  checkSQLColAttributesString(this->stmt, L"", 3, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 3, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"DECIMAL"));
-  checkSQLColAttributesString(this->stmt, L"", 4, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 4, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"FLOAT"));
-  checkSQLColAttributesString(this->stmt, L"", 5, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 5, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"DOUBLE"));
-  checkSQLColAttributesString(this->stmt, L"", 6, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 6, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"BOOLEAN"));
-  checkSQLColAttributesString(this->stmt, L"", 7, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 7, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"DATE"));
-  checkSQLColAttributesString(this->stmt, L"", 8, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 8, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"TIME"));
-  checkSQLColAttributesString(this->stmt, L"", 9, SQL_COLUMN_TYPE_NAME,
+  CheckSQLColAttributesString(this->stmt, L"", 9, SQL_COLUMN_TYPE_NAME,
                               std::wstring(L"TIMESTAMP"));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLColAttributeUnnamed) {
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
-  checkSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_UNNAMED, SQL_NAMED);
+  std::wstring wsql = this->GetQueryAllDataTypes();
+  CheckSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_UNNAMED, SQL_NAMED);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLColAttributeUpdatable) {
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server and remote server do not return updatable information
-  checkSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_UPDATABLE,
+  CheckSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_UPDATABLE,
                               SQL_ATTR_READWRITE_UNKNOWN);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLColAttributesUpdatable) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server and remote server do not return updatable information
-  checkSQLColAttributesNumeric(this->stmt, wsql, 1, SQL_COLUMN_UPDATABLE,
+  CheckSQLColAttributesNumeric(this->stmt, wsql, 1, SQL_COLUMN_UPDATABLE,
                                SQL_ATTR_READWRITE_UNKNOWN);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColValidateInput) {
-  this->connect();
+  this->Connect();
   this->CreateTestTables();
 
-  SQLSMALLINT columnCount = 0;
-  SQLSMALLINT expectedValue = 3;
-  SQLWCHAR sqlQuery[] = L"SELECT * FROM TestTable LIMIT 1;";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLWCHAR sql_query[] = L"SELECT * FROM TestTable LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLUSMALLINT bookmarkColumn = 0;
-  SQLUSMALLINT validColumn = 1;
-  SQLUSMALLINT outOfRangeColumn = 4;
-  SQLUSMALLINT negativeColumn = -1;
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT dataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLUSMALLINT bookmark_column = 0;
+  SQLUSMALLINT out_of_range_column = 4;
+  SQLUSMALLINT negative_column = -1;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2402,48 +2412,51 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColValidateInput) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Invalid descriptor index - Bookmarks are not supported
-  ret = SQLDescribeCol(this->stmt, bookmarkColumn, columnName, bufCharLen, &nameLength,
-                       &dataType, &columnSize, &decimalDigits, &nullable);
+  ret =
+      SQLDescribeCol(this->stmt, bookmark_column, column_name, buf_char_len, &name_length,
+                     &data_type, &column_size, &decimal_digits, &nullable);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_07009);
 
   // Invalid descriptor index - index out of range
-  ret = SQLDescribeCol(this->stmt, outOfRangeColumn, columnName, bufCharLen, &nameLength,
-                       &dataType, &columnSize, &decimalDigits, &nullable);
+  ret =
+      SQLDescribeCol(this->stmt, out_of_range_column, column_name, buf_char_len,
+                     &name_length, &data_type, &column_size, &decimal_digits, &nullable);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_07009);
 
   // Invalid descriptor index - index out of range
-  ret = SQLDescribeCol(this->stmt, negativeColumn, columnName, bufCharLen, &nameLength,
-                       &dataType, &columnSize, &decimalDigits, &nullable);
+  ret =
+      SQLDescribeCol(this->stmt, negative_column, column_name, buf_char_len, &name_length,
+                     &data_type, &column_size, &decimal_digits, &nullable);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_07009);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
   // Mock server has a limitation where only SQL_WVARCHAR column type values are returned
   // from SELECT AS queries
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
-  size_t columnIndex = 0;
+  size_t column_index = 0;
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
-  SQLWCHAR* columnNames[] = {
+  SQLWCHAR* column_names[] = {
       (SQLWCHAR*)L"stiny_int_min",    (SQLWCHAR*)L"stiny_int_max",
       (SQLWCHAR*)L"utiny_int_min",    (SQLWCHAR*)L"utiny_int_max",
       (SQLWCHAR*)L"ssmall_int_min",   (SQLWCHAR*)L"ssmall_int_max",
@@ -2460,7 +2473,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
       (SQLWCHAR*)L"c_wvarchar",       (SQLWCHAR*)L"c_varchar",
       (SQLWCHAR*)L"date_min",         (SQLWCHAR*)L"date_max",
       (SQLWCHAR*)L"timestamp_min",    (SQLWCHAR*)L"timestamp_max"};
-  SQLSMALLINT columnDataTypes[] = {
+  SQLSMALLINT column_data_types[] = {
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
@@ -2477,50 +2490,51 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    columnIndex = i + 1;
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
 
-    ret = SQLDescribeCol(this->stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                         &columnDataType, &columnSize, &decimalDigits, &nullable);
+    ret =
+        SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
+                       &column_data_type, &column_size, &decimal_digits, &nullable);
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
+    EXPECT_EQ(name_length, wcslen(column_names[i]));
 
-    std::wstring returned(columnName, columnName + nameLength);
-    EXPECT_EQ(returned, columnNames[i]);
-    EXPECT_EQ(columnDataType, columnDataTypes[i]);
-    EXPECT_EQ(columnSize, 1024);
-    EXPECT_EQ(decimalDigits, 0);
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(returned, column_names[i]);
+    EXPECT_EQ(column_data_type, column_data_types[i]);
+    EXPECT_EQ(column_size, 1024);
+    EXPECT_EQ(decimal_digits, 0);
     EXPECT_EQ(nullable, SQL_NULLABLE);
 
-    nameLength = 0;
-    columnDataType = 0;
-    columnSize = 0;
-    decimalDigits = 0;
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
     nullable = 0;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
-  size_t columnIndex = 0;
+  size_t column_index = 0;
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
-  SQLWCHAR* columnNames[] = {
+  SQLWCHAR* column_names[] = {
       (SQLWCHAR*)L"stiny_int_min",    (SQLWCHAR*)L"stiny_int_max",
       (SQLWCHAR*)L"utiny_int_min",    (SQLWCHAR*)L"utiny_int_max",
       (SQLWCHAR*)L"ssmall_int_min",   (SQLWCHAR*)L"ssmall_int_max",
@@ -2537,7 +2551,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
       (SQLWCHAR*)L"c_wvarchar",       (SQLWCHAR*)L"c_varchar",
       (SQLWCHAR*)L"date_min",         (SQLWCHAR*)L"date_max",
       (SQLWCHAR*)L"timestamp_min",    (SQLWCHAR*)L"timestamp_max"};
-  SQLSMALLINT columnDataTypes[] = {
+  SQLSMALLINT column_data_types[] = {
       SQL_INTEGER,        SQL_INTEGER,       SQL_INTEGER,  SQL_INTEGER,   SQL_INTEGER,
       SQL_INTEGER,        SQL_INTEGER,       SQL_INTEGER,  SQL_INTEGER,   SQL_INTEGER,
       SQL_BIGINT,         SQL_BIGINT,        SQL_BIGINT,   SQL_BIGINT,    SQL_BIGINT,
@@ -2545,11 +2559,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
       SQL_DOUBLE,         SQL_DOUBLE,        SQL_BIT,      SQL_BIT,       SQL_WVARCHAR,
       SQL_WVARCHAR,       SQL_WVARCHAR,      SQL_WVARCHAR, SQL_TYPE_DATE, SQL_TYPE_DATE,
       SQL_TYPE_TIMESTAMP, SQL_TYPE_TIMESTAMP};
-  SQLULEN columnSizes[] = {4, 4, 4,     4,     4,     4,     4,  4,  4,  4, 8,
-                           8, 8, 8,     8,     65536, 19,    19, 8,  8,  8, 8,
-                           1, 1, 65536, 65536, 65536, 65536, 10, 10, 23, 23};
-  SQLULEN columnDecimalDigits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,
-                                   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 23, 23};
+  SQLULEN column_sizes[] = {4, 4, 4,     4,     4,     4,     4,  4,  4,  4, 8,
+                            8, 8, 8,     8,     65536, 19,    19, 8,  8,  8, 8,
+                            1, 1, 65536, 65536, 65536, 65536, 10, 10, 23, 23};
+  SQLULEN column_decimal_digits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,
+                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 23, 23};
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
@@ -2560,62 +2574,63 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    columnIndex = i + 1;
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
 
-    ret = SQLDescribeCol(this->stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                         &columnDataType, &columnSize, &decimalDigits, &nullable);
+    ret =
+        SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
+                       &column_data_type, &column_size, &decimal_digits, &nullable);
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
+    EXPECT_EQ(name_length, wcslen(column_names[i]));
 
-    std::wstring returned(columnName, columnName + nameLength);
-    EXPECT_EQ(returned, columnNames[i]);
-    EXPECT_EQ(columnDataType, columnDataTypes[i]);
-    EXPECT_EQ(columnSize, columnSizes[i]);
-    EXPECT_EQ(decimalDigits, columnDecimalDigits[i]);
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(returned, column_names[i]);
+    EXPECT_EQ(column_data_type, column_data_types[i]);
+    EXPECT_EQ(column_size, column_sizes[i]);
+    EXPECT_EQ(decimal_digits, column_decimal_digits[i]);
     EXPECT_EQ(nullable, SQL_NULLABLE);
 
-    nameLength = 0;
-    columnDataType = 0;
-    columnSize = 0;
-    decimalDigits = 0;
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
     nullable = 0;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadata) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
-  size_t columnIndex = 0;
+  size_t column_index = 0;
 
-  SQLWCHAR sqlQuery[] = L"SELECT * from $scratch.ODBCTest LIMIT 1;";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLWCHAR sql_query[] = L"SELECT * from $scratch.ODBCTest LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLWCHAR* columnNames[] = {(SQLWCHAR*)L"sinteger_max",     (SQLWCHAR*)L"sbigint_max",
-                             (SQLWCHAR*)L"decimal_positive", (SQLWCHAR*)L"float_max",
-                             (SQLWCHAR*)L"double_max",       (SQLWCHAR*)L"bit_true",
-                             (SQLWCHAR*)L"date_max",         (SQLWCHAR*)L"time_max",
-                             (SQLWCHAR*)L"timestamp_max"};
-  SQLSMALLINT columnDataTypes[] = {SQL_INTEGER,   SQL_BIGINT,    SQL_DECIMAL,
-                                   SQL_FLOAT,     SQL_DOUBLE,    SQL_BIT,
-                                   SQL_TYPE_DATE, SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP};
-  SQLULEN columnSizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
-  SQLULEN columnDecimalDigits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
+  SQLWCHAR* column_names[] = {(SQLWCHAR*)L"sinteger_max",     (SQLWCHAR*)L"sbigint_max",
+                              (SQLWCHAR*)L"decimal_positive", (SQLWCHAR*)L"float_max",
+                              (SQLWCHAR*)L"double_max",       (SQLWCHAR*)L"bit_true",
+                              (SQLWCHAR*)L"date_max",         (SQLWCHAR*)L"time_max",
+                              (SQLWCHAR*)L"timestamp_max"};
+  SQLSMALLINT column_data_types[] = {SQL_INTEGER,   SQL_BIGINT,    SQL_DECIMAL,
+                                     SQL_FLOAT,     SQL_DOUBLE,    SQL_BIT,
+                                     SQL_TYPE_DATE, SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP};
+  SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
+  SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2623,62 +2638,63 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadata) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    columnIndex = i + 1;
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
 
-    ret = SQLDescribeCol(this->stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                         &columnDataType, &columnSize, &decimalDigits, &nullable);
+    ret =
+        SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
+                       &column_data_type, &column_size, &decimal_digits, &nullable);
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
+    EXPECT_EQ(name_length, wcslen(column_names[i]));
 
-    std::wstring returned(columnName, columnName + nameLength);
-    EXPECT_EQ(returned, columnNames[i]);
-    EXPECT_EQ(columnDataType, columnDataTypes[i]);
-    EXPECT_EQ(columnSize, columnSizes[i]);
-    EXPECT_EQ(decimalDigits, columnDecimalDigits[i]);
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(returned, column_names[i]);
+    EXPECT_EQ(column_data_type, column_data_types[i]);
+    EXPECT_EQ(column_size, column_sizes[i]);
+    EXPECT_EQ(decimal_digits, columndecimal_digits[i]);
     EXPECT_EQ(nullable, SQL_NULLABLE);
 
-    nameLength = 0;
-    columnDataType = 0;
-    columnSize = 0;
-    decimalDigits = 0;
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
     nullable = 0;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadataODBC2) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
-  size_t columnIndex = 0;
+  size_t column_index = 0;
 
-  SQLWCHAR sqlQuery[] = L"SELECT * from $scratch.ODBCTest LIMIT 1;";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLWCHAR sql_query[] = L"SELECT * from $scratch.ODBCTest LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLWCHAR* columnNames[] = {(SQLWCHAR*)L"sinteger_max",     (SQLWCHAR*)L"sbigint_max",
-                             (SQLWCHAR*)L"decimal_positive", (SQLWCHAR*)L"float_max",
-                             (SQLWCHAR*)L"double_max",       (SQLWCHAR*)L"bit_true",
-                             (SQLWCHAR*)L"date_max",         (SQLWCHAR*)L"time_max",
-                             (SQLWCHAR*)L"timestamp_max"};
-  SQLSMALLINT columnDataTypes[] = {SQL_INTEGER, SQL_BIGINT, SQL_DECIMAL,
-                                   SQL_FLOAT,   SQL_DOUBLE, SQL_BIT,
-                                   SQL_DATE,    SQL_TIME,   SQL_TIMESTAMP};
-  SQLULEN columnSizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
-  SQLULEN columnDecimalDigits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
+  SQLWCHAR* column_names[] = {(SQLWCHAR*)L"sinteger_max",     (SQLWCHAR*)L"sbigint_max",
+                              (SQLWCHAR*)L"decimal_positive", (SQLWCHAR*)L"float_max",
+                              (SQLWCHAR*)L"double_max",       (SQLWCHAR*)L"bit_true",
+                              (SQLWCHAR*)L"date_max",         (SQLWCHAR*)L"time_max",
+                              (SQLWCHAR*)L"timestamp_max"};
+  SQLSMALLINT column_data_types[] = {SQL_INTEGER, SQL_BIGINT, SQL_DECIMAL,
+                                     SQL_FLOAT,   SQL_DOUBLE, SQL_BIT,
+                                     SQL_DATE,    SQL_TIME,   SQL_TIMESTAMP};
+  SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
+  SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2686,56 +2702,57 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadataODBC2) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    columnIndex = i + 1;
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
 
-    ret = SQLDescribeCol(this->stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                         &columnDataType, &columnSize, &decimalDigits, &nullable);
+    ret =
+        SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
+                       &column_data_type, &column_size, &decimal_digits, &nullable);
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
+    EXPECT_EQ(name_length, wcslen(column_names[i]));
 
-    std::wstring returned(columnName, columnName + nameLength);
-    EXPECT_EQ(returned, columnNames[i]);
-    EXPECT_EQ(columnDataType, columnDataTypes[i]);
-    EXPECT_EQ(columnSize, columnSizes[i]);
-    EXPECT_EQ(decimalDigits, columnDecimalDigits[i]);
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(returned, column_names[i]);
+    EXPECT_EQ(column_data_type, column_data_types[i]);
+    EXPECT_EQ(column_size, column_sizes[i]);
+    EXPECT_EQ(decimal_digits, columndecimal_digits[i]);
     EXPECT_EQ(nullable, SQL_NULLABLE);
 
-    nameLength = 0;
-    columnDataType = 0;
-    columnSize = 0;
-    decimalDigits = 0;
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
     nullable = 0;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColAllTypesTableMetadata) {
-  this->connect();
+  this->Connect();
   this->CreateTableAllDataType();
 
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
-  size_t columnIndex = 0;
+  size_t column_index = 0;
 
-  SQLWCHAR sqlQuery[] = L"SELECT * from AllTypesTable LIMIT 1;";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLWCHAR sql_query[] = L"SELECT * from AllTypesTable LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLWCHAR* columnNames[] = {(SQLWCHAR*)L"bigint_col", (SQLWCHAR*)L"char_col",
-                             (SQLWCHAR*)L"varbinary_col", (SQLWCHAR*)L"double_col"};
-  SQLSMALLINT columnDataTypes[] = {SQL_BIGINT, SQL_WVARCHAR, SQL_BINARY, SQL_DOUBLE};
-  SQLULEN columnSizes[] = {8, 0, 0, 8};
+  SQLWCHAR* column_names[] = {(SQLWCHAR*)L"bigint_col", (SQLWCHAR*)L"char_col",
+                              (SQLWCHAR*)L"varbinary_col", (SQLWCHAR*)L"double_col"};
+  SQLSMALLINT column_data_types[] = {SQL_BIGINT, SQL_WVARCHAR, SQL_BINARY, SQL_DOUBLE};
+  SQLULEN column_sizes[] = {8, 0, 0, 8};
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2743,55 +2760,56 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColAllTypesTableMetadata) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    columnIndex = i + 1;
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
 
-    ret = SQLDescribeCol(this->stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                         &columnDataType, &columnSize, &decimalDigits, &nullable);
+    ret =
+        SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
+                       &column_data_type, &column_size, &decimal_digits, &nullable);
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
+    EXPECT_EQ(name_length, wcslen(column_names[i]));
 
-    std::wstring returned(columnName, columnName + nameLength);
-    EXPECT_EQ(returned, columnNames[i]);
-    EXPECT_EQ(columnDataType, columnDataTypes[i]);
-    EXPECT_EQ(columnSize, columnSizes[i]);
-    EXPECT_EQ(decimalDigits, 0);
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(returned, column_names[i]);
+    EXPECT_EQ(column_data_type, column_data_types[i]);
+    EXPECT_EQ(column_size, column_sizes[i]);
+    EXPECT_EQ(decimal_digits, 0);
     EXPECT_EQ(nullable, SQL_NULLABLE);
 
-    nameLength = 0;
-    columnDataType = 0;
-    columnSize = 0;
-    decimalDigits = 0;
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
     nullable = 0;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColUnicodeTableMetadata) {
-  this->connect();
+  this->Connect();
   this->CreateUnicodeTable();
 
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
-  size_t columnIndex = 1;
+  size_t column_index = 1;
 
-  SQLWCHAR sqlQuery[] = L"SELECT * from 数据 LIMIT 1;";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLWCHAR sql_query[] = L"SELECT * from 数据 LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLWCHAR expectedColumnName[] = L"资料";
-  SQLSMALLINT expectedColumnDataType = SQL_WVARCHAR;
-  SQLULEN expectedColumnSize = 0;
+  SQLWCHAR expected_column_name[] = L"资料";
+  SQLSMALLINT expected_column_data_type = SQL_WVARCHAR;
+  SQLULEN expected_column_size = 0;
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2799,37 +2817,37 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColUnicodeTableMetadata) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  ret = SQLDescribeCol(this->stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                       &columnDataType, &columnSize, &decimalDigits, &nullable);
+  ret = SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
+                       &column_data_type, &column_size, &decimal_digits, &nullable);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(nameLength, wcslen(expectedColumnName));
+  EXPECT_EQ(name_length, wcslen(expected_column_name));
 
-  std::wstring returned(columnName, columnName + nameLength);
-  EXPECT_EQ(returned, expectedColumnName);
-  EXPECT_EQ(columnDataType, expectedColumnDataType);
-  EXPECT_EQ(columnSize, expectedColumnSize);
-  EXPECT_EQ(decimalDigits, 0);
+  std::wstring returned(column_name, column_name + name_length);
+  EXPECT_EQ(returned, expected_column_name);
+  EXPECT_EQ(column_data_type, expected_column_data_type);
+  EXPECT_EQ(column_size, expected_column_size);
+  EXPECT_EQ(decimal_digits, 0);
   EXPECT_EQ(nullable, SQL_NULLABLE);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeCol) {
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
-  size_t columnIndex = 0;
+  size_t column_index = 0;
 
-  SQLWCHAR* columnNames[] = {
+  SQLWCHAR* column_names[] = {
       (SQLWCHAR*)L"TABLE_CAT",        (SQLWCHAR*)L"TABLE_SCHEM",
       (SQLWCHAR*)L"TABLE_NAME",       (SQLWCHAR*)L"COLUMN_NAME",
       (SQLWCHAR*)L"DATA_TYPE",        (SQLWCHAR*)L"TYPE_NAME",
@@ -2839,110 +2857,112 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeCol) {
       (SQLWCHAR*)L"COLUMN_DEF",       (SQLWCHAR*)L"SQL_DATA_TYPE",
       (SQLWCHAR*)L"SQL_DATETIME_SUB", (SQLWCHAR*)L"CHAR_OCTET_LENGTH",
       (SQLWCHAR*)L"ORDINAL_POSITION", (SQLWCHAR*)L"IS_NULLABLE"};
-  SQLSMALLINT columnDataTypes[] = {
+  SQLSMALLINT column_data_types[] = {
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_SMALLINT, SQL_WVARCHAR,
       SQL_INTEGER,  SQL_INTEGER,  SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR,
       SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_INTEGER,  SQL_INTEGER,  SQL_WVARCHAR};
-  SQLULEN columnSizes[] = {1024, 1024, 1024, 1024, 2, 1024, 4, 4, 2,
-                           2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
+  SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 2, 1024, 4, 4, 2,
+                            2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
 
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    columnIndex = i + 1;
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
 
-    ret = SQLDescribeCol(this->stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                         &columnDataType, &columnSize, &decimalDigits, &nullable);
+    ret =
+        SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
+                       &column_data_type, &column_size, &decimal_digits, &nullable);
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
+    EXPECT_EQ(name_length, wcslen(column_names[i]));
 
-    std::wstring returned(columnName, columnName + nameLength);
-    EXPECT_EQ(returned, columnNames[i]);
-    EXPECT_EQ(columnDataType, columnDataTypes[i]);
-    EXPECT_EQ(columnSize, columnSizes[i]);
-    EXPECT_EQ(decimalDigits, 0);
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(returned, column_names[i]);
+    EXPECT_EQ(column_data_type, column_data_types[i]);
+    EXPECT_EQ(column_size, column_sizes[i]);
+    EXPECT_EQ(decimal_digits, 0);
     EXPECT_EQ(nullable, SQL_NULLABLE);
 
-    nameLength = 0;
-    columnDataType = 0;
-    columnSize = 0;
-    decimalDigits = 0;
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
     nullable = 0;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeColODBC2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
-  size_t columnIndex = 0;
+  size_t column_index = 0;
 
-  SQLWCHAR* columnNames[] = {(SQLWCHAR*)L"TABLE_QUALIFIER",
-                             (SQLWCHAR*)L"TABLE_OWNER",
-                             (SQLWCHAR*)L"TABLE_NAME",
-                             (SQLWCHAR*)L"COLUMN_NAME",
-                             (SQLWCHAR*)L"DATA_TYPE",
-                             (SQLWCHAR*)L"TYPE_NAME",
-                             (SQLWCHAR*)L"PRECISION",
-                             (SQLWCHAR*)L"LENGTH",
-                             (SQLWCHAR*)L"SCALE",
-                             (SQLWCHAR*)L"RADIX",
-                             (SQLWCHAR*)L"NULLABLE",
-                             (SQLWCHAR*)L"REMARKS",
-                             (SQLWCHAR*)L"COLUMN_DEF",
-                             (SQLWCHAR*)L"SQL_DATA_TYPE",
-                             (SQLWCHAR*)L"SQL_DATETIME_SUB",
-                             (SQLWCHAR*)L"CHAR_OCTET_LENGTH",
-                             (SQLWCHAR*)L"ORDINAL_POSITION",
-                             (SQLWCHAR*)L"IS_NULLABLE"};
-  SQLSMALLINT columnDataTypes[] = {
+  SQLWCHAR* column_names[] = {(SQLWCHAR*)L"TABLE_QUALIFIER",
+                              (SQLWCHAR*)L"TABLE_OWNER",
+                              (SQLWCHAR*)L"TABLE_NAME",
+                              (SQLWCHAR*)L"COLUMN_NAME",
+                              (SQLWCHAR*)L"DATA_TYPE",
+                              (SQLWCHAR*)L"TYPE_NAME",
+                              (SQLWCHAR*)L"PRECISION",
+                              (SQLWCHAR*)L"LENGTH",
+                              (SQLWCHAR*)L"SCALE",
+                              (SQLWCHAR*)L"RADIX",
+                              (SQLWCHAR*)L"NULLABLE",
+                              (SQLWCHAR*)L"REMARKS",
+                              (SQLWCHAR*)L"COLUMN_DEF",
+                              (SQLWCHAR*)L"SQL_DATA_TYPE",
+                              (SQLWCHAR*)L"SQL_DATETIME_SUB",
+                              (SQLWCHAR*)L"CHAR_OCTET_LENGTH",
+                              (SQLWCHAR*)L"ORDINAL_POSITION",
+                              (SQLWCHAR*)L"IS_NULLABLE"};
+  SQLSMALLINT column_data_types[] = {
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_SMALLINT, SQL_WVARCHAR,
       SQL_INTEGER,  SQL_INTEGER,  SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR,
       SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_INTEGER,  SQL_INTEGER,  SQL_WVARCHAR};
-  SQLULEN columnSizes[] = {1024, 1024, 1024, 1024, 2, 1024, 4, 4, 2,
-                           2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
+  SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 2, 1024, 4, 4, 2,
+                            2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
 
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    columnIndex = i + 1;
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
 
-    ret = SQLDescribeCol(this->stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                         &columnDataType, &columnSize, &decimalDigits, &nullable);
+    ret =
+        SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
+                       &column_data_type, &column_size, &decimal_digits, &nullable);
 
     EXPECT_EQ(ret, SQL_SUCCESS);
 
-    EXPECT_EQ(nameLength, wcslen(columnNames[i]));
+    EXPECT_EQ(name_length, wcslen(column_names[i]));
 
-    std::wstring returned(columnName, columnName + nameLength);
-    EXPECT_EQ(returned, columnNames[i]);
-    EXPECT_EQ(columnDataType, columnDataTypes[i]);
-    EXPECT_EQ(columnSize, columnSizes[i]);
-    EXPECT_EQ(decimalDigits, 0);
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(returned, column_names[i]);
+    EXPECT_EQ(column_data_type, column_data_types[i]);
+    EXPECT_EQ(column_size, column_sizes[i]);
+    EXPECT_EQ(decimal_digits, 0);
     EXPECT_EQ(nullable, SQL_NULLABLE);
 
-    nameLength = 0;
-    columnDataType = 0;
-    columnSize = 0;
-    decimalDigits = 0;
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
     nullable = 0;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
@@ -30,7 +30,7 @@ namespace arrow::flight::sql::odbc {
 
 #ifdef SQL_ATTR_ASYNC_DBC_EVENT
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAsyncDbcEventUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_EVENT, 0, 0);
 
@@ -38,51 +38,51 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAsyncDbcEventUnsupported)
   // Driver Manager on Windows returns error code HY118
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY118);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_ENABLE
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAyncEnableUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_ENABLE, 0, 0);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_DBC_PCALLBACK
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAyncDbcPcCallbackUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, 0, 0);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_DBC_PCONTEXT
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAyncDbcPcContextUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, 0, 0);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAutoIpdReadOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify read-only attribute cannot be set
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_AUTO_IPD, 0, 0);
@@ -90,11 +90,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAutoIpdReadOnly) {
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY092);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrConnectionDeadReadOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify read-only attribute cannot be set
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_CONNECTION_DEAD, 0, 0);
@@ -102,35 +102,35 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrConnectionDeadReadOnly) {
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY092);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 #ifdef SQL_ATTR_DBC_INFO_TOKEN
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrDbcInfoTokenUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_DBC_INFO_TOKEN, 0, 0);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrEnlistInDtcUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ENLIST_IN_DTC, 0, 0);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
-  this->allocEnvConnHandles();
+  this->AllocEnvConnHandles();
 
   // Verify DM-only attribute is settable via Driver Manager
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ODBC_CURSORS,
@@ -138,13 +138,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  std::string connect_str = this->getConnectionString();
-  this->connectWithString(connect_str);
-  this->disconnect();
+  std::string connect_str = this->GetConnectionString();
+  this->ConnectWithString(connect_str);
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrQuietModeReadOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify read-only attribute cannot be set
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_QUIET_MODE, 0, 0);
@@ -152,22 +152,22 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrQuietModeReadOnly) {
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY092);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTraceDMOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify DM-only attribute is settable via Driver Manager
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_TRACE,
                                     reinterpret_cast<SQLPOINTER>(SQL_OPT_TRACE_OFF), 0);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTracefileDMOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify DM-only attribute is handled by Driver Manager
 
@@ -180,11 +180,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTracefileDMOnly) {
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY000);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTranslateLabDMOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify DM-only attribute is handled by Driver Manager
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, 0, 0);
@@ -192,22 +192,22 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTranslateLabDMOnly) {
   // Checks for invalid argument return error
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY024);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTranslateOptionUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_OPTION, 0, 0);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTxnIsolationUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret =
       SQLSetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION,
@@ -215,12 +215,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTxnIsolationUnsupported) 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 #ifdef SQL_ATTR_DBC_INFO_TOKEN
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrDbcInfoTokenSetOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify that set-only attribute cannot be read
   SQLPOINTER ptr = NULL;
@@ -229,12 +229,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrDbcInfoTokenSetOnly) {
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY092);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrOdbcCursorsDMOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify that DM-only attribute is handled by driver manager
   SQLULEN cursor_attr;
@@ -244,11 +244,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrOdbcCursorsDMOnly) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(cursor_attr, SQL_CUR_USE_DRIVER);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTraceDMOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify that DM-only attribute is handled by driver manager
   SQLUINTEGER trace;
@@ -257,45 +257,45 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTraceDMOnly) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(trace, SQL_OPT_TRACE_OFF);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTraceFileDMOnly) {
-  this->connect();
+  this->Connect();
 
   // Verify that DM-only attribute is handled by driver manager
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE];
-  SQLINTEGER outstrlen;
-  SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRACEFILE, outstr,
-                                    ODBC_BUFFER_SIZE, &outstrlen);
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE];
+  SQLINTEGER out_str_len;
+  SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRACEFILE, out_str,
+                                    ODBC_BUFFER_SIZE, &out_str_len);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
   // Length is returned in bytes for SQLGetConnectAttr,
   // we want the number of characters
-  outstrlen /= driver::odbcabstraction::GetSqlWCharSize();
+  out_str_len /= driver::odbcabstraction::GetSqlWCharSize();
   std::string out_connection_string =
-      ODBC::SqlWcharToString(outstr, static_cast<SQLSMALLINT>(outstrlen));
+      ODBC::SqlWcharToString(out_str, static_cast<SQLSMALLINT>(out_str_len));
   EXPECT_TRUE(!out_connection_string.empty());
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTranslateLibUnsupported) {
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE];
-  SQLINTEGER outstrlen;
-  SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, outstr,
-                                    ODBC_BUFFER_SIZE, &outstrlen);
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE];
+  SQLINTEGER out_str_len;
+  SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, out_str,
+                                    ODBC_BUFFER_SIZE, &out_str_len);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTranslateOptionUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLINTEGER option;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_OPTION, &option, 0, 0);
@@ -303,11 +303,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTranslateOptionUnsupporte
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTxnIsolationUnsupported) {
-  this->connect();
+  this->Connect();
 
   SQLINTEGER isolation;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, &isolation, 0, 0);
@@ -315,13 +315,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTxnIsolationUnsupported) 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 #ifdef SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE
 TYPED_TEST(FlightSQLODBCTestBase,
            TestSQLGetConnectAttrAsyncDbcFunctionsEnableUnsupported) {
-  this->connect();
+  this->Connect();
 
   // Verifies that the Windows driver manager returns HY114 for unsupported functionality
   SQLUINTEGER enable;
@@ -331,7 +331,7 @@ TYPED_TEST(FlightSQLODBCTestBase,
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY114);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
@@ -339,7 +339,7 @@ TYPED_TEST(FlightSQLODBCTestBase,
 
 #ifdef SQL_ATTR_ASYNC_DBC_EVENT
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcEventDefault) {
-  this->connect();
+  this->Connect();
 
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_EVENT, ptr, 0, 0);
@@ -347,13 +347,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcEventDefault) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_DBC_PCALLBACK
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcPcallbackDefault) {
-  this->connect();
+  this->Connect();
 
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, ptr, 0, 0);
@@ -361,13 +361,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcPcallbackDefault)
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_DBC_PCONTEXT
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcPcontextDefault) {
-  this->connect();
+  this->Connect();
 
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, ptr, 0, 0);
@@ -375,12 +375,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcPcontextDefault) 
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncEnableDefault) {
-  this->connect();
+  this->Connect();
 
   SQLULEN enable;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_ENABLE, &enable, 0, 0);
@@ -388,11 +388,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncEnableDefault) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(enable, SQL_ASYNC_ENABLE_OFF);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAutoIpdDefault) {
-  this->connect();
+  this->Connect();
 
   SQLUINTEGER ipd;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_AUTO_IPD, &ipd, 0, 0);
@@ -400,11 +400,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAutoIpdDefault) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(ipd, static_cast<SQLUINTEGER>(SQL_FALSE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAutocommitDefault) {
-  this->connect();
+  this->Connect();
 
   SQLUINTEGER auto_commit;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_AUTOCOMMIT, &auto_commit, 0, 0);
@@ -412,11 +412,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAutocommitDefault) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(auto_commit, SQL_AUTOCOMMIT_ON);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrEnlistInDtcDefault) {
-  this->connect();
+  this->Connect();
 
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ENLIST_IN_DTC, ptr, 0, 0);
@@ -424,11 +424,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrEnlistInDtcDefault) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrQuietModeDefault) {
-  this->connect();
+  this->Connect();
 
   HWND ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_QUIET_MODE, ptr, 0, 0);
@@ -436,11 +436,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrQuietModeDefault) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAccessModeValid) {
-  this->connect();
+  this->Connect();
 
   // The driver always returns SQL_MODE_READ_WRITE
 
@@ -472,11 +472,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAccessModeValid) {
   // Verify warning status
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_01S02);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrConnectionTimeoutValid) {
-  this->connect();
+  this->Connect();
 
   // Check default value first
   SQLUINTEGER timeout = -1;
@@ -498,11 +498,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrConnectionTimeoutValid) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(timeout, 42);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrLoginTimeoutValid) {
-  this->connect();
+  this->Connect();
 
   // Check default value first
   SQLUINTEGER timeout = -1;
@@ -523,11 +523,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrLoginTimeoutValid) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_EQ(timeout, 42);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrPacketSizeValid) {
-  this->connect();
+  this->Connect();
 
   // The driver always returns 0. PACKET_SIZE value is unused by the driver.
 
@@ -559,7 +559,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrPacketSizeValid) {
   // Verify warning status
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_01S02);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -31,11 +31,11 @@ namespace arrow::flight::sql::odbc {
 // Helper Functions
 
 // Validate unsigned short SQLUSMALLINT return value
-void validate(SQLHDBC connection, SQLUSMALLINT infoType, SQLUSMALLINT expected_value) {
+void Validate(SQLHDBC connection, SQLUSMALLINT info_type, SQLUSMALLINT expected_value) {
   SQLUSMALLINT info_value;
   SQLSMALLINT message_length;
 
-  SQLRETURN ret = SQLGetInfo(connection, infoType, &info_value, 0, &message_length);
+  SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -43,11 +43,11 @@ void validate(SQLHDBC connection, SQLUSMALLINT infoType, SQLUSMALLINT expected_v
 }
 
 // Validate unsigned long SQLUINTEGER return value
-void validate(SQLHDBC connection, SQLUSMALLINT infoType, SQLUINTEGER expected_value) {
+void Validate(SQLHDBC connection, SQLUSMALLINT info_type, SQLUINTEGER expected_value) {
   SQLUINTEGER info_value;
   SQLSMALLINT message_length;
 
-  SQLRETURN ret = SQLGetInfo(connection, infoType, &info_value, 0, &message_length);
+  SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -55,11 +55,11 @@ void validate(SQLHDBC connection, SQLUSMALLINT infoType, SQLUINTEGER expected_va
 }
 
 // Validate unsigned length SQLULEN return value
-void validate(SQLHDBC connection, SQLUSMALLINT infoType, SQLULEN expected_value) {
+void Validate(SQLHDBC connection, SQLUSMALLINT info_type, SQLULEN expected_value) {
   SQLULEN info_value;
   SQLSMALLINT message_length;
 
-  SQLRETURN ret = SQLGetInfo(connection, infoType, &info_value, 0, &message_length);
+  SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -67,12 +67,12 @@ void validate(SQLHDBC connection, SQLUSMALLINT infoType, SQLULEN expected_value)
 }
 
 // Validate wchar string SQLWCHAR return value
-void validate(SQLHDBC connection, SQLUSMALLINT infoType, SQLWCHAR* expected_value) {
+void Validate(SQLHDBC connection, SQLUSMALLINT info_type, SQLWCHAR* expected_value) {
   SQLWCHAR info_value[ODBC_BUFFER_SIZE] = L"";
   SQLSMALLINT message_length;
 
   SQLRETURN ret =
-      SQLGetInfo(connection, infoType, info_value, ODBC_BUFFER_SIZE, &message_length);
+      SQLGetInfo(connection, info_type, info_value, ODBC_BUFFER_SIZE, &message_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -80,12 +80,12 @@ void validate(SQLHDBC connection, SQLUSMALLINT infoType, SQLWCHAR* expected_valu
 }
 
 // Validate unsigned long SQLUINTEGER return value is greater than
-void validateGreaterThan(SQLHDBC connection, SQLUSMALLINT infoType,
+void ValidateGreaterThan(SQLHDBC connection, SQLUSMALLINT info_type,
                          SQLUINTEGER compared_value) {
   SQLUINTEGER info_value;
   SQLSMALLINT message_length;
 
-  SQLRETURN ret = SQLGetInfo(connection, infoType, &info_value, 0, &message_length);
+  SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -93,12 +93,12 @@ void validateGreaterThan(SQLHDBC connection, SQLUSMALLINT infoType,
 }
 
 // Validate unsigned length SQLULEN return value is greater than
-void validateGreaterThan(SQLHDBC connection, SQLUSMALLINT infoType,
+void ValidateGreaterThan(SQLHDBC connection, SQLUSMALLINT info_type,
                          SQLULEN compared_value) {
   SQLULEN info_value;
   SQLSMALLINT message_length;
 
-  SQLRETURN ret = SQLGetInfo(connection, infoType, &info_value, 0, &message_length);
+  SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -106,15 +106,15 @@ void validateGreaterThan(SQLHDBC connection, SQLUSMALLINT infoType,
 }
 
 // Validate wchar string SQLWCHAR return value is not empty
-void validateNotEmptySQLWCHAR(SQLHDBC connection, SQLUSMALLINT infoType,
-                              bool allowTruncation) {
+void ValidateNotEmptySQLWCHAR(SQLHDBC connection, SQLUSMALLINT info_type,
+                              bool allow_truncation) {
   SQLWCHAR info_value[ODBC_BUFFER_SIZE] = L"";
   SQLSMALLINT message_length;
 
   SQLRETURN ret =
-      SQLGetInfo(connection, infoType, info_value, ODBC_BUFFER_SIZE, &message_length);
+      SQLGetInfo(connection, info_type, info_value, ODBC_BUFFER_SIZE, &message_length);
 
-  if (allowTruncation && ret == SQL_SUCCESS_WITH_INFO) {
+  if (allow_truncation && ret == SQL_SUCCESS_WITH_INFO) {
     EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
   } else {
     EXPECT_EQ(ret, SQL_SUCCESS);
@@ -126,88 +126,88 @@ void validateNotEmptySQLWCHAR(SQLHDBC connection, SQLUSMALLINT infoType,
 // Driver Information
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoActiveEnvironments) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ACTIVE_ENVIRONMENTS, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_ACTIVE_ENVIRONMENTS, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 #ifdef SQL_ASYNC_DBC_FUNCTIONS
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAsyncDbcFunctions) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ASYNC_DBC_FUNCTIONS,
+  Validate(this->conn, SQL_ASYNC_DBC_FUNCTIONS,
            static_cast<SQLUINTEGER>(SQL_ASYNC_DBC_NOT_CAPABLE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAsyncMode) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ASYNC_MODE, static_cast<SQLUINTEGER>(SQL_AM_NONE));
+  Validate(this->conn, SQL_ASYNC_MODE, static_cast<SQLUINTEGER>(SQL_AM_NONE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 #ifdef SQL_ASYNC_NOTIFICATION
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAsyncNotification) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ASYNC_NOTIFICATION,
+  Validate(this->conn, SQL_ASYNC_NOTIFICATION,
            static_cast<SQLUINTEGER>(SQL_ASYNC_NOTIFICATION_NOT_CAPABLE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoBatchRowCount) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_BATCH_ROW_COUNT, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_BATCH_ROW_COUNT, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoBatchSupport) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_BATCH_SUPPORT, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_BATCH_SUPPORT, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDataSourceName) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DATA_SOURCE_NAME, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_DATA_SOURCE_NAME, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 #ifdef SQL_DRIVER_AWARE_POOLING_SUPPORTED
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverAwarePoolingSupported) {
   // A driver does not need to implement SQL_DRIVER_AWARE_POOLING_SUPPORTED and the
   // Driver Manager will not honor to the driver's return value.
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DRIVER_AWARE_POOLING_SUPPORTED,
+  Validate(this->conn, SQL_DRIVER_AWARE_POOLING_SUPPORTED,
            static_cast<SQLUINTEGER>(SQL_DRIVER_AWARE_POOLING_NOT_CAPABLE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 // These information types are implemented by the Driver Manager alone.
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverHdbc) {
-  this->connect();
+  this->Connect();
 
   // Value returned from driver manager is the connection address
-  validateGreaterThan(this->conn, SQL_DRIVER_HDBC, static_cast<SQLULEN>(0));
+  ValidateGreaterThan(this->conn, SQL_DRIVER_HDBC, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // These information types are implemented by the Driver Manager alone.
@@ -215,35 +215,35 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverHdesc) {
   // TODO This is failing due to no descriptor being created
   // enable after SQL_HANDLE_DESC is supported
   GTEST_SKIP();
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DRIVER_HDESC, static_cast<SQLULEN>(0));
+  Validate(this->conn, SQL_DRIVER_HDESC, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // These information types are implemented by the Driver Manager alone.
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverHenv) {
-  this->connect();
+  this->Connect();
 
   // Value returned from driver manager is the env address
-  validateGreaterThan(this->conn, SQL_DRIVER_HENV, static_cast<SQLULEN>(0));
+  ValidateGreaterThan(this->conn, SQL_DRIVER_HENV, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // These information types are implemented by the Driver Manager alone.
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverHlib) {
-  this->connect();
+  this->Connect();
 
-  validateGreaterThan(this->conn, SQL_DRIVER_HLIB, static_cast<SQLULEN>(0));
+  ValidateGreaterThan(this->conn, SQL_DRIVER_HLIB, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // These information types are implemented by the Driver Manager alone.
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverHstmt) {
-  this->connect();
+  this->Connect();
 
   // Value returned from driver manager is the stmt address
   SQLHSTMT local_stmt = this->stmt;
@@ -251,140 +251,140 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverHstmt) {
   EXPECT_EQ(ret, SQL_SUCCESS);
   EXPECT_GT(local_stmt, static_cast<SQLHSTMT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverName) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DRIVER_NAME, (SQLWCHAR*)L"Arrow Flight ODBC Driver");
+  Validate(this->conn, SQL_DRIVER_NAME, (SQLWCHAR*)L"Arrow Flight ODBC Driver");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverOdbcVer) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DRIVER_ODBC_VER, (SQLWCHAR*)L"03.80");
+  Validate(this->conn, SQL_DRIVER_ODBC_VER, (SQLWCHAR*)L"03.80");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverVer) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DRIVER_VER, (SQLWCHAR*)L"00.09.0000.0");
+  Validate(this->conn, SQL_DRIVER_VER, (SQLWCHAR*)L"00.09.0000.0");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDynamicCursorAttributes1) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES1, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES1, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDynamicCursorAttributes2) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES2, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES2, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoForwardOnlyCursorAttributes1) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1,
+  Validate(this->conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1,
            static_cast<SQLUINTEGER>(SQL_CA1_NEXT));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoForwardOnlyCursorAttributes2) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2,
+  Validate(this->conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2,
            static_cast<SQLUINTEGER>(SQL_CA2_READ_ONLY_CONCURRENCY));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoFileUsage) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_FILE_USAGE, static_cast<SQLUSMALLINT>(SQL_FILE_NOT_SUPPORTED));
+  Validate(this->conn, SQL_FILE_USAGE, static_cast<SQLUSMALLINT>(SQL_FILE_NOT_SUPPORTED));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoGetDataExtensions) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_GETDATA_EXTENSIONS,
+  Validate(this->conn, SQL_GETDATA_EXTENSIONS,
            static_cast<SQLUINTEGER>(SQL_GD_ANY_COLUMN | SQL_GD_ANY_ORDER));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoSchemaViews) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_INFO_SCHEMA_VIEWS,
+  Validate(this->conn, SQL_INFO_SCHEMA_VIEWS,
            static_cast<SQLUINTEGER>(SQL_ISV_TABLES | SQL_ISV_COLUMNS | SQL_ISV_VIEWS));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoKeysetCursorAttributes1) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_KEYSET_CURSOR_ATTRIBUTES1, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_KEYSET_CURSOR_ATTRIBUTES1, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoKeysetCursorAttributes2) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_KEYSET_CURSOR_ATTRIBUTES2, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_KEYSET_CURSOR_ATTRIBUTES2, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxAsyncConcurrentStatements) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_ASYNC_CONCURRENT_STATEMENTS, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_MAX_ASYNC_CONCURRENT_STATEMENTS, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxConcurrentActivities) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_CONCURRENT_ACTIVITIES, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_CONCURRENT_ACTIVITIES, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxDriverConnections) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_DRIVER_CONNECTIONS, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_DRIVER_CONNECTIONS, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoOdbcInterfaceConformance) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ODBC_INTERFACE_CONFORMANCE,
+  Validate(this->conn, SQL_ODBC_INTERFACE_CONFORMANCE,
            static_cast<SQLUINTEGER>(SQL_OIC_CORE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // case SQL_ODBC_STANDARD_CLI_CONFORMANCE: - mentioned in SQLGetInfo spec with no
@@ -392,918 +392,918 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoOdbcInterfaceConformance) {
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoOdbcStandardCliConformance) {
   // Type commented out in odbc_connection.cc
   GTEST_SKIP();
-  this->connect();
+  this->Connect();
 
   // Type does not exist in sql.h
-  // validate(this->conn, SQL_ODBC_STANDARD_CLI_CONFORMANCE,
+  // Validate(this->conn, SQL_ODBC_STANDARD_CLI_CONFORMANCE,
   // static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoOdbcVer) {
   // This is implemented only in the Driver Manager.
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ODBC_VER, (SQLWCHAR*)L"03.80.0000");
+  Validate(this->conn, SQL_ODBC_VER, (SQLWCHAR*)L"03.80.0000");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoParamArrayRowCounts) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_PARAM_ARRAY_ROW_COUNTS,
+  Validate(this->conn, SQL_PARAM_ARRAY_ROW_COUNTS,
            static_cast<SQLUINTEGER>(SQL_PARC_NO_BATCH));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoParamArraySelects) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_PARAM_ARRAY_SELECTS,
+  Validate(this->conn, SQL_PARAM_ARRAY_SELECTS,
            static_cast<SQLUINTEGER>(SQL_PAS_NO_SELECT));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoRowUpdates) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ROW_UPDATES, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_ROW_UPDATES, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoSearchPatternEscape) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_SEARCH_PATTERN_ESCAPE, (SQLWCHAR*)L"\\");
+  Validate(this->conn, SQL_SEARCH_PATTERN_ESCAPE, (SQLWCHAR*)L"\\");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoServerName) {
-  this->connect();
+  this->Connect();
 
-  validateNotEmptySQLWCHAR(this->conn, SQL_SERVER_NAME, false);
+  ValidateNotEmptySQLWCHAR(this->conn, SQL_SERVER_NAME, false);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoStaticCursorAttributes1) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_STATIC_CURSOR_ATTRIBUTES1, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_STATIC_CURSOR_ATTRIBUTES1, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoStaticCursorAttributes2) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_STATIC_CURSOR_ATTRIBUTES2, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_STATIC_CURSOR_ATTRIBUTES2, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // DBMS Product Information
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDatabaseName) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DATABASE_NAME, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_DATABASE_NAME, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDbmsName) {
-  this->connect();
+  this->Connect();
 
-  validateNotEmptySQLWCHAR(this->conn, SQL_DBMS_NAME, false);
+  ValidateNotEmptySQLWCHAR(this->conn, SQL_DBMS_NAME, false);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDbmsVer) {
-  this->connect();
+  this->Connect();
 
-  validateNotEmptySQLWCHAR(this->conn, SQL_DBMS_VER, false);
+  ValidateNotEmptySQLWCHAR(this->conn, SQL_DBMS_VER, false);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // Data Source Information
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAccessibleProcedures) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ACCESSIBLE_PROCEDURES, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_ACCESSIBLE_PROCEDURES, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAccessibleTables) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ACCESSIBLE_TABLES, (SQLWCHAR*)L"Y");
+  Validate(this->conn, SQL_ACCESSIBLE_TABLES, (SQLWCHAR*)L"Y");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoBookmarkPersistence) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_BOOKMARK_PERSISTENCE, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_BOOKMARK_PERSISTENCE, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCatalogTerm) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CATALOG_TERM, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_CATALOG_TERM, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCollationSeq) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_COLLATION_SEQ, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_COLLATION_SEQ, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConcatNullBehavior) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONCAT_NULL_BEHAVIOR, static_cast<SQLUSMALLINT>(SQL_CB_NULL));
+  Validate(this->conn, SQL_CONCAT_NULL_BEHAVIOR, static_cast<SQLUSMALLINT>(SQL_CB_NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCursorCommitBehavior) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CURSOR_COMMIT_BEHAVIOR,
+  Validate(this->conn, SQL_CURSOR_COMMIT_BEHAVIOR,
            static_cast<SQLUSMALLINT>(SQL_CB_CLOSE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCursorRollbackBehavior) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CURSOR_ROLLBACK_BEHAVIOR,
+  Validate(this->conn, SQL_CURSOR_ROLLBACK_BEHAVIOR,
            static_cast<SQLUSMALLINT>(SQL_CB_CLOSE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCursorSensitivity) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CURSOR_SENSITIVITY, static_cast<SQLUINTEGER>(SQL_UNSPECIFIED));
+  Validate(this->conn, SQL_CURSOR_SENSITIVITY, static_cast<SQLUINTEGER>(SQL_UNSPECIFIED));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDataSourceReadOnly) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DATA_SOURCE_READ_ONLY, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_DATA_SOURCE_READ_ONLY, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDefaultTxnIsolation) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DEFAULT_TXN_ISOLATION, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DEFAULT_TXN_ISOLATION, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDescribeParameter) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DESCRIBE_PARAMETER, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_DESCRIBE_PARAMETER, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMultResultSets) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MULT_RESULT_SETS, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_MULT_RESULT_SETS, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMultipleActiveTxn) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MULTIPLE_ACTIVE_TXN, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_MULTIPLE_ACTIVE_TXN, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoNeedLongDataLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_NEED_LONG_DATA_LEN, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_NEED_LONG_DATA_LEN, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoNullCollation) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_NULL_COLLATION, static_cast<SQLUSMALLINT>(SQL_NC_START));
+  Validate(this->conn, SQL_NULL_COLLATION, static_cast<SQLUSMALLINT>(SQL_NC_START));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoProcedureTerm) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_PROCEDURE_TERM, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_PROCEDURE_TERM, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoSchemaTerm) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_SCHEMA_TERM, (SQLWCHAR*)L"schema");
+  Validate(this->conn, SQL_SCHEMA_TERM, (SQLWCHAR*)L"schema");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoScrollOptions) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_SCROLL_OPTIONS, static_cast<SQLUINTEGER>(SQL_SO_FORWARD_ONLY));
+  Validate(this->conn, SQL_SCROLL_OPTIONS, static_cast<SQLUINTEGER>(SQL_SO_FORWARD_ONLY));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoTableTerm) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_TABLE_TERM, (SQLWCHAR*)L"table");
+  Validate(this->conn, SQL_TABLE_TERM, (SQLWCHAR*)L"table");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoTxnCapable) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_TXN_CAPABLE, static_cast<SQLUSMALLINT>(SQL_TC_NONE));
+  Validate(this->conn, SQL_TXN_CAPABLE, static_cast<SQLUSMALLINT>(SQL_TC_NONE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoTxnIsolationOption) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_TXN_ISOLATION_OPTION, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_TXN_ISOLATION_OPTION, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoUserName) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_USER_NAME, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_USER_NAME, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // Supported SQL
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAggregateFunctions) {
-  this->connect();
+  this->Connect();
 
-  validate(
+  Validate(
       this->conn, SQL_AGGREGATE_FUNCTIONS,
       static_cast<SQLUINTEGER>(SQL_AF_ALL | SQL_AF_AVG | SQL_AF_COUNT | SQL_AF_DISTINCT |
                                SQL_AF_MAX | SQL_AF_MIN | SQL_AF_SUM));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAlterDomain) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ALTER_DOMAIN, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_ALTER_DOMAIN, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAlterSchema) {
   // Type commented out in odbc_connection.cc
   GTEST_SKIP();
-  this->connect();
+  this->Connect();
 
   // Type does not exist in sql.h
-  // validate(this->conn, SQL_ALTER_SCHEMA, static_cast<SQLUINTEGER>(0));
+  // Validate(this->conn, SQL_ALTER_SCHEMA, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAlterTable) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ALTER_TABLE, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_ALTER_TABLE, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoAnsiSqlDatetimeLiterals) {
   // Type commented out in odbc_connection.cc
   GTEST_SKIP();
-  this->connect();
+  this->Connect();
 
   // Type does not exist in sql.h
-  // validate(this->conn, SQL_ANSI_SQL_DATETIME_LITERALS, (SQLWCHAR*)L"");
+  // Validate(this->conn, SQL_ANSI_SQL_DATETIME_LITERALS, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCatalogLocation) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CATALOG_LOCATION, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_CATALOG_LOCATION, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCatalogName) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CATALOG_NAME, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_CATALOG_NAME, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCatalogNameSeparator) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CATALOG_NAME_SEPARATOR, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_CATALOG_NAME_SEPARATOR, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoCatalogUsage) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CATALOG_USAGE, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CATALOG_USAGE, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoColumnAlias) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_COLUMN_ALIAS, (SQLWCHAR*)L"Y");
+  Validate(this->conn, SQL_COLUMN_ALIAS, (SQLWCHAR*)L"Y");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoCorrelationName) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CORRELATION_NAME, static_cast<SQLUSMALLINT>(SQL_CN_NONE));
+  Validate(this->conn, SQL_CORRELATION_NAME, static_cast<SQLUSMALLINT>(SQL_CN_NONE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCreateAssertion) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CREATE_ASSERTION, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CREATE_ASSERTION, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCreateCharacterSet) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CREATE_CHARACTER_SET, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CREATE_CHARACTER_SET, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCreateCollation) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CREATE_COLLATION, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CREATE_COLLATION, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCreateDomain) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CREATE_DOMAIN, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CREATE_DOMAIN, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoCreateSchema) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CREATE_SCHEMA, static_cast<SQLUINTEGER>(1));
+  Validate(this->conn, SQL_CREATE_SCHEMA, static_cast<SQLUINTEGER>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoCreateTable) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CREATE_TABLE, static_cast<SQLUINTEGER>(1));
+  Validate(this->conn, SQL_CREATE_TABLE, static_cast<SQLUINTEGER>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoCreateTranslation) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CREATE_TRANSLATION, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CREATE_TRANSLATION, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDdlIndex) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DDL_INDEX, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DDL_INDEX, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDropAssertion) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DROP_ASSERTION, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DROP_ASSERTION, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDropCharacterSet) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DROP_CHARACTER_SET, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DROP_CHARACTER_SET, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDropCollation) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DROP_COLLATION, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DROP_COLLATION, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDropDomain) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DROP_DOMAIN, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DROP_DOMAIN, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDropSchema) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DROP_SCHEMA, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DROP_SCHEMA, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDropTable) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DROP_TABLE, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DROP_TABLE, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDropTranslation) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DROP_TRANSLATION, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DROP_TRANSLATION, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDropView) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_DROP_VIEW, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_DROP_VIEW, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoExpressionsInOrderby) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_EXPRESSIONS_IN_ORDERBY, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_EXPRESSIONS_IN_ORDERBY, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoGroupBy) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_GROUP_BY,
+  Validate(this->conn, SQL_GROUP_BY,
            static_cast<SQLUSMALLINT>(SQL_GB_GROUP_BY_CONTAINS_SELECT));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoIdentifierCase) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_IDENTIFIER_CASE, static_cast<SQLUSMALLINT>(SQL_IC_MIXED));
+  Validate(this->conn, SQL_IDENTIFIER_CASE, static_cast<SQLUSMALLINT>(SQL_IC_MIXED));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoIdentifierQuoteChar) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_IDENTIFIER_QUOTE_CHAR, (SQLWCHAR*)L"\"");
+  Validate(this->conn, SQL_IDENTIFIER_QUOTE_CHAR, (SQLWCHAR*)L"\"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoIndexKeywords) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_INDEX_KEYWORDS, static_cast<SQLUINTEGER>(SQL_IK_NONE));
+  Validate(this->conn, SQL_INDEX_KEYWORDS, static_cast<SQLUINTEGER>(SQL_IK_NONE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoInsertStatement) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_INSERT_STATEMENT,
+  Validate(this->conn, SQL_INSERT_STATEMENT,
            static_cast<SQLUINTEGER>(SQL_IS_INSERT_LITERALS | SQL_IS_INSERT_SEARCHED |
                                     SQL_IS_SELECT_INTO));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoIntegrity) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_INTEGRITY, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_INTEGRITY, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoKeywords) {
-  this->connect();
+  this->Connect();
 
-  validateNotEmptySQLWCHAR(this->conn, SQL_KEYWORDS, true);
+  ValidateNotEmptySQLWCHAR(this->conn, SQL_KEYWORDS, true);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoLikeEscapeClause) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_LIKE_ESCAPE_CLAUSE, (SQLWCHAR*)L"Y");
+  Validate(this->conn, SQL_LIKE_ESCAPE_CLAUSE, (SQLWCHAR*)L"Y");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoNonNullableColumns) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_NON_NULLABLE_COLUMNS, static_cast<SQLUSMALLINT>(SQL_NNC_NULL));
+  Validate(this->conn, SQL_NON_NULLABLE_COLUMNS, static_cast<SQLUSMALLINT>(SQL_NNC_NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoOjCapabilities) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_OJ_CAPABILITIES,
+  Validate(this->conn, SQL_OJ_CAPABILITIES,
            static_cast<SQLUINTEGER>(SQL_OJ_LEFT | SQL_OJ_RIGHT | SQL_OJ_FULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoOrderByColumnsInSelect) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_ORDER_BY_COLUMNS_IN_SELECT, (SQLWCHAR*)L"Y");
+  Validate(this->conn, SQL_ORDER_BY_COLUMNS_IN_SELECT, (SQLWCHAR*)L"Y");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoOuterJoins) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_OUTER_JOINS, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_OUTER_JOINS, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoProcedures) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_PROCEDURES, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_PROCEDURES, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoQuotedIdentifierCase) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_QUOTED_IDENTIFIER_CASE,
+  Validate(this->conn, SQL_QUOTED_IDENTIFIER_CASE,
            static_cast<SQLUSMALLINT>(SQL_IC_MIXED));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoSchemaUsage) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_SCHEMA_USAGE, static_cast<SQLUINTEGER>(SQL_SU_DML_STATEMENTS));
+  Validate(this->conn, SQL_SCHEMA_USAGE, static_cast<SQLUINTEGER>(SQL_SU_DML_STATEMENTS));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoSpecialCharacters) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_SPECIAL_CHARACTERS, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_SPECIAL_CHARACTERS, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoSqlConformance) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_SQL_CONFORMANCE, static_cast<SQLUINTEGER>(SQL_SC_SQL92_ENTRY));
+  Validate(this->conn, SQL_SQL_CONFORMANCE, static_cast<SQLUINTEGER>(SQL_SC_SQL92_ENTRY));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoSubqueries) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_SUBQUERIES,
+  Validate(this->conn, SQL_SUBQUERIES,
            static_cast<SQLUINTEGER>(SQL_SQ_CORRELATED_SUBQUERIES | SQL_SQ_COMPARISON |
                                     SQL_SQ_EXISTS | SQL_SQ_IN | SQL_SQ_QUANTIFIED));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoUnion) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_UNION,
+  Validate(this->conn, SQL_UNION,
            static_cast<SQLUINTEGER>(SQL_U_UNION | SQL_U_UNION_ALL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // SQL Limits
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxBinaryLiteralLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_BINARY_LITERAL_LEN, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_MAX_BINARY_LITERAL_LEN, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoMaxCatalogNameLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_CATALOG_NAME_LEN, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_CATALOG_NAME_LEN, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxCharLiteralLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_CHAR_LITERAL_LEN, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_MAX_CHAR_LITERAL_LEN, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoMaxColumnNameLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_COLUMN_NAME_LEN, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_COLUMN_NAME_LEN, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxColumnsInGroupBy) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_COLUMNS_IN_GROUP_BY, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_COLUMNS_IN_GROUP_BY, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxColumnsInIndex) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_COLUMNS_IN_INDEX, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_COLUMNS_IN_INDEX, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxColumnsInOrderBy) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_COLUMNS_IN_ORDER_BY, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_COLUMNS_IN_ORDER_BY, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxColumnsInSelect) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_COLUMNS_IN_SELECT, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_COLUMNS_IN_SELECT, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxColumnsInTable) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_COLUMNS_IN_TABLE, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_COLUMNS_IN_TABLE, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoMaxCursorNameLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_CURSOR_NAME_LEN, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_CURSOR_NAME_LEN, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxIdentifierLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_IDENTIFIER_LEN, static_cast<SQLUSMALLINT>(65535));
+  Validate(this->conn, SQL_MAX_IDENTIFIER_LEN, static_cast<SQLUSMALLINT>(65535));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxIndexSize) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_INDEX_SIZE, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_MAX_INDEX_SIZE, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxProcedureNameLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_PROCEDURE_NAME_LEN, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_PROCEDURE_NAME_LEN, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxRowSize) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_ROW_SIZE, (SQLWCHAR*)L"");
+  Validate(this->conn, SQL_MAX_ROW_SIZE, (SQLWCHAR*)L"");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoMaxRowSizeIncludesLong) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_ROW_SIZE_INCLUDES_LONG, (SQLWCHAR*)L"N");
+  Validate(this->conn, SQL_MAX_ROW_SIZE_INCLUDES_LONG, (SQLWCHAR*)L"N");
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoMaxSchemaNameLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_SCHEMA_NAME_LEN, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_SCHEMA_NAME_LEN, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxStatementLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_STATEMENT_LEN, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_MAX_STATEMENT_LEN, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoMaxTableNameLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_TABLE_NAME_LEN, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_TABLE_NAME_LEN, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoMaxTablesInSelect) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_TABLES_IN_SELECT, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_TABLES_IN_SELECT, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoMaxUserNameLen) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_MAX_USER_NAME_LEN, static_cast<SQLUSMALLINT>(0));
+  Validate(this->conn, SQL_MAX_USER_NAME_LEN, static_cast<SQLUSMALLINT>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // Scalar Function Information
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertFunctions) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_FUNCTIONS, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_FUNCTIONS, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoNumericFunctions) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_NUMERIC_FUNCTIONS, static_cast<SQLUINTEGER>(4058942));
+  Validate(this->conn, SQL_NUMERIC_FUNCTIONS, static_cast<SQLUINTEGER>(4058942));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoStringFunctions) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_STRING_FUNCTIONS,
+  Validate(this->conn, SQL_STRING_FUNCTIONS,
            static_cast<SQLUINTEGER>(SQL_FN_STR_LTRIM | SQL_FN_STR_LENGTH |
                                     SQL_FN_STR_REPLACE | SQL_FN_STR_RTRIM));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoSystemFunctions) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_SYSTEM_FUNCTIONS,
+  Validate(this->conn, SQL_SYSTEM_FUNCTIONS,
            static_cast<SQLUINTEGER>(SQL_FN_SYS_IFNULL | SQL_FN_SYS_USERNAME));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoTimedateAddIntervals) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_TIMEDATE_ADD_INTERVALS,
+  Validate(this->conn, SQL_TIMEDATE_ADD_INTERVALS,
            static_cast<SQLUINTEGER>(SQL_FN_TSI_FRAC_SECOND | SQL_FN_TSI_SECOND |
                                     SQL_FN_TSI_MINUTE | SQL_FN_TSI_HOUR | SQL_FN_TSI_DAY |
                                     SQL_FN_TSI_WEEK | SQL_FN_TSI_MONTH |
                                     SQL_FN_TSI_QUARTER | SQL_FN_TSI_YEAR));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoTimedateDiffIntervals) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_TIMEDATE_DIFF_INTERVALS,
+  Validate(this->conn, SQL_TIMEDATE_DIFF_INTERVALS,
            static_cast<SQLUINTEGER>(SQL_FN_TSI_FRAC_SECOND | SQL_FN_TSI_SECOND |
                                     SQL_FN_TSI_MINUTE | SQL_FN_TSI_HOUR | SQL_FN_TSI_DAY |
                                     SQL_FN_TSI_WEEK | SQL_FN_TSI_MONTH |
                                     SQL_FN_TSI_QUARTER | SQL_FN_TSI_YEAR));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoTimedateFunctions) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_TIMEDATE_FUNCTIONS,
+  Validate(this->conn, SQL_TIMEDATE_FUNCTIONS,
            static_cast<SQLUINTEGER>(
                SQL_FN_TD_CURRENT_DATE | SQL_FN_TD_CURRENT_TIME |
                SQL_FN_TD_CURRENT_TIMESTAMP | SQL_FN_TD_CURDATE | SQL_FN_TD_CURTIME |
@@ -1313,177 +1313,177 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoTimedateFunctions) {
                SQL_FN_TD_QUARTER | SQL_FN_TD_SECOND | SQL_FN_TD_TIMESTAMPADD |
                SQL_FN_TD_TIMESTAMPDIFF | SQL_FN_TD_WEEK | SQL_FN_TD_YEAR));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // Conversion Information
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertBigint) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_BIGINT, static_cast<SQLUINTEGER>(8));
+  Validate(this->conn, SQL_CONVERT_BIGINT, static_cast<SQLUINTEGER>(8));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertBinary) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_BINARY, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_BINARY, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertBit) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_BIT, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_BIT, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertChar) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_CHAR, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_CHAR, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertDate) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_DATE, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_DATE, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertDecimal) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_DECIMAL, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_DECIMAL, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertDouble) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_DOUBLE, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_DOUBLE, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertFloat) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_FLOAT, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_FLOAT, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertInteger) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_INTEGER, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_INTEGER, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertIntervalDayTime) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_INTERVAL_DAY_TIME, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_INTERVAL_DAY_TIME, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertIntervalYearMonth) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_INTERVAL_YEAR_MONTH, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_INTERVAL_YEAR_MONTH, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertLongvarbinary) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_LONGVARBINARY, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_LONGVARBINARY, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertLongvarchar) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_LONGVARCHAR, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_LONGVARCHAR, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetInfoConvertNumeric) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_NUMERIC, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_NUMERIC, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertReal) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_REAL, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_REAL, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertSmallint) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_SMALLINT, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_SMALLINT, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertTime) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_TIME, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_TIME, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertTimestamp) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_TIMESTAMP, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_TIMESTAMP, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertTinyint) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_TINYINT, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_TINYINT, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertVarbinary) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_VARBINARY, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_VARBINARY, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoConvertVarchar) {
-  this->connect();
+  this->Connect();
 
-  validate(this->conn, SQL_CONVERT_VARCHAR, static_cast<SQLUINTEGER>(0));
+  Validate(this->conn, SQL_CONVERT_VARCHAR, static_cast<SQLUINTEGER>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -218,7 +218,7 @@ TEST(SQLSetEnvAttr, TestSQLSetEnvAttrODBCVersionInvalid) {
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetEnvAttrOutputNTS) {
-  this->connect();
+  this->Connect();
 
   SQLINTEGER output_nts;
 
@@ -228,7 +228,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetEnvAttrOutputNTS) {
 
   EXPECT_EQ(output_nts, SQL_TRUE);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetEnvAttrGetLength) {
@@ -236,7 +236,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetEnvAttrGetLength) {
   // Windows. This test case can be potentially used on macOS/Linux
   GTEST_SKIP();
 
-  this->connect();
+  this->Connect();
 
   SQLINTEGER length;
 
@@ -247,21 +247,21 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetEnvAttrGetLength) {
 
   EXPECT_EQ(length, sizeof(SQLINTEGER));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetEnvAttrNullValuePointer) {
   // Test is disabled because call to SQLGetEnvAttr is handled by the driver manager on
   // Windows. This test case can be potentially used on macOS/Linux
   GTEST_SKIP();
-  this->connect();
+  this->Connect();
 
   SQLRETURN return_get =
       SQLGetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION, nullptr, 0, nullptr);
 
   EXPECT_TRUE(return_get == SQL_ERROR);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST(SQLSetEnvAttr, TestSQLSetEnvAttrOutputNTSValid) {
@@ -331,18 +331,18 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnect) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Connect string
-  std::string connect_str = this->getConnectionString();
+  std::string connect_str = this->GetConnectionString();
   ASSERT_OK_AND_ASSIGN(std::wstring wconnect_str,
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE] = L"";
-  SQLSMALLINT outstrlen;
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE] = L"";
+  SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
   ret = SQLDriverConnect(conn, NULL, &connect_str0[0],
-                         static_cast<SQLSMALLINT>(connect_str0.size()), outstr,
-                         ODBC_BUFFER_SIZE, &outstrlen, SQL_DRIVER_NOPROMPT);
+                         static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
+                         ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
   if (ret != SQL_SUCCESS) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
@@ -350,14 +350,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnect) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  // Check that outstr has same content as connect_str
-  std::string out_connection_string = ODBC::SqlWcharToString(outstr, outstrlen);
+  // Check that out_str has same content as connect_str
+  std::string out_connection_string = ODBC::SqlWcharToString(out_str, out_str_len);
   Connection::ConnPropertyMap out_properties;
   Connection::ConnPropertyMap in_properties;
-  ODBC::ODBCConnection::getPropertiesFromConnString(out_connection_string,
+  ODBC::ODBCConnection::GetPropertiesFromConnString(out_connection_string,
                                                     out_properties);
-  ODBC::ODBCConnection::getPropertiesFromConnString(connect_str, in_properties);
-  EXPECT_TRUE(compareConnPropertyMap(out_properties, in_properties));
+  ODBC::ODBCConnection::GetPropertiesFromConnString(connect_str, in_properties);
+  EXPECT_TRUE(CompareConnPropertyMap(out_properties, in_properties));
 
   // Disconnect from ODBC
   ret = SQLDisconnect(conn);
@@ -400,11 +400,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnectDsn) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Connect string
-  std::string connect_str = this->getConnectionString();
+  std::string connect_str = this->GetConnectionString();
 
   // Write connection string content into a DSN,
   // must succeed before continuing
-  ASSERT_TRUE(writeDSN(connect_str));
+  ASSERT_TRUE(WriteDSN(connect_str));
 
   std::string dsn(TEST_DSN);
   ASSERT_OK_AND_ASSIGN(std::wstring wdsn, arrow::util::UTF8ToWideString(dsn));
@@ -416,13 +416,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnectDsn) {
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE] = L"";
-  SQLSMALLINT outstrlen;
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE] = L"";
+  SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
   ret = SQLDriverConnect(conn, NULL, &connect_str0[0],
-                         static_cast<SQLSMALLINT>(connect_str0.size()), outstr,
-                         ODBC_BUFFER_SIZE, &outstrlen, SQL_DRIVER_NOPROMPT);
+                         static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
+                         ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
   if (ret != SQL_SUCCESS) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
@@ -473,12 +473,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLConnect) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Connect string
-  std::string connect_str = this->getConnectionString();
+  std::string connect_str = this->GetConnectionString();
 
   // Write connection string content into a DSN,
   // must succeed before continuing
   std::string uid(""), pwd("");
-  ASSERT_TRUE(writeDSN(connect_str));
+  ASSERT_TRUE(WriteDSN(connect_str));
 
   std::string dsn(TEST_DSN);
   ASSERT_OK_AND_ASSIGN(std::wstring wdsn, arrow::util::UTF8ToWideString(dsn));
@@ -542,11 +542,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInputUidPwd) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Connect string
-  std::string connect_str = getConnectionString();
+  std::string connect_str = GetConnectionString();
 
   // Retrieve valid uid and pwd, assumes TEST_CONNECT_STR contains uid and pwd
   Connection::ConnPropertyMap properties;
-  ODBC::ODBCConnection::getPropertiesFromConnString(connect_str, properties);
+  ODBC::ODBCConnection::GetPropertiesFromConnString(connect_str, properties);
   std::string uid_key("uid");
   std::string pwd_key("pwd");
   std::string uid = properties[uid_key];
@@ -556,7 +556,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInputUidPwd) {
   // must succeed before continuing
   properties.erase(uid_key);
   properties.erase(pwd_key);
-  ASSERT_TRUE(writeDSN(properties));
+  ASSERT_TRUE(WriteDSN(properties));
 
   std::string dsn(TEST_DSN);
   ASSERT_OK_AND_ASSIGN(std::wstring wdsn, arrow::util::UTF8ToWideString(dsn));
@@ -620,11 +620,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInvalidUid) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Connect string
-  std::string connect_str = getConnectionString();
+  std::string connect_str = GetConnectionString();
 
   // Retrieve valid uid and pwd, assumes TEST_CONNECT_STR contains uid and pwd
   Connection::ConnPropertyMap properties;
-  ODBC::ODBCConnection::getPropertiesFromConnString(connect_str, properties);
+  ODBC::ODBCConnection::GetPropertiesFromConnString(connect_str, properties);
   std::string uid = properties[std::string("uid")];
   std::string pwd = properties[std::string("pwd")];
 
@@ -633,7 +633,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInvalidUid) {
 
   // Write connection string content into a DSN,
   // must succeed before continuing
-  ASSERT_TRUE(writeDSN(connect_str));
+  ASSERT_TRUE(WriteDSN(connect_str));
 
   std::string dsn(TEST_DSN);
   ASSERT_OK_AND_ASSIGN(std::wstring wdsn, arrow::util::UTF8ToWideString(dsn));
@@ -688,7 +688,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectDSNPrecedence) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Connect string
-  std::string connect_str = getConnectionString();
+  std::string connect_str = GetConnectionString();
 
   // Write connection string content into a DSN,
   // must succeed before continuing
@@ -696,7 +696,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectDSNPrecedence) {
   // Pass incorrect uid and password to SQLConnect, they will be ignored.
   // Assumes TEST_CONNECT_STR contains uid and pwd
   std::string uid("non_existent_id"), pwd("non_existent_password");
-  ASSERT_TRUE(writeDSN(connect_str));
+  ASSERT_TRUE(WriteDSN(connect_str));
 
   std::string dsn(TEST_DSN);
   ASSERT_OK_AND_ASSIGN(std::wstring wdsn, arrow::util::UTF8ToWideString(dsn));
@@ -762,25 +762,25 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLDriverConnectInvalidUid) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Invalid connect string
-  std::string connect_str = getInvalidConnectionString();
+  std::string connect_str = GetInvalidConnectionString();
 
   ASSERT_OK_AND_ASSIGN(std::wstring wconnect_str,
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE];
-  SQLSMALLINT outstrlen;
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE];
+  SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
   ret = SQLDriverConnect(conn, NULL, &connect_str0[0],
-                         static_cast<SQLSMALLINT>(connect_str0.size()), outstr,
-                         ODBC_BUFFER_SIZE, &outstrlen, SQL_DRIVER_NOPROMPT);
+                         static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
+                         ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
   EXPECT_TRUE(ret == SQL_ERROR);
 
   VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, error_state_28000);
 
-  std::string out_connection_string = ODBC::SqlWcharToString(outstr, outstrlen);
+  std::string out_connection_string = ODBC::SqlWcharToString(out_str, out_str_len);
   EXPECT_TRUE(out_connection_string.empty());
 
   // Free connection handle
@@ -834,12 +834,12 @@ TEST(SQLDisconnect, TestSQLDisconnectWithoutConnection) {
 
 TYPED_TEST(FlightSQLODBCTestBase, TestConnect) {
   // Verifies connect and disconnect works on its own
-  this->connect();
-  this->disconnect();
+  this->Connect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLAllocFreeStmt) {
-  this->connect();
+  this->Connect();
   SQLHSTMT statement;
 
   // Allocate a statement using alloc statement
@@ -862,7 +862,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLAllocFreeStmt) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestCloseConnectionWithOpenStatement) {
@@ -886,18 +886,18 @@ TYPED_TEST(FlightSQLODBCTestBase, TestCloseConnectionWithOpenStatement) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Connect string
-  std::string connect_str = this->getConnectionString();
+  std::string connect_str = this->GetConnectionString();
   ASSERT_OK_AND_ASSIGN(std::wstring wconnect_str,
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE] = L"";
-  SQLSMALLINT outstrlen;
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE] = L"";
+  SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
   ret = SQLDriverConnect(conn, NULL, &connect_str0[0],
-                         static_cast<SQLSMALLINT>(connect_str0.size()), outstr,
-                         ODBC_BUFFER_SIZE, &outstrlen, SQL_DRIVER_NOPROMPT);
+                         static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
+                         ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -923,7 +923,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestCloseConnectionWithOpenStatement) {
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLAllocFreeDesc) {
-  this->connect();
+  this->Connect();
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
@@ -936,11 +936,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLAllocFreeDesc) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrDescriptor) {
-  this->connect();
+  this->Connect();
 
   SQLHDESC apd_descriptor, ard_descriptor;
 
@@ -1018,7 +1018,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrDescriptor) {
 
   EXPECT_EQ(value, internal_ard);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
@@ -48,19 +48,19 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailure) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Invalid connect string
-  std::string connect_str = this->getInvalidConnectionString();
+  std::string connect_str = this->GetInvalidConnectionString();
 
   ASSERT_OK_AND_ASSIGN(std::wstring wconnect_str,
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE];
-  SQLSMALLINT outstrlen;
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE];
+  SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
   ret = SQLDriverConnect(conn, NULL, &connect_str0[0],
-                         static_cast<SQLSMALLINT>(connect_str0.size()), outstr,
-                         ODBC_BUFFER_SIZE, &outstrlen, SQL_DRIVER_NOPROMPT);
+                         static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
+                         ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
   EXPECT_EQ(ret, SQL_ERROR);
 
@@ -156,19 +156,19 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailureNTS) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Invalid connect string
-  std::string connect_str = this->getInvalidConnectionString();
+  std::string connect_str = this->GetInvalidConnectionString();
 
   ASSERT_OK_AND_ASSIGN(std::wstring wconnect_str,
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE];
-  SQLSMALLINT outstrlen;
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE];
+  SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
   ret = SQLDriverConnect(conn, NULL, &connect_str0[0],
-                         static_cast<SQLSMALLINT>(connect_str0.size()), outstr,
-                         ODBC_BUFFER_SIZE, &outstrlen, SQL_DRIVER_NOPROMPT);
+                         static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
+                         ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
   EXPECT_EQ(ret, SQL_ERROR);
 
@@ -201,7 +201,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailureNTS) {
 
 TYPED_TEST(FlightSQLODBCTestBase,
            TestSQLGetDiagFieldWForDescriptorFailureFromDriverManager) {
-  this->connect();
+  this->Connect();
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
@@ -276,12 +276,12 @@ TYPED_TEST(FlightSQLODBCTestBase,
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase,
            TestSQLGetDiagRecForDescriptorFailureFromDriverManager) {
-  this->connect();
+  this->Connect();
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
@@ -317,7 +317,7 @@ TYPED_TEST(FlightSQLODBCTestBase,
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecForConnectFailure) {
@@ -340,19 +340,19 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecForConnectFailure) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Invalid connect string
-  std::string connect_str = this->getInvalidConnectionString();
+  std::string connect_str = this->GetInvalidConnectionString();
 
   ASSERT_OK_AND_ASSIGN(std::wstring wconnect_str,
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR outstr[ODBC_BUFFER_SIZE];
-  SQLSMALLINT outstrlen;
+  SQLWCHAR out_str[ODBC_BUFFER_SIZE];
+  SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
   ret = SQLDriverConnect(conn, NULL, &connect_str0[0],
-                         static_cast<SQLSMALLINT>(connect_str0.size()), outstr,
-                         ODBC_BUFFER_SIZE, &outstrlen, SQL_DRIVER_NOPROMPT);
+                         static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
+                         ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
   EXPECT_EQ(ret, SQL_ERROR);
 
@@ -387,7 +387,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecForConnectFailure) {
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecInputData) {
   // SQLGetDiagRec does not post diagnostic records for itself.
-  this->connect();
+  this->Connect();
 
   SQLWCHAR sql_state[6];
   SQLINTEGER native_error;
@@ -410,13 +410,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecInputData) {
 
   EXPECT_EQ(ret, SQL_INVALID_HANDLE);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorInputData) {
   // Test ODBC 2.0 API SQLError. Driver manager maps SQLError to SQLGetDiagRec.
   // SQLError does not post diagnostic records for itself.
-  this->connect();
+  this->Connect();
 
   // Pass valid handles with null inputs
   SQLRETURN ret = SQLError(this->env, 0, 0, 0, 0, 0, 0, 0);
@@ -436,7 +436,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorInputData) {
 
   EXPECT_EQ(ret, SQL_INVALID_HANDLE);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorFromDriverManager) {
@@ -444,7 +444,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorFromDriverManager) {
   // Known Windows Driver Manager (DM) behavior:
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
-  this->connect();
+  this->Connect();
 
   // Attempt to set environment attribute after connection handle allocation
   SQLRETURN ret = SQLSetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION,
@@ -470,7 +470,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorFromDriverManager) {
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnError) {
@@ -478,7 +478,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnError) {
   // Known Windows Driver Manager (DM) behavior:
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
-  this->connect();
+  this->Connect();
 
   // Attempt to set unsupported attribute
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, 0, 0, 0);
@@ -503,7 +503,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnError) {
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtError) {
@@ -511,7 +511,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtError) {
   // Known Windows Driver Manager (DM) behavior:
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"1";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -538,12 +538,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtError) {
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtWarning) {
   // Test ODBC 2.0 API SQLError.
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 'VERY LONG STRING here' AS string_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -588,7 +588,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorODBCVer2FromDriverManager)
   // Known Windows Driver Manager (DM) behavior:
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   // Attempt to set environment attribute after connection handle allocation
   SQLRETURN ret = SQLSetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION,
@@ -614,7 +614,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorODBCVer2FromDriverManager)
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnErrorODBCVer2) {
@@ -622,7 +622,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnErrorODBCVer2) {
   // Known Windows Driver Manager (DM) behavior:
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   // Attempt to set unsupported attribute
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, 0, 0, 0);
@@ -647,7 +647,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnErrorODBCVer2) {
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtErrorODBCVer2) {
@@ -655,7 +655,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtErrorODBCVer2) {
   // Known Windows Driver Manager (DM) behavior:
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   std::wstring wsql = L"1";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -683,12 +683,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtErrorODBCVer2) {
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtWarningODBCVer2) {
   // Test ODBC 2.0 API SQLError.
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   std::wstring wsql = L"SELECT 'VERY LONG STRING here' AS string_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());

--- a/cpp/src/arrow/flight/sql/odbc/tests/get_functions_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/get_functions_test.cc
@@ -30,7 +30,7 @@ namespace arrow::flight::sql::odbc {
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsAllFunctions) {
   // Verify driver manager return values for SQLGetFunctions
-  this->connect();
+  this->Connect();
 
   SQLUSMALLINT api_exists[SQL_API_ODBC3_ALL_FUNCTIONS_SIZE];
   const std::vector<int> supported_functions = {
@@ -75,12 +75,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsAllFunctions) {
     EXPECT_EQ(SQL_FUNC_EXISTS(api_exists, api), SQL_FALSE);
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsAllFunctionsODBCVer2) {
   // Verify driver manager return values for SQLGetFunctions
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   // ODBC 2.0 SQLGetFunctions returns 100 elements according to spec
   SQLUSMALLINT api_exists[100];
@@ -116,11 +116,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsAllFunctionsODBCVer2) {
     EXPECT_EQ(api_exists[api], SQL_FALSE);
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsSupportedSingleAPI) {
-  this->connect();
+  this->Connect();
 
   const std::vector<SQLUSMALLINT> supported_functions = {
       SQL_API_SQLALLOCHANDLE, SQL_API_SQLBINDCOL, SQL_API_SQLGETDIAGFIELD,
@@ -154,11 +154,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsSupportedSingleAPI) {
     api_exists = -1;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsUnsupportedSingleAPI) {
-  this->connect();
+  this->Connect();
 
   const std::vector<SQLUSMALLINT> unsupported_functions = {
       SQL_API_SQLPUTDATA,        SQL_API_SQLGETDESCFIELD,     SQL_API_SQLGETDESCREC,
@@ -180,11 +180,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsUnsupportedSingleAPI) {
     api_exists = -1;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsSupportedSingleAPIODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   const std::vector<SQLUSMALLINT> supported_functions = {
       SQL_API_SQLCONNECT, SQL_API_SQLGETINFO, SQL_API_SQLDESCRIBECOL,
@@ -210,11 +210,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsSupportedSingleAPIODBCVer2)
     api_exists = -1;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsUnsupportedSingleAPIODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   const std::vector<SQLUSMALLINT> unsupported_functions = {
       SQL_API_SQLPUTDATA,        SQL_API_SQLPARAMDATA,        SQL_API_SQLSETCURSORNAME,
@@ -234,7 +234,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsUnsupportedSingleAPIODBCVer
     api_exists = -1;
   }
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -48,22 +48,22 @@ using driver::odbcabstraction::Connection;
 class FlightSQLODBCRemoteTestBase : public ::testing::Test {
  public:
   /// \brief Allocate environment and connection handles
-  void allocEnvConnHandles(SQLINTEGER odbc_ver = SQL_OV_ODBC3);
+  void AllocEnvConnHandles(SQLINTEGER odbc_ver = SQL_OV_ODBC3);
   /// \brief Connect to Arrow Flight SQL server using connection string defined in
   /// environment variable "ARROW_FLIGHT_SQL_ODBC_CONN", allocate statement handle.
   /// Connects using ODBC Ver 3 by default
-  void connect(SQLINTEGER odbc_ver = SQL_OV_ODBC3);
+  void Connect(SQLINTEGER odbc_ver = SQL_OV_ODBC3);
   /// \brief Connect to Arrow Flight SQL server using connection string
-  void connectWithString(std::string connection_str);
+  void ConnectWithString(std::string connection_str);
   /// \brief Disconnect from server
-  void disconnect();
+  void Disconnect();
   /// \brief Get connection string from environment variable "ARROW_FLIGHT_SQL_ODBC_CONN"
-  std::string virtual getConnectionString();
+  std::string virtual GetConnectionString();
   /// \brief Get invalid connection string based on connection string defined in
   /// environment variable "ARROW_FLIGHT_SQL_ODBC_CONN"
-  std::string virtual getInvalidConnectionString();
+  std::string virtual GetInvalidConnectionString();
   /// \brief Return a SQL query that selects all data types
-  std::wstring virtual getQueryAllDataTypes();
+  std::wstring virtual GetQueryAllDataTypes();
 
   /** ODBC Environment. */
   SQLHENV env = 0;
@@ -78,8 +78,8 @@ class FlightSQLODBCRemoteTestBase : public ::testing::Test {
   void SetUp() override;
 };
 
-static constexpr std::string_view kAuthHeader = "authorization";
-static constexpr std::string_view kBearerPrefix = "Bearer ";
+static constexpr std::string_view authorization_header = "authorization";
+static constexpr std::string_view bearer_prefix = "Bearer ";
 static constexpr std::string_view test_token = "t0k3n";
 
 std::string FindTokenInCallHeaders(const CallHeaders& incoming_headers);
@@ -87,8 +87,8 @@ std::string FindTokenInCallHeaders(const CallHeaders& incoming_headers);
 // A server middleware for validating incoming bearer header authentication.
 class MockServerMiddleware : public ServerMiddleware {
  public:
-  explicit MockServerMiddleware(const CallHeaders& incoming_headers, bool* isValid)
-      : isValid_(isValid) {
+  explicit MockServerMiddleware(const CallHeaders& incoming_headers, bool* is_valid)
+      : is_valid_(is_valid) {
     incoming_headers_ = incoming_headers;
   }
 
@@ -100,30 +100,30 @@ class MockServerMiddleware : public ServerMiddleware {
 
  private:
   CallHeaders incoming_headers_;
-  bool* isValid_;
+  bool* is_valid_;
 };
 
 // Factory for base64 header authentication testing.
 class MockServerMiddlewareFactory : public ServerMiddlewareFactory {
  public:
-  MockServerMiddlewareFactory() : isValid_(false) {}
+  MockServerMiddlewareFactory() : is_valid_(false) {}
 
   Status StartCall(const CallInfo& info, const ServerCallContext& context,
                    std::shared_ptr<ServerMiddleware>* middleware) override;
 
  private:
-  bool isValid_;
+  bool is_valid_;
 };
 
 class FlightSQLODBCMockTestBase : public FlightSQLODBCRemoteTestBase {
   // Sets up a mock server for each test case
  public:
   /// \brief Get connection string for mock server
-  std::string getConnectionString() override;
+  std::string GetConnectionString() override;
   /// \brief Get invalid connection string for mock server
-  std::string getInvalidConnectionString() override;
+  std::string GetInvalidConnectionString() override;
   /// \brief Return a SQL query that selects all data types
-  std::wstring getQueryAllDataTypes() override;
+  std::wstring GetQueryAllDataTypes() override;
 
   /// \brief Run a SQL query to create default table for table test cases
   void CreateTestTables();
@@ -158,7 +158,7 @@ TYPED_TEST_SUITE(FlightSQLODBCTestBase, TestTypes);
 enum { ODBC_BUFFER_SIZE = 1024 };
 
 /// Compare ConnPropertyMap, key value is case-insensitive
-bool compareConnPropertyMap(Connection::ConnPropertyMap map1,
+bool CompareConnPropertyMap(Connection::ConnPropertyMap map1,
                             Connection::ConnPropertyMap map2);
 
 /// Get error message from ODBC driver using SQLGetDiagRec
@@ -194,41 +194,41 @@ void VerifyOdbcErrorState(SQLSMALLINT handle_type, SQLHANDLE handle,
 /// \brief Write connection string into DSN
 /// \param[in] connection_str the connection string.
 /// \return true on success
-bool writeDSN(std::string connection_str);
+bool WriteDSN(std::string connection_str);
 
 /// \brief Write properties map into DSN
 /// \param[in] properties map.
 /// \return true on success
-bool writeDSN(Connection::ConnPropertyMap properties);
+bool WriteDSN(Connection::ConnPropertyMap properties);
 
 /// \brief Check wide char vector and convert into wstring
-/// \param[in] strVal Vector of SQLWCHAR.
-/// \param[in] strLen length of string, in bytes.
+/// \param[in] str_val Vector of SQLWCHAR.
+/// \param[in] str_len length of string, in bytes.
 /// \return wstring
-std::wstring ConvertToWString(const std::vector<SQLWCHAR>& strVal, SQLSMALLINT strLen);
+std::wstring ConvertToWString(const std::vector<SQLWCHAR>& str_val, SQLSMALLINT str_len);
 
 /// \brief Check wide string column.
 /// \param[in] stmt Statement.
-/// \param[in] colId Column ID to check.
+/// \param[in] col_id Column ID to check.
 /// \param[in] expected Expected value.
-void CheckStringColumnW(SQLHSTMT stmt, int colId, const std::wstring& expected);
+void CheckStringColumnW(SQLHSTMT stmt, int col_id, const std::wstring& expected);
 
 /// \brief Check wide string column value is null.
 /// \param[in] stmt Statement.
-/// \param[in] colId Column ID to check.
-void CheckNullColumnW(SQLHSTMT stmt, int colId);
+/// \param[in] col_id Column ID to check.
+void CheckNullColumnW(SQLHSTMT stmt, int col_id);
 
 /// \brief Check int column.
 /// \param[in] stmt Statement.
-/// \param[in] colId Column ID to check.
+/// \param[in] col_id Column ID to check.
 /// \param[in] expected Expected value.
-void CheckIntColumn(SQLHSTMT stmt, int colId, const SQLINTEGER& expected);
+void CheckIntColumn(SQLHSTMT stmt, int col_id, const SQLINTEGER& expected);
 
 /// \brief Check smallint column.
 /// \param[in] stmt Statement.
-/// \param[in] colId Column ID to check.
+/// \param[in] col_id Column ID to check.
 /// \param[in] expected Expected value.
-void CheckSmallIntColumn(SQLHSTMT stmt, int colId, const SQLSMALLINT& expected);
+void CheckSmallIntColumn(SQLHSTMT stmt, int col_id, const SQLSMALLINT& expected);
 
 /// \brief Check sql return against expected.
 /// \param[in] stmt Statement.

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -34,13 +34,13 @@ namespace arrow::flight::sql::odbc {
 // Helper Functions
 
 // Validate SQLULEN return value
-void validateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
+void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
                          SQLULEN expected_value) {
   SQLULEN value = 0;
-  SQLINTEGER stringLength = 0;
+  SQLINTEGER string_length = 0;
 
   SQLRETURN ret =
-      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &stringLength);
+      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -48,13 +48,13 @@ void validateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
 }
 
 // Validate SQLLEN return value
-void validateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
+void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
                          SQLLEN expected_value) {
   SQLLEN value = 0;
-  SQLINTEGER stringLength = 0;
+  SQLINTEGER string_length = 0;
 
   SQLRETURN ret =
-      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &stringLength);
+      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -62,13 +62,13 @@ void validateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
 }
 
 // Validate SQLPOINTER return value
-void validateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
+void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
                          SQLPOINTER expected_value) {
   SQLPOINTER value = nullptr;
-  SQLINTEGER stringLength = 0;
+  SQLINTEGER string_length = 0;
 
   SQLRETURN ret =
-      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &stringLength);
+      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -76,12 +76,12 @@ void validateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
 }
 
 // Validate unsigned length SQLULEN return value is greater than
-void validateGetStmtAttrGreaterThan(SQLHSTMT statement, SQLINTEGER attribute,
+void ValidateGetStmtAttrGreaterThan(SQLHSTMT statement, SQLINTEGER attribute,
                                     SQLULEN compared_value) {
   SQLULEN value = 0;
-  SQLINTEGER stringLengthPtr;
+  SQLINTEGER string_length_ptr;
 
-  SQLRETURN ret = SQLGetStmtAttr(statement, attribute, &value, 0, &stringLengthPtr);
+  SQLRETURN ret = SQLGetStmtAttr(statement, attribute, &value, 0, &string_length_ptr);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -89,12 +89,12 @@ void validateGetStmtAttrGreaterThan(SQLHSTMT statement, SQLINTEGER attribute,
 }
 
 // Validate error return value and code
-void validateGetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
+void ValidateGetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
                                   std::string_view error_code) {
   SQLULEN value = 0;
-  SQLINTEGER stringLengthPtr;
+  SQLINTEGER string_length_ptr;
 
-  SQLRETURN ret = SQLGetStmtAttr(statement, attribute, &value, 0, &stringLengthPtr);
+  SQLRETURN ret = SQLGetStmtAttr(statement, attribute, &value, 0, &string_length_ptr);
 
   EXPECT_EQ(ret, SQL_ERROR);
 
@@ -102,39 +102,39 @@ void validateGetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
 }
 
 // Validate return value for call to SQLSetStmtAttr with SQLULEN
-void validateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLULEN new_value) {
-  SQLINTEGER stringLengthPtr = sizeof(SQLULEN);
+void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLULEN new_value) {
+  SQLINTEGER string_length_ptr = sizeof(SQLULEN);
 
   SQLRETURN ret = SQLSetStmtAttr(
-      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), stringLengthPtr);
+      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 }
 
 // Validate return value for call to SQLSetStmtAttr with SQLLEN
-void validateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLLEN new_value) {
-  SQLINTEGER stringLengthPtr = sizeof(SQLLEN);
+void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLLEN new_value) {
+  SQLINTEGER string_length_ptr = sizeof(SQLLEN);
 
   SQLRETURN ret = SQLSetStmtAttr(
-      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), stringLengthPtr);
+      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 }
 
 // Validate return value for call to SQLSetStmtAttr with SQLPOINTER
-void validateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLPOINTER value) {
+void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLPOINTER value) {
   SQLRETURN ret = SQLSetStmtAttr(statement, attribute, value, 0);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 }
 
 // Validate error return value and code
-void validateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
+void ValidateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
                                   SQLULEN new_value, std::string_view error_code) {
-  SQLINTEGER stringLengthPtr = sizeof(SQLULEN);
+  SQLINTEGER string_length_ptr = sizeof(SQLULEN);
 
   SQLRETURN ret = SQLSetStmtAttr(
-      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), stringLengthPtr);
+      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
 
   EXPECT_EQ(ret, SQL_ERROR);
 
@@ -144,275 +144,275 @@ void validateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
 // Test Cases
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAppParamDesc) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_APP_PARAM_DESC,
+  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_APP_PARAM_DESC,
                                  static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAppRowDesc) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_APP_ROW_DESC,
+  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_APP_ROW_DESC,
                                  static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAsyncEnable) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ASYNC_ENABLE,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ASYNC_ENABLE,
                       static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAsyncStmtEventUnsupported) {
-  this->connect();
+  this->Connect();
 
   // Optional feature not implemented
-  validateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, error_state_HYC00);
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAsyncStmtPCCallbackUnsupported) {
-  this->connect();
+  this->Connect();
 
   // Optional feature not implemented
-  validateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK,
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK,
                                error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCONTEXT
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAsyncStmtPCContextUnsupported) {
-  this->connect();
+  this->Connect();
 
   // Optional feature not implemented
-  validateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT,
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT,
                                error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrConcurrency) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
                       static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrCursorScrollable) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
                       static_cast<SQLULEN>(SQL_NONSCROLLABLE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrCursorSensitivity) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
                       static_cast<SQLULEN>(SQL_UNSPECIFIED));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrCursorType) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
                       static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrEnableAutoIPD) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
                       static_cast<SQLULEN>(SQL_FALSE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrFetchBookmarkPointer) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrIMPParamDesc) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
+  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
                                  static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrIMPRowDesc) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_IMP_ROW_DESC,
+  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_IMP_ROW_DESC,
                                  static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrKeysetSize) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrMaxLength) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrMaxRows) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrMetadataID) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrNoscan) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamBindOffsetPtr) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(nullptr));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamBindType) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
                       static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamOperationPtr) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
                       static_cast<SQLPOINTER>(nullptr));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamStatusPtr) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
                       static_cast<SQLPOINTER>(nullptr));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamsProcessedPtr) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
                       static_cast<SQLPOINTER>(nullptr));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamsetSize) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrQueryTimeout) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(0));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRetrieveData) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
                       static_cast<SQLULEN>(SQL_RD_ON));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowArraySize) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowBindOffsetPtr) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(nullptr));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowBindType) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowNumber) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -426,468 +426,468 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowNumber) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(1));
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowOperationPtr) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
                       static_cast<SQLPOINTER>(nullptr));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowStatusPtr) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
                       static_cast<SQLPOINTER>(nullptr));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowsFetchedPtr) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
                       static_cast<SQLPOINTER>(nullptr));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrSimulateCursor) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
                       static_cast<SQLULEN>(SQL_SC_UNIQUE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrUseBookmarks) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
                       static_cast<SQLULEN>(SQL_UB_OFF));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // This is a pre ODBC 3 attribute
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowsetSize) {
-  this->connect();
+  this->Connect();
 
-  validateGetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
+  ValidateGetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAppParamDesc) {
   SQLULEN app_param_desc = 0;
-  SQLINTEGER stringLengthPtr;
-  this->connect();
+  SQLINTEGER string_length_ptr;
+  this->Connect();
 
   SQLRETURN ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &app_param_desc, 0,
-                                 &stringLengthPtr);
+                                 &string_length_ptr);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, static_cast<SQLULEN>(0));
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
                       static_cast<SQLULEN>(app_param_desc));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAppRowDesc) {
   SQLULEN app_row_desc = 0;
-  SQLINTEGER stringLengthPtr;
-  this->connect();
+  SQLINTEGER string_length_ptr;
+  this->Connect();
 
   SQLRETURN ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &app_row_desc, 0,
-                                 &stringLengthPtr);
+                                 &string_length_ptr);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(0));
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC,
                       static_cast<SQLULEN>(app_row_desc));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 #ifdef SQL_ATTR_ASYNC_ENABLE
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAsyncEnableUnsupported) {
-  this->connect();
+  this->Connect();
 
   // Optional feature not implemented
-  validateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF,
                                error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAsyncStmtEventUnsupported) {
-  this->connect();
+  this->Connect();
 
   // Driver does not support asynchronous notification
-  validateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, 0,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, 0,
                                error_state_HY118);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAsyncStmtPCCallbackUnsupported) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, 0,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, 0,
                                error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCONTEXT
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAsyncStmtPCContextUnsupported) {
-  this->connect();
+  this->Connect();
 
   // Optional feature not implemented
-  validateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, 0,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, 0,
                                error_state_HYC00);
 
-  this->disconnect();
+  this->Disconnect();
 }
 #endif
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrConcurrency) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
                       static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrCursorScrollable) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
                       static_cast<SQLULEN>(SQL_NONSCROLLABLE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrCursorSensitivity) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
                       static_cast<SQLULEN>(SQL_UNSPECIFIED));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrCursorType) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
                       static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrEnableAutoIPD) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
                       static_cast<SQLULEN>(SQL_FALSE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrFetchBookmarkPointer) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrIMPParamDesc) {
-  this->connect();
+  this->Connect();
 
   // Invalid use of an automatically allocated descriptor handle
-  validateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
                                static_cast<SQLULEN>(0), error_state_HY017);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrIMPRowDesc) {
-  this->connect();
+  this->Connect();
 
   // Invalid use of an automatically allocated descriptor handle
-  validateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_ROW_DESC, static_cast<SQLULEN>(0),
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_ROW_DESC, static_cast<SQLULEN>(0),
                                error_state_HY017);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrKeysetSizeUnsupported) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrMaxLength) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrMaxRows) {
-  this->connect();
+  this->Connect();
 
   // Cannot set read-only attribute
-  validateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0),
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0),
                                error_state_HY092);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrMetadataID) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrNoscan) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamBindOffsetPtr) {
-  this->connect();
+  this->Connect();
 
   SQLULEN offset = 1000;
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamBindType) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
                       static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamOperationPtr) {
-  this->connect();
+  this->Connect();
 
   constexpr SQLULEN param_set_size = 4;
   SQLUSMALLINT param_operations[param_set_size] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
                                                    SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
                       static_cast<SQLPOINTER>(param_operations));
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
                       static_cast<SQLPOINTER>(param_operations));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamStatusPtr) {
-  this->connect();
+  this->Connect();
 
   // Driver does not support parameters, so just check array can be saved/retrieved
   constexpr SQLULEN param_status_size = 4;
   SQLUSMALLINT param_status[param_status_size] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
                                                   SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
                       static_cast<SQLPOINTER>(param_status));
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
                       static_cast<SQLPOINTER>(param_status));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamsProcessedPtr) {
-  this->connect();
+  this->Connect();
 
   SQLULEN processed_count = 0;
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
                       static_cast<SQLPOINTER>(&processed_count));
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
                       static_cast<SQLPOINTER>(&processed_count));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamsetSize) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrQueryTimeout) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRetrieveData) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
                       static_cast<SQLULEN>(SQL_RD_ON));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowArraySize) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowBindOffsetPtr) {
-  this->connect();
+  this->Connect();
 
   SQLULEN offset = 1000;
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowBindType) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowNumber) {
-  this->connect();
+  this->Connect();
 
   // Cannot set read-only attribute
-  validateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(0),
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(0),
                                error_state_HY092);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowOperationPtr) {
-  this->connect();
+  this->Connect();
 
   constexpr SQLULEN param_set_size = 4;
   SQLUSMALLINT row_operations[param_set_size] = {SQL_ROW_PROCEED, SQL_ROW_IGNORE,
                                                  SQL_ROW_PROCEED, SQL_ROW_IGNORE};
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
                       static_cast<SQLPOINTER>(row_operations));
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
                       static_cast<SQLPOINTER>(row_operations));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowStatusPtr) {
-  this->connect();
+  this->Connect();
 
   constexpr SQLULEN row_status_size = 4;
   SQLUSMALLINT values[4] = {0, 0, 0, 0};
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
                       static_cast<SQLPOINTER>(values));
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
                       static_cast<SQLPOINTER>(values));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowsFetchedPtr) {
-  this->connect();
+  this->Connect();
 
   SQLULEN rows_fetched = 1;
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
                       static_cast<SQLPOINTER>(&rows_fetched));
 
-  validateGetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
                       static_cast<SQLPOINTER>(&rows_fetched));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrSimulateCursor) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
                       static_cast<SQLULEN>(SQL_SC_UNIQUE));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrUseBookmarks) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
                       static_cast<SQLULEN>(SQL_UB_OFF));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // This is a pre ODBC 3 attribute
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowsetSize) {
-  this->connect();
+  this->Connect();
 
-  validateSetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -31,7 +31,7 @@
 
 namespace arrow::flight::sql::odbc {
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectSimpleQuery) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -61,11 +61,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectSimpleQuery) {
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectInvalidQuery) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -77,11 +77,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectInvalidQuery) {
   // ODBC provides generic error code HY000 to all statement errors
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY000);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecuteSimpleQuery) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -114,11 +114,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecuteSimpleQuery) {
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLPrepareInvalidQuery) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -133,13 +133,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLPrepareInvalidQuery) {
   // Verify function sequence error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY010);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   SQLRETURN ret =
@@ -426,13 +426,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
   EXPECT_EQ(timestamp_var.second, 59);
   EXPECT_EQ(timestamp_var.fraction, 0);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectTimeQuery) {
   // Mock server test is skipped due to limitation on the mock server.
   // Time type from mock server does not include the fraction
-  this->connect();
+  this->Connect();
 
   std::wstring wsql =
       LR"(
@@ -468,13 +468,13 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectTimeQuery) {
   EXPECT_EQ(time_var.minute, 59);
   EXPECT_EQ(time_var.second, 59);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectVarbinaryQuery) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT X'ABCDEF' AS c_varbinary;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -495,16 +495,16 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectVarbinaryQuery) {
   EXPECT_EQ(varbinary_val[1], '\xCD');
   EXPECT_EQ(varbinary_val[2], '\xEF');
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 // Tests with SQL_C_DEFAULT as the target type
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
   // Test with default types. Only testing target types supported by server.
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   SQLRETURN ret =
@@ -705,13 +705,13 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
   EXPECT_EQ(timestamp_var.second, 59);
   EXPECT_EQ(timestamp_var.fraction, 0);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectTimeQueryDefaultType) {
   // Mock server test is skipped due to limitation on the mock server.
   // Time type from mock server does not include the fraction
-  this->connect();
+  this->Connect();
 
   std::wstring wsql =
       LR"(
@@ -747,14 +747,14 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectTimeQueryDefaultType) {
   EXPECT_EQ(time_var.minute, 59);
   EXPECT_EQ(time_var.second, 59);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectVarbinaryQueryDefaultType) {
   // Limitation on mock test server prevents SQL_C_DEFAULT from working properly.
   // Mock server has type `DENSE_UNION` for varbinary.
   // Note that not all remote servers support "from_hex" function
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT from_hex('ABCDEF') AS c_varbinary;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -775,11 +775,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectVarbinaryQueryDefaultType) 
   EXPECT_EQ(varbinary_val[1], '\xCD');
   EXPECT_EQ(varbinary_val[2], '\xEF');
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectGuidQueryUnsupported) {
-  this->connect();
+  this->Connect();
 
   // Query GUID as string as SQLite does not support GUID
   std::wstring wsql = L"SELECT 'C77313CF-4E08-47CE-B6DF-94DD2FCF3541' AS guid;";
@@ -802,11 +802,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectGuidQueryUnsupported) {
   // GUID is not supported by ODBC
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY000);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectRowFetching) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql =
       LR"(
@@ -866,11 +866,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectRowFetching) {
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
-  this->connect();
+  this->Connect();
 
   SQLLEN rows_fetched;
   SQLRETURN ret = SQLSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
@@ -938,12 +938,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollUnsupportedOrientation) {
   // SQL_FETCH_PRIOR is the only supported fetch orientation.
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -985,11 +985,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollUnsupportedOrientation) {
   // DM returns state HY106 for SQL_FETCH_BOOKMARK
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY106);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectVarcharTruncation) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 'VERY LONG STRING here' AS string_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1048,11 +1048,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectVarcharTruncation) {
   // Verify SQL_NO_DATA is returned
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectWVarcharTruncation) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 'VERY LONG Unicode STRING 句子 here' AS wstring_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1112,13 +1112,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectWVarcharTruncation) {
   // Verify SQL_NO_DATA is returned
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectVarbinaryTruncation) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT X'ABCDEFAB' AS c_varbinary;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1161,14 +1161,14 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectVarbinaryTruncation) {
   // Verify SQL_NO_DATA is returned
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectFloatTruncation) {
   // Test is disabled until float truncation is supported.
   // GH-46985: return warning message instead of error on float truncation case
   GTEST_SKIP();
-  this->connect();
+  this->Connect();
 
   std::wstring wsql;
   if constexpr (std::is_same_v<TypeParam, FlightSQLODBCMockTestBase>) {
@@ -1194,13 +1194,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectFloatTruncation) {
 
   EXPECT_EQ(ssmall_int_val, 1);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectNullQuery) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT null as null_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1221,14 +1221,14 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectNullQuery) {
   // Verify SQL_NULL_DATA is returned for indicator
   EXPECT_EQ(ind, SQL_NULL_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectTruncationQueryNullIndicator) {
   // Driver should not error out when indicator is null if the cell is non-null
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
-  this->connect();
+  this->Connect();
 
   std::wstring wsql =
       LR"(
@@ -1283,13 +1283,13 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectTruncationQueryNullIndicator)
   // Verify binary truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01004);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectNullQueryNullIndicator) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT null as null_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -1309,14 +1309,14 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectNullQueryNullIndicator) {
   // Verify invalid null indicator is reported, as it is required
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_22002);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
   // Verify the driver ignores invalid buffer length for fixed data types
-  this->connect();
+  this->Connect();
 
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   SQLRETURN ret =
@@ -1550,11 +1550,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
   EXPECT_EQ(timestamp_var.second, 59);
   EXPECT_EQ(timestamp_var.fraction, 0);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColDataQuery) {
-  this->connect();
+  this->Connect();
 
   // Numeric Types
 
@@ -1730,7 +1730,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColDataQuery) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Execute query and fetch data once since there is only 1 row.
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
@@ -1834,13 +1834,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColDataQuery) {
   EXPECT_EQ(timestamp_val_max.second, 59);
   EXPECT_EQ(timestamp_val_max.fraction, 0);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColTimeQuery) {
   // Mock server test is skipped due to limitation on the mock server.
   // Time type from mock server does not include the fraction
-  this->connect();
+  this->Connect();
 
   SQL_TIME_STRUCT time_var_min{};
   SQL_TIME_STRUCT time_var_max{};
@@ -1877,13 +1877,13 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColTimeQuery) {
   EXPECT_EQ(time_var_max.minute, 59);
   EXPECT_EQ(time_var_max.second, 59);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLBindColVarbinaryQuery) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
-  this->connect();
+  this->Connect();
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
@@ -1906,13 +1906,13 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLBindColVarbinaryQuery) {
   EXPECT_EQ(varbinary_val[1], '\xCD');
   EXPECT_EQ(varbinary_val[2], '\xEF');
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColNullQuery) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
-  this->connect();
+  this->Connect();
 
   SQLINTEGER val;
   SQLLEN ind;
@@ -1932,13 +1932,13 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColNullQuery) {
   // Verify SQL_NULL_DATA is returned for indicator
   EXPECT_EQ(ind, SQL_NULL_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColNullQueryNullIndicator) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
-  this->connect();
+  this->Connect();
 
   SQLINTEGER val;
 
@@ -1956,11 +1956,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColNullQueryNullIndicator) {
   // Verify invalid null indicator is reported, as it is required
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_22002);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColRowFetching) {
-  this->connect();
+  this->Connect();
 
   SQLINTEGER val;
   SQLLEN buf_len = sizeof(val);
@@ -2008,12 +2008,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColRowFetching) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColRowArraySize) {
   // Set SQL_ATTR_ROW_ARRAY_SIZE to fetch 3 rows at once
-  this->connect();
+  this->Connect();
 
   constexpr SQLULEN rows = 3;
   SQLINTEGER val[rows];
@@ -2061,14 +2061,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColRowArraySize) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnly) {
   // GH-47021: implement driver to return indicator value when data pointer is null
   GTEST_SKIP();
   // Verify driver supports null data pointer with valid indicator pointer
-  this->connect();
+  this->Connect();
 
   // Numeric Types
 
@@ -2086,7 +2086,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnly) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Execute query and fetch data once since there is only 1 row.
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
@@ -2101,12 +2101,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnly) {
 
   // Char array
   EXPECT_EQ(char_val_ind, 1);
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnlySQLUnbind) {
   // Verify driver supports valid indicator pointer after unbinding all columns
-  this->connect();
+  this->Connect();
 
   // Numeric Types
 
@@ -2131,7 +2131,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnlySQLUnbind) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Execute query and fetch data once since there is only 1 row.
-  std::wstring wsql = this->getQueryAllDataTypes();
+  std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
@@ -2147,12 +2147,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnlySQLUnbind) {
   // Char array
   // EXPECT_EQ(char_val_ind, 1);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLExtendedFetchRowFetching) {
   // Set SQL_ROWSET_SIZE to fetch 3 rows at once
-  this->connect();
+  this->Connect();
 
   constexpr SQLULEN rows = 3;
   SQLINTEGER val[rows];
@@ -2204,7 +2204,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExtendedFetchRowFetching) {
   ret = SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count2, row_status2);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExtendedFetchQueryNullIndicator) {
@@ -2212,7 +2212,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExtendedFetchQueryNullIndicator) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
   GTEST_SKIP();
-  this->connect();
+  this->Connect();
 
   SQLINTEGER val;
 
@@ -2232,12 +2232,12 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExtendedFetchQueryNullIndicator) {
   EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_22002);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLMoreResultsNoData) {
   // Verify SQLMoreResults is stubbed to return SQL_NO_DATA
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -2250,11 +2250,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLMoreResultsNoData) {
 
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLMoreResultsInvalidFunctionSequence) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLMoreResults(this->stmt);
 
@@ -2263,152 +2263,153 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLMoreResultsInvalidFunctionSequence) {
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY010);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsInputString) {
-  this->connect();
+  this->Connect();
 
   SQLWCHAR buf[1024];
-  SQLINTEGER bufCharLen = sizeof(buf) / ODBC::GetSqlWCharSize();
-  SQLWCHAR inputStr[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER inputCharLen = static_cast<SQLINTEGER>(wcslen(inputStr));
-  SQLINTEGER outputCharLen = 0;
-  std::wstring expectedString = std::wstring(inputStr);
+  SQLINTEGER buf_char_len = sizeof(buf) / ODBC::GetSqlWCharSize();
+  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
+  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  SQLINTEGER output_char_len = 0;
+  std::wstring expected_string = std::wstring(input_str);
 
-  SQLRETURN ret =
-      SQLNativeSql(this->conn, inputStr, inputCharLen, buf, bufCharLen, &outputCharLen);
+  SQLRETURN ret = SQLNativeSql(this->conn, input_str, input_char_len, buf, buf_char_len,
+                               &output_char_len);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(outputCharLen, inputCharLen);
+  EXPECT_EQ(output_char_len, input_char_len);
 
   // returned length is in characters
-  std::wstring returnedString(buf, buf + outputCharLen);
+  std::wstring returned_string(buf, buf + output_char_len);
 
-  EXPECT_EQ(returnedString, expectedString);
+  EXPECT_EQ(returned_string, expected_string);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsNTSInputString) {
-  this->connect();
+  this->Connect();
 
   SQLWCHAR buf[1024];
-  SQLINTEGER bufCharLen = sizeof(buf) / ODBC::GetSqlWCharSize();
-  SQLWCHAR inputStr[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER inputCharLen = static_cast<SQLINTEGER>(wcslen(inputStr));
-  SQLINTEGER outputCharLen = 0;
-  std::wstring expectedString = std::wstring(inputStr);
+  SQLINTEGER buf_char_len = sizeof(buf) / ODBC::GetSqlWCharSize();
+  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
+  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  SQLINTEGER output_char_len = 0;
+  std::wstring expected_string = std::wstring(input_str);
 
   SQLRETURN ret =
-      SQLNativeSql(this->conn, inputStr, SQL_NTS, buf, bufCharLen, &outputCharLen);
+      SQLNativeSql(this->conn, input_str, SQL_NTS, buf, buf_char_len, &output_char_len);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(outputCharLen, inputCharLen);
+  EXPECT_EQ(output_char_len, input_char_len);
 
   // returned length is in characters
-  std::wstring returnedString(buf, buf + outputCharLen);
+  std::wstring returned_string(buf, buf + output_char_len);
 
-  EXPECT_EQ(returnedString, expectedString);
+  EXPECT_EQ(returned_string, expected_string);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsInputStringLength) {
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR inputStr[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER inputCharLen = static_cast<SQLINTEGER>(wcslen(inputStr));
-  SQLINTEGER outputCharLen = 0;
-  std::wstring expectedString = std::wstring(inputStr);
+  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
+  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  SQLINTEGER output_char_len = 0;
+  std::wstring expected_string = std::wstring(input_str);
 
   SQLRETURN ret =
-      SQLNativeSql(this->conn, inputStr, inputCharLen, nullptr, 0, &outputCharLen);
+      SQLNativeSql(this->conn, input_str, input_char_len, nullptr, 0, &output_char_len);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(outputCharLen, inputCharLen);
+  EXPECT_EQ(output_char_len, input_char_len);
 
-  ret = SQLNativeSql(this->conn, inputStr, SQL_NTS, nullptr, 0, &outputCharLen);
+  ret = SQLNativeSql(this->conn, input_str, SQL_NTS, nullptr, 0, &output_char_len);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(outputCharLen, inputCharLen);
+  EXPECT_EQ(output_char_len, input_char_len);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsTruncatedString) {
-  this->connect();
+  this->Connect();
 
-  const SQLINTEGER smallBufSizeInChar = 11;
-  SQLWCHAR smallBuf[smallBufSizeInChar];
-  SQLINTEGER smallBufCharLen = sizeof(smallBuf) / ODBC::GetSqlWCharSize();
-  SQLWCHAR inputStr[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER inputCharLen = static_cast<SQLINTEGER>(wcslen(inputStr));
-  SQLINTEGER outputCharLen = 0;
+  const SQLINTEGER small_buf_size_in_char = 11;
+  SQLWCHAR small_buf[small_buf_size_in_char];
+  SQLINTEGER small_buf_char_len = sizeof(small_buf) / ODBC::GetSqlWCharSize();
+  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
+  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  SQLINTEGER output_char_len = 0;
 
   // Create expected return string based on buf size
-  SQLWCHAR expectedStringBuf[smallBufSizeInChar];
-  wcsncpy(expectedStringBuf, inputStr, 10);
-  expectedStringBuf[10] = L'\0';
-  std::wstring expectedString(expectedStringBuf, expectedStringBuf + smallBufSizeInChar);
+  SQLWCHAR expected_string_buf[small_buf_size_in_char];
+  wcsncpy(expected_string_buf, input_str, 10);
+  expected_string_buf[10] = L'\0';
+  std::wstring expected_string(expected_string_buf,
+                               expected_string_buf + small_buf_size_in_char);
 
-  SQLRETURN ret = SQLNativeSql(this->conn, inputStr, inputCharLen, smallBuf,
-                               smallBufCharLen, &outputCharLen);
+  SQLRETURN ret = SQLNativeSql(this->conn, input_str, input_char_len, small_buf,
+                               small_buf_char_len, &output_char_len);
 
   EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_01004);
 
   // Returned text length represents full string char length regardless of truncation
-  EXPECT_EQ(outputCharLen, inputCharLen);
+  EXPECT_EQ(output_char_len, input_char_len);
 
-  std::wstring returnedString(smallBuf, smallBuf + smallBufCharLen);
+  std::wstring returned_string(small_buf, small_buf + small_buf_char_len);
 
-  EXPECT_EQ(returnedString, expectedString);
+  EXPECT_EQ(returned_string, expected_string);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsErrorOnBadInputs) {
-  this->connect();
+  this->Connect();
 
   SQLWCHAR buf[1024];
-  SQLINTEGER bufCharLen = sizeof(buf) / ODBC::GetSqlWCharSize();
-  SQLWCHAR inputStr[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER inputCharLen = static_cast<SQLINTEGER>(wcslen(inputStr));
-  SQLINTEGER outputCharLen = 0;
+  SQLINTEGER buf_char_len = sizeof(buf) / ODBC::GetSqlWCharSize();
+  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
+  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  SQLINTEGER output_char_len = 0;
 
-  SQLRETURN ret =
-      SQLNativeSql(this->conn, nullptr, inputCharLen, buf, bufCharLen, &outputCharLen);
-
-  EXPECT_EQ(ret, SQL_ERROR);
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY009);
-
-  ret = SQLNativeSql(this->conn, nullptr, SQL_NTS, buf, bufCharLen, &outputCharLen);
+  SQLRETURN ret = SQLNativeSql(this->conn, nullptr, input_char_len, buf, buf_char_len,
+                               &output_char_len);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY009);
 
-  ret = SQLNativeSql(this->conn, inputStr, -100, buf, bufCharLen, &outputCharLen);
+  ret = SQLNativeSql(this->conn, nullptr, SQL_NTS, buf, buf_char_len, &output_char_len);
+
+  EXPECT_EQ(ret, SQL_ERROR);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY009);
+
+  ret = SQLNativeSql(this->conn, input_str, -100, buf, buf_char_len, &output_char_len);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY090);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsReturnsColumnsOnSelect) {
-  this->connect();
+  this->Connect();
 
-  SQLSMALLINT columnCount = 0;
-  SQLSMALLINT expectedValue = 3;
-  SQLWCHAR sqlQuery[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLSMALLINT column_count = 0;
+  SQLSMALLINT expected_value = 3;
+  SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2420,22 +2421,22 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsReturnsColumnsOnSelect) {
   CheckStringColumnW(this->stmt, 2, L"One");
   CheckIntColumn(this->stmt, 3, 3);
 
-  ret = SQLNumResultCols(this->stmt, &columnCount);
+  ret = SQLNumResultCols(this->stmt, &column_count);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(columnCount, expectedValue);
+  EXPECT_EQ(column_count, expected_value);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsReturnsSuccessOnNullptr) {
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR sqlQuery[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2451,34 +2452,34 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsReturnsSuccessOnNullptr) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsFunctionSequenceErrorOnNoQuery) {
-  this->connect();
+  this->Connect();
 
-  SQLSMALLINT columnCount = 0;
-  SQLSMALLINT expectedValue = 0;
+  SQLSMALLINT column_count = 0;
+  SQLSMALLINT expected_value = 0;
 
-  SQLRETURN ret = SQLNumResultCols(this->stmt, &columnCount);
+  SQLRETURN ret = SQLNumResultCols(this->stmt, &column_count);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY010);
 
-  EXPECT_EQ(columnCount, expectedValue);
+  EXPECT_EQ(column_count, expected_value);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountReturnsNegativeOneOnSelect) {
-  this->connect();
+  this->Connect();
 
-  SQLLEN rowCount = 0;
-  SQLLEN expectedValue = -1;
-  SQLWCHAR sqlQuery[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLLEN row_count = 0;
+  SQLLEN expected_value = -1;
+  SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2490,22 +2491,22 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountReturnsNegativeOneOnSelect) {
   CheckStringColumnW(this->stmt, 2, L"One");
   CheckIntColumn(this->stmt, 3, 3);
 
-  ret = SQLRowCount(this->stmt, &rowCount);
+  ret = SQLRowCount(this->stmt, &row_count);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(rowCount, expectedValue);
+  EXPECT_EQ(row_count, expected_value);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountReturnsSuccessOnNullptr) {
-  this->connect();
+  this->Connect();
 
-  SQLWCHAR sqlQuery[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
-  SQLINTEGER queryLength = static_cast<SQLINTEGER>(wcslen(sqlQuery));
+  SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  SQLRETURN ret = SQLExecDirect(this->stmt, sqlQuery, queryLength);
+  SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
@@ -2521,27 +2522,27 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountReturnsSuccessOnNullptr) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountFunctionSequenceErrorOnNoQuery) {
-  this->connect();
+  this->Connect();
 
-  SQLLEN rowCount = 0;
-  SQLLEN expectedValue = 0;
+  SQLLEN row_count = 0;
+  SQLLEN expected_value = 0;
 
-  SQLRETURN ret = SQLRowCount(this->stmt, &rowCount);
+  SQLRETURN ret = SQLRowCount(this->stmt, &row_count);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY010);
 
-  EXPECT_EQ(rowCount, expectedValue);
+  EXPECT_EQ(row_count, expected_value);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLFreeStmtSQLClose) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -2555,11 +2556,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFreeStmtSQLClose) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLCloseCursor) {
-  this->connect();
+  this->Connect();
 
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
@@ -2573,22 +2574,22 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLCloseCursor) {
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLFreeStmtSQLCloseWithoutCursor) {
   // SQLFreeStmt(SQL_CLOSE) does not throw error with invalid cursor
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLFreeStmt(this->stmt, SQL_CLOSE);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLCloseCursorWithoutCursor) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLCloseCursor(this->stmt);
 
@@ -2597,7 +2598,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLCloseCursorWithoutCursor) {
   // Verify invalid cursor error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -30,80 +30,81 @@ namespace arrow::flight::sql::odbc {
 
 using std::optional;
 
-void checkSQLDescribeCol(SQLHSTMT stmt, const SQLUSMALLINT columnIndex,
-                         const std::wstring& expectedName,
-                         const SQLSMALLINT& expectedDataType,
-                         const SQLULEN& expectedColumnSize,
-                         const SQLSMALLINT& expectedDecimalDigits,
-                         const SQLSMALLINT& expectedNullable) {
-  SQLWCHAR columnName[1024];
-  SQLSMALLINT bufCharLen =
-      static_cast<SQLSMALLINT>(sizeof(columnName) / ODBC::GetSqlWCharSize());
-  SQLSMALLINT nameLength = 0;
-  SQLSMALLINT columnDataType = 0;
-  SQLULEN columnSize = 0;
-  SQLSMALLINT decimalDigits = 0;
+void CheckSQLDescribeCol(SQLHSTMT stmt, const SQLUSMALLINT column_index,
+                         const std::wstring& expected_name,
+                         const SQLSMALLINT& expected_data_type,
+                         const SQLULEN& expected_column_size,
+                         const SQLSMALLINT& expected_decimal_digits,
+                         const SQLSMALLINT& expected_nullable) {
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / ODBC::GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
 
-  SQLRETURN ret = SQLDescribeCol(stmt, columnIndex, columnName, bufCharLen, &nameLength,
-                                 &columnDataType, &columnSize, &decimalDigits, &nullable);
+  SQLRETURN ret =
+      SQLDescribeCol(stmt, column_index, column_name, buf_char_len, &name_length,
+                     &column_data_type, &column_size, &decimal_digits, &nullable);
 
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  EXPECT_EQ(nameLength, expectedName.size());
+  EXPECT_EQ(name_length, expected_name.size());
 
-  std::wstring returned(columnName, columnName + nameLength);
-  EXPECT_EQ(returned, expectedName);
-  EXPECT_EQ(columnDataType, expectedDataType);
-  EXPECT_EQ(columnSize, expectedColumnSize);
-  EXPECT_EQ(decimalDigits, expectedDecimalDigits);
-  EXPECT_EQ(nullable, expectedNullable);
+  std::wstring returned(column_name, column_name + name_length);
+  EXPECT_EQ(returned, expected_name);
+  EXPECT_EQ(column_data_type, expected_data_type);
+  EXPECT_EQ(column_size, expected_column_size);
+  EXPECT_EQ(decimal_digits, expected_decimal_digits);
+  EXPECT_EQ(nullable, expected_nullable);
 }
 
-void checkSQLDescribeColODBC2(SQLHSTMT stmt) {
-  SQLWCHAR* columnNames[] = {(SQLWCHAR*)L"TYPE_NAME",
-                             (SQLWCHAR*)L"DATA_TYPE",
-                             (SQLWCHAR*)L"PRECISION",
-                             (SQLWCHAR*)L"LITERAL_PREFIX",
-                             (SQLWCHAR*)L"LITERAL_SUFFIX",
-                             (SQLWCHAR*)L"CREATE_PARAMS",
-                             (SQLWCHAR*)L"NULLABLE",
-                             (SQLWCHAR*)L"CASE_SENSITIVE",
-                             (SQLWCHAR*)L"SEARCHABLE",
-                             (SQLWCHAR*)L"UNSIGNED_ATTRIBUTE",
-                             (SQLWCHAR*)L"MONEY",
-                             (SQLWCHAR*)L"AUTO_INCREMENT",
-                             (SQLWCHAR*)L"LOCAL_TYPE_NAME",
-                             (SQLWCHAR*)L"MINIMUM_SCALE",
-                             (SQLWCHAR*)L"MAXIMUM_SCALE",
-                             (SQLWCHAR*)L"SQL_DATA_TYPE",
-                             (SQLWCHAR*)L"SQL_DATETIME_SUB",
-                             (SQLWCHAR*)L"NUM_PREC_RADIX",
-                             (SQLWCHAR*)L"INTERVAL_PRECISION"};
-  SQLSMALLINT columnDataTypes[] = {SQL_WVARCHAR, SQL_SMALLINT, SQL_INTEGER,  SQL_WVARCHAR,
-                                   SQL_WVARCHAR, SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT,
-                                   SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
-                                   SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
-                                   SQL_SMALLINT, SQL_INTEGER,  SQL_SMALLINT};
-  SQLULEN columnSizes[] = {1024, 2, 4,    1024, 1024, 1024, 2, 2, 2, 2,
-                           2,    2, 1024, 2,    2,    2,    2, 4, 2};
-  SQLSMALLINT columnDecimalDigits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  SQLSMALLINT columnNullable[] = {SQL_NO_NULLS, SQL_NO_NULLS, SQL_NULLABLE, SQL_NULLABLE,
-                                  SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS, SQL_NO_NULLS,
-                                  SQL_NO_NULLS, SQL_NULLABLE, SQL_NO_NULLS, SQL_NULLABLE,
-                                  SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS,
-                                  SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE};
+void CheckSQLDescribeColODBC2(SQLHSTMT stmt) {
+  SQLWCHAR* column_names[] = {(SQLWCHAR*)L"TYPE_NAME",
+                              (SQLWCHAR*)L"DATA_TYPE",
+                              (SQLWCHAR*)L"PRECISION",
+                              (SQLWCHAR*)L"LITERAL_PREFIX",
+                              (SQLWCHAR*)L"LITERAL_SUFFIX",
+                              (SQLWCHAR*)L"CREATE_PARAMS",
+                              (SQLWCHAR*)L"NULLABLE",
+                              (SQLWCHAR*)L"CASE_SENSITIVE",
+                              (SQLWCHAR*)L"SEARCHABLE",
+                              (SQLWCHAR*)L"UNSIGNED_ATTRIBUTE",
+                              (SQLWCHAR*)L"MONEY",
+                              (SQLWCHAR*)L"AUTO_INCREMENT",
+                              (SQLWCHAR*)L"LOCAL_TYPE_NAME",
+                              (SQLWCHAR*)L"MINIMUM_SCALE",
+                              (SQLWCHAR*)L"MAXIMUM_SCALE",
+                              (SQLWCHAR*)L"SQL_DATA_TYPE",
+                              (SQLWCHAR*)L"SQL_DATETIME_SUB",
+                              (SQLWCHAR*)L"NUM_PREC_RADIX",
+                              (SQLWCHAR*)L"INTERVAL_PRECISION"};
+  SQLSMALLINT column_data_types[] = {
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_INTEGER,  SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
+      SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT,
+      SQL_SMALLINT, SQL_SMALLINT, SQL_INTEGER,  SQL_SMALLINT};
+  SQLULEN column_sizes[] = {1024, 2, 4,    1024, 1024, 1024, 2, 2, 2, 2,
+                            2,    2, 1024, 2,    2,    2,    2, 4, 2};
+  SQLSMALLINT column_decimal_digits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  SQLSMALLINT column_nullable[] = {SQL_NO_NULLS, SQL_NO_NULLS, SQL_NULLABLE, SQL_NULLABLE,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS, SQL_NO_NULLS,
+                                   SQL_NO_NULLS, SQL_NULLABLE, SQL_NO_NULLS, SQL_NULLABLE,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE};
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    SQLUSMALLINT columnIndex = i + 1;
-    checkSQLDescribeCol(stmt, columnIndex, columnNames[i], columnDataTypes[i],
-                        columnSizes[i], columnDecimalDigits[i], columnNullable[i]);
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    SQLUSMALLINT column_index = i + 1;
+    CheckSQLDescribeCol(stmt, column_index, column_names[i], column_data_types[i],
+                        column_sizes[i], column_decimal_digits[i], column_nullable[i]);
   }
 }
 
-void checkSQLDescribeColODBC3(SQLHSTMT stmt) {
-  SQLWCHAR* columnNames[] = {
+void CheckSQLDescribeColODBC3(SQLHSTMT stmt) {
+  SQLWCHAR* column_names[] = {
       (SQLWCHAR*)L"TYPE_NAME",         (SQLWCHAR*)L"DATA_TYPE",
       (SQLWCHAR*)L"COLUMN_SIZE",       (SQLWCHAR*)L"LITERAL_PREFIX",
       (SQLWCHAR*)L"LITERAL_SUFFIX",    (SQLWCHAR*)L"CREATE_PARAMS",
@@ -114,80 +115,81 @@ void checkSQLDescribeColODBC3(SQLHSTMT stmt) {
       (SQLWCHAR*)L"MAXIMUM_SCALE",     (SQLWCHAR*)L"SQL_DATA_TYPE",
       (SQLWCHAR*)L"SQL_DATETIME_SUB",  (SQLWCHAR*)L"NUM_PREC_RADIX",
       (SQLWCHAR*)L"INTERVAL_PRECISION"};
-  SQLSMALLINT columnDataTypes[] = {SQL_WVARCHAR, SQL_SMALLINT, SQL_INTEGER,  SQL_WVARCHAR,
-                                   SQL_WVARCHAR, SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT,
-                                   SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
-                                   SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
-                                   SQL_SMALLINT, SQL_INTEGER,  SQL_SMALLINT};
-  SQLULEN columnSizes[] = {1024, 2, 4,    1024, 1024, 1024, 2, 2, 2, 2,
-                           2,    2, 1024, 2,    2,    2,    2, 4, 2};
-  SQLSMALLINT columnDecimalDigits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  SQLSMALLINT columnNullable[] = {SQL_NO_NULLS, SQL_NO_NULLS, SQL_NULLABLE, SQL_NULLABLE,
-                                  SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS, SQL_NO_NULLS,
-                                  SQL_NO_NULLS, SQL_NULLABLE, SQL_NO_NULLS, SQL_NULLABLE,
-                                  SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS,
-                                  SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE};
+  SQLSMALLINT column_data_types[] = {
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_INTEGER,  SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
+      SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT,
+      SQL_SMALLINT, SQL_SMALLINT, SQL_INTEGER,  SQL_SMALLINT};
+  SQLULEN column_sizes[] = {1024, 2, 4,    1024, 1024, 1024, 2, 2, 2, 2,
+                            2,    2, 1024, 2,    2,    2,    2, 4, 2};
+  SQLSMALLINT column_decimal_digits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  SQLSMALLINT column_nullable[] = {SQL_NO_NULLS, SQL_NO_NULLS, SQL_NULLABLE, SQL_NULLABLE,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS, SQL_NO_NULLS,
+                                   SQL_NO_NULLS, SQL_NULLABLE, SQL_NO_NULLS, SQL_NULLABLE,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE};
 
-  for (size_t i = 0; i < sizeof(columnNames) / sizeof(*columnNames); ++i) {
-    SQLUSMALLINT columnIndex = i + 1;
-    checkSQLDescribeCol(stmt, columnIndex, columnNames[i], columnDataTypes[i],
-                        columnSizes[i], columnDecimalDigits[i], columnNullable[i]);
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    SQLUSMALLINT column_index = i + 1;
+    CheckSQLDescribeCol(stmt, column_index, column_names[i], column_data_types[i],
+                        column_sizes[i], column_decimal_digits[i], column_nullable[i]);
   }
 }
 
-void checkSQLGetTypeInfo(
-    SQLHSTMT stmt, const std::wstring& expectedTypeName,
-    const SQLSMALLINT& expectedDataType, const SQLINTEGER& expectedColumnSize,
-    const optional<std::wstring>& expectedLiteralPrefix,
-    const optional<std::wstring>& expectedLiteralSuffix,
-    const optional<std::wstring>& expectedCreateParams,
-    const SQLSMALLINT& expectedNullable, const SQLSMALLINT& expectedCaseSensitive,
-    const SQLSMALLINT& expectedSearchable, const SQLSMALLINT& expectedUnsignedAttr,
-    const SQLSMALLINT& expectedFixedPrecScale, const SQLSMALLINT& expectedAutoUniqueValue,
-    const std::wstring& expectedLocalTypeName, const SQLSMALLINT& expectedMinScale,
-    const SQLSMALLINT& expectedMaxScale, const SQLSMALLINT& expectedSqlDataType,
-    const SQLSMALLINT& expectedSqlDatetimeSub, const SQLINTEGER& expectedNumPrecRadix,
-    const SQLINTEGER& expectedIntervalPrec) {
-  CheckStringColumnW(stmt, 1, expectedTypeName);   // type name
-  CheckSmallIntColumn(stmt, 2, expectedDataType);  // data type
-  CheckIntColumn(stmt, 3, expectedColumnSize);     // column size
+void CheckSQLGetTypeInfo(
+    SQLHSTMT stmt, const std::wstring& expected_type_name,
+    const SQLSMALLINT& expected_data_type, const SQLINTEGER& expected_column_size,
+    const optional<std::wstring>& expected_literal_prefix,
+    const optional<std::wstring>& expected_literal_suffix,
+    const optional<std::wstring>& expected_create_params,
+    const SQLSMALLINT& expected_nullable, const SQLSMALLINT& expected_case_sensitive,
+    const SQLSMALLINT& expected_searchable, const SQLSMALLINT& expected_unsigned_attr,
+    const SQLSMALLINT& expected_fixed_prec_scale,
+    const SQLSMALLINT& expected_auto_unique_value,
+    const std::wstring& expected_local_type_name, const SQLSMALLINT& expected_min_scale,
+    const SQLSMALLINT& expected_max_scale, const SQLSMALLINT& expected_sql_data_type,
+    const SQLSMALLINT& expected_sql_datetime_sub,
+    const SQLINTEGER& expected_num_prec_radix, const SQLINTEGER& expected_interval_prec) {
+  CheckStringColumnW(stmt, 1, expected_type_name);   // type name
+  CheckSmallIntColumn(stmt, 2, expected_data_type);  // data type
+  CheckIntColumn(stmt, 3, expected_column_size);     // column size
 
-  if (expectedLiteralPrefix) {  // literal prefix
-    CheckStringColumnW(stmt, 4, *expectedLiteralPrefix);
+  if (expected_literal_prefix) {  // literal prefix
+    CheckStringColumnW(stmt, 4, *expected_literal_prefix);
   } else {
     CheckNullColumnW(stmt, 4);
   }
 
-  if (expectedLiteralSuffix) {  // literal suffix
-    CheckStringColumnW(stmt, 5, *expectedLiteralSuffix);
+  if (expected_literal_suffix) {  // literal suffix
+    CheckStringColumnW(stmt, 5, *expected_literal_suffix);
   } else {
     CheckNullColumnW(stmt, 5);
   }
 
-  if (expectedCreateParams) {  // create params
-    CheckStringColumnW(stmt, 6, *expectedCreateParams);
+  if (expected_create_params) {  // create params
+    CheckStringColumnW(stmt, 6, *expected_create_params);
   } else {
     CheckNullColumnW(stmt, 6);
   }
 
-  CheckSmallIntColumn(stmt, 7, expectedNullable);          // nullable
-  CheckSmallIntColumn(stmt, 8, expectedCaseSensitive);     // case sensitive
-  CheckSmallIntColumn(stmt, 9, expectedSearchable);        // searchable
-  CheckSmallIntColumn(stmt, 10, expectedUnsignedAttr);     // unsigned attr
-  CheckSmallIntColumn(stmt, 11, expectedFixedPrecScale);   // fixed prec scale
-  CheckSmallIntColumn(stmt, 12, expectedAutoUniqueValue);  // auto unique value
-  CheckStringColumnW(stmt, 13, expectedLocalTypeName);     // local type name
-  CheckSmallIntColumn(stmt, 14, expectedMinScale);         // min scale
-  CheckSmallIntColumn(stmt, 15, expectedMaxScale);         // max scale
-  CheckSmallIntColumn(stmt, 16, expectedSqlDataType);      // sql data type
-  CheckSmallIntColumn(stmt, 17, expectedSqlDatetimeSub);   // sql datetime sub
-  CheckIntColumn(stmt, 18, expectedNumPrecRadix);          // num prec radix
-  CheckIntColumn(stmt, 19, expectedIntervalPrec);          // interval prec
+  CheckSmallIntColumn(stmt, 7, expected_nullable);            // nullable
+  CheckSmallIntColumn(stmt, 8, expected_case_sensitive);      // case sensitive
+  CheckSmallIntColumn(stmt, 9, expected_searchable);          // searchable
+  CheckSmallIntColumn(stmt, 10, expected_unsigned_attr);      // unsigned attr
+  CheckSmallIntColumn(stmt, 11, expected_fixed_prec_scale);   // fixed prec scale
+  CheckSmallIntColumn(stmt, 12, expected_auto_unique_value);  // auto unique value
+  CheckStringColumnW(stmt, 13, expected_local_type_name);     // local type name
+  CheckSmallIntColumn(stmt, 14, expected_min_scale);          // min scale
+  CheckSmallIntColumn(stmt, 15, expected_max_scale);          // max scale
+  CheckSmallIntColumn(stmt, 16, expected_sql_data_type);      // sql data type
+  CheckSmallIntColumn(stmt, 17, expected_sql_datetime_sub);   // sql datetime sub
+  CheckIntColumn(stmt, 18, expected_num_prec_radix);          // num prec radix
+  CheckIntColumn(stmt, 19, expected_interval_prec);           // interval prec
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_ALL_TYPES);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -196,470 +198,470 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"bit"),  // expectedTypeName
-                      SQL_BIT,               // expectedDataType
-                      1,                     // expectedColumnSize
-                      std::nullopt,          // expectedLiteralPrefix
-                      std::nullopt,          // expectedLiteralSuffix
-                      std::nullopt,          // expectedCreateParams
-                      SQL_NULLABLE,          // expectedNullable
-                      SQL_FALSE,             // expectedCaseSensitive
-                      SQL_SEARCHABLE,        // expectedSearchable
-                      NULL,                  // expectedUnsignedAttr
-                      SQL_FALSE,             // expectedFixedPrecScale
-                      NULL,                  // expectedAutoUniqueValue
-                      std::wstring(L"bit"),  // expectedLocalTypeName
-                      NULL,                  // expectedMinScale
-                      NULL,                  // expectedMaxScale
-                      SQL_BIT,               // expectedSqlDataType
-                      NULL,                  // expectedSqlDatetimeSub
-                      NULL,                  // expectedNumPrecRadix
-                      NULL);                 // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"bit"),  // expected_type_name
+                      SQL_BIT,               // expected_data_type
+                      1,                     // expected_column_size
+                      std::nullopt,          // expected_literal_prefix
+                      std::nullopt,          // expected_literal_suffix
+                      std::nullopt,          // expected_create_params
+                      SQL_NULLABLE,          // expected_nullable
+                      SQL_FALSE,             // expected_case_sensitive
+                      SQL_SEARCHABLE,        // expected_searchable
+                      NULL,                  // expected_unsigned_attr
+                      SQL_FALSE,             // expected_fixed_prec_scale
+                      NULL,                  // expected_auto_unique_value
+                      std::wstring(L"bit"),  // expected_local_type_name
+                      NULL,                  // expected_min_scale
+                      NULL,                  // expected_max_scale
+                      SQL_BIT,               // expected_sql_data_type
+                      NULL,                  // expected_sql_datetime_sub
+                      NULL,                  // expected_num_prec_radix
+                      NULL);                 // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check tinyint data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"tinyint"),  // expectedTypeName
-                      SQL_TINYINT,               // expectedDataType
-                      3,                         // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"tinyint"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_TINYINT,               // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"tinyint"),  // expected_type_name
+                      SQL_TINYINT,               // expected_data_type
+                      3,                         // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"tinyint"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_TINYINT,               // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check bigint data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"bigint"),  // expectedTypeName
-                      SQL_BIGINT,               // expectedDataType
-                      19,                       // expectedColumnSize
-                      std::nullopt,             // expectedLiteralPrefix
-                      std::nullopt,             // expectedLiteralSuffix
-                      std::nullopt,             // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      SQL_FALSE,                // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"bigint"),  // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_BIGINT,               // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"bigint"),  // expected_type_name
+                      SQL_BIGINT,               // expected_data_type
+                      19,                       // expected_column_size
+                      std::nullopt,             // expected_literal_prefix
+                      std::nullopt,             // expected_literal_suffix
+                      std::nullopt,             // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      SQL_FALSE,                // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"bigint"),  // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_BIGINT,               // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check longvarbinary data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"longvarbinary"),  // expectedTypeName
-                      SQL_LONGVARBINARY,               // expectedDataType
-                      65536,                           // expectedColumnSize
-                      std::nullopt,                    // expectedLiteralPrefix
-                      std::nullopt,                    // expectedLiteralSuffix
-                      std::nullopt,                    // expectedCreateParams
-                      SQL_NULLABLE,                    // expectedNullable
-                      SQL_FALSE,                       // expectedCaseSensitive
-                      SQL_SEARCHABLE,                  // expectedSearchable
-                      NULL,                            // expectedUnsignedAttr
-                      SQL_FALSE,                       // expectedFixedPrecScale
-                      NULL,                            // expectedAutoUniqueValue
-                      std::wstring(L"longvarbinary"),  // expectedLocalTypeName
-                      NULL,                            // expectedMinScale
-                      NULL,                            // expectedMaxScale
-                      SQL_LONGVARBINARY,               // expectedSqlDataType
-                      NULL,                            // expectedSqlDatetimeSub
-                      NULL,                            // expectedNumPrecRadix
-                      NULL);                           // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"longvarbinary"),  // expected_type_name
+                      SQL_LONGVARBINARY,               // expected_data_type
+                      65536,                           // expected_column_size
+                      std::nullopt,                    // expected_literal_prefix
+                      std::nullopt,                    // expected_literal_suffix
+                      std::nullopt,                    // expected_create_params
+                      SQL_NULLABLE,                    // expected_nullable
+                      SQL_FALSE,                       // expected_case_sensitive
+                      SQL_SEARCHABLE,                  // expected_searchable
+                      NULL,                            // expected_unsigned_attr
+                      SQL_FALSE,                       // expected_fixed_prec_scale
+                      NULL,                            // expected_auto_unique_value
+                      std::wstring(L"longvarbinary"),  // expected_local_type_name
+                      NULL,                            // expected_min_scale
+                      NULL,                            // expected_max_scale
+                      SQL_LONGVARBINARY,               // expected_sql_data_type
+                      NULL,                            // expected_sql_datetime_sub
+                      NULL,                            // expected_num_prec_radix
+                      NULL);                           // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check varbinary data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"varbinary"),  // expectedTypeName
-                      SQL_VARBINARY,               // expectedDataType
-                      255,                         // expectedColumnSize
-                      std::nullopt,                // expectedLiteralPrefix
-                      std::nullopt,                // expectedLiteralSuffix
-                      std::nullopt,                // expectedCreateParams
-                      SQL_NULLABLE,                // expectedNullable
-                      SQL_FALSE,                   // expectedCaseSensitive
-                      SQL_SEARCHABLE,              // expectedSearchable
-                      NULL,                        // expectedUnsignedAttr
-                      SQL_FALSE,                   // expectedFixedPrecScale
-                      NULL,                        // expectedAutoUniqueValue
-                      std::wstring(L"varbinary"),  // expectedLocalTypeName
-                      NULL,                        // expectedMinScale
-                      NULL,                        // expectedMaxScale
-                      SQL_VARBINARY,               // expectedSqlDataType
-                      NULL,                        // expectedSqlDatetimeSub
-                      NULL,                        // expectedNumPrecRadix
-                      NULL);                       // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"varbinary"),  // expected_type_name
+                      SQL_VARBINARY,               // expected_data_type
+                      255,                         // expected_column_size
+                      std::nullopt,                // expected_literal_prefix
+                      std::nullopt,                // expected_literal_suffix
+                      std::nullopt,                // expected_create_params
+                      SQL_NULLABLE,                // expected_nullable
+                      SQL_FALSE,                   // expected_case_sensitive
+                      SQL_SEARCHABLE,              // expected_searchable
+                      NULL,                        // expected_unsigned_attr
+                      SQL_FALSE,                   // expected_fixed_prec_scale
+                      NULL,                        // expected_auto_unique_value
+                      std::wstring(L"varbinary"),  // expected_local_type_name
+                      NULL,                        // expected_min_scale
+                      NULL,                        // expected_max_scale
+                      SQL_VARBINARY,               // expected_sql_data_type
+                      NULL,                        // expected_sql_datetime_sub
+                      NULL,                        // expected_num_prec_radix
+                      NULL);                       // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check text data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"text"),    // expectedTypeName
-                      SQL_WLONGVARCHAR,         // expectedDataType
-                      65536,                    // expectedColumnSize
-                      std::wstring(L"'"),       // expectedLiteralPrefix
-                      std::wstring(L"'"),       // expectedLiteralSuffix
-                      std::wstring(L"length"),  // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      NULL,                     // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"text"),    // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_WLONGVARCHAR,         // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"text"),    // expected_type_name
+                      SQL_WLONGVARCHAR,         // expected_data_type
+                      65536,                    // expected_column_size
+                      std::wstring(L"'"),       // expected_literal_prefix
+                      std::wstring(L"'"),       // expected_literal_suffix
+                      std::wstring(L"length"),  // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      NULL,                     // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"text"),    // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_WLONGVARCHAR,         // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check longvarchar data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"longvarchar"),  // expectedTypeName
-                      SQL_WLONGVARCHAR,              // expectedDataType
-                      65536,                         // expectedColumnSize
-                      std::wstring(L"'"),            // expectedLiteralPrefix
-                      std::wstring(L"'"),            // expectedLiteralSuffix
-                      std::wstring(L"length"),       // expectedCreateParams
-                      SQL_NULLABLE,                  // expectedNullable
-                      SQL_FALSE,                     // expectedCaseSensitive
-                      SQL_SEARCHABLE,                // expectedSearchable
-                      NULL,                          // expectedUnsignedAttr
-                      SQL_FALSE,                     // expectedFixedPrecScale
-                      NULL,                          // expectedAutoUniqueValue
-                      std::wstring(L"longvarchar"),  // expectedLocalTypeName
-                      NULL,                          // expectedMinScale
-                      NULL,                          // expectedMaxScale
-                      SQL_WLONGVARCHAR,              // expectedSqlDataType
-                      NULL,                          // expectedSqlDatetimeSub
-                      NULL,                          // expectedNumPrecRadix
-                      NULL);                         // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"longvarchar"),  // expected_type_name
+                      SQL_WLONGVARCHAR,              // expected_data_type
+                      65536,                         // expected_column_size
+                      std::wstring(L"'"),            // expected_literal_prefix
+                      std::wstring(L"'"),            // expected_literal_suffix
+                      std::wstring(L"length"),       // expected_create_params
+                      SQL_NULLABLE,                  // expected_nullable
+                      SQL_FALSE,                     // expected_case_sensitive
+                      SQL_SEARCHABLE,                // expected_searchable
+                      NULL,                          // expected_unsigned_attr
+                      SQL_FALSE,                     // expected_fixed_prec_scale
+                      NULL,                          // expected_auto_unique_value
+                      std::wstring(L"longvarchar"),  // expected_local_type_name
+                      NULL,                          // expected_min_scale
+                      NULL,                          // expected_max_scale
+                      SQL_WLONGVARCHAR,              // expected_sql_data_type
+                      NULL,                          // expected_sql_datetime_sub
+                      NULL,                          // expected_num_prec_radix
+                      NULL);                         // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check char data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"char"),    // expectedTypeName
-                      SQL_WCHAR,                // expectedDataType
-                      255,                      // expectedColumnSize
-                      std::wstring(L"'"),       // expectedLiteralPrefix
-                      std::wstring(L"'"),       // expectedLiteralSuffix
-                      std::wstring(L"length"),  // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      NULL,                     // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"char"),    // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_WCHAR,                // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"char"),    // expected_type_name
+                      SQL_WCHAR,                // expected_data_type
+                      255,                      // expected_column_size
+                      std::wstring(L"'"),       // expected_literal_prefix
+                      std::wstring(L"'"),       // expected_literal_suffix
+                      std::wstring(L"length"),  // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      NULL,                     // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"char"),    // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_WCHAR,                // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check integer data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"integer"),  // expectedTypeName
-                      SQL_INTEGER,               // expectedDataType
-                      9,                         // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"integer"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_INTEGER,               // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"integer"),  // expected_type_name
+                      SQL_INTEGER,               // expected_data_type
+                      9,                         // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"integer"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_INTEGER,               // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check smallint data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"smallint"),  // expectedTypeName
-                      SQL_SMALLINT,               // expectedDataType
-                      5,                          // expectedColumnSize
-                      std::nullopt,               // expectedLiteralPrefix
-                      std::nullopt,               // expectedLiteralSuffix
-                      std::nullopt,               // expectedCreateParams
-                      SQL_NULLABLE,               // expectedNullable
-                      SQL_FALSE,                  // expectedCaseSensitive
-                      SQL_SEARCHABLE,             // expectedSearchable
-                      SQL_FALSE,                  // expectedUnsignedAttr
-                      SQL_FALSE,                  // expectedFixedPrecScale
-                      NULL,                       // expectedAutoUniqueValue
-                      std::wstring(L"smallint"),  // expectedLocalTypeName
-                      NULL,                       // expectedMinScale
-                      NULL,                       // expectedMaxScale
-                      SQL_SMALLINT,               // expectedSqlDataType
-                      NULL,                       // expectedSqlDatetimeSub
-                      NULL,                       // expectedNumPrecRadix
-                      NULL);                      // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"smallint"),  // expected_type_name
+                      SQL_SMALLINT,               // expected_data_type
+                      5,                          // expected_column_size
+                      std::nullopt,               // expected_literal_prefix
+                      std::nullopt,               // expected_literal_suffix
+                      std::nullopt,               // expected_create_params
+                      SQL_NULLABLE,               // expected_nullable
+                      SQL_FALSE,                  // expected_case_sensitive
+                      SQL_SEARCHABLE,             // expected_searchable
+                      SQL_FALSE,                  // expected_unsigned_attr
+                      SQL_FALSE,                  // expected_fixed_prec_scale
+                      NULL,                       // expected_auto_unique_value
+                      std::wstring(L"smallint"),  // expected_local_type_name
+                      NULL,                       // expected_min_scale
+                      NULL,                       // expected_max_scale
+                      SQL_SMALLINT,               // expected_sql_data_type
+                      NULL,                       // expected_sql_datetime_sub
+                      NULL,                       // expected_num_prec_radix
+                      NULL);                      // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check float data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"float"),  // expectedTypeName
-                      SQL_FLOAT,               // expectedDataType
-                      7,                       // expectedColumnSize
-                      std::nullopt,            // expectedLiteralPrefix
-                      std::nullopt,            // expectedLiteralSuffix
-                      std::nullopt,            // expectedCreateParams
-                      SQL_NULLABLE,            // expectedNullable
-                      SQL_FALSE,               // expectedCaseSensitive
-                      SQL_SEARCHABLE,          // expectedSearchable
-                      SQL_FALSE,               // expectedUnsignedAttr
-                      SQL_FALSE,               // expectedFixedPrecScale
-                      NULL,                    // expectedAutoUniqueValue
-                      std::wstring(L"float"),  // expectedLocalTypeName
-                      NULL,                    // expectedMinScale
-                      NULL,                    // expectedMaxScale
-                      SQL_FLOAT,               // expectedSqlDataType
-                      NULL,                    // expectedSqlDatetimeSub
-                      NULL,                    // expectedNumPrecRadix
-                      NULL);                   // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"float"),  // expected_type_name
+                      SQL_FLOAT,               // expected_data_type
+                      7,                       // expected_column_size
+                      std::nullopt,            // expected_literal_prefix
+                      std::nullopt,            // expected_literal_suffix
+                      std::nullopt,            // expected_create_params
+                      SQL_NULLABLE,            // expected_nullable
+                      SQL_FALSE,               // expected_case_sensitive
+                      SQL_SEARCHABLE,          // expected_searchable
+                      SQL_FALSE,               // expected_unsigned_attr
+                      SQL_FALSE,               // expected_fixed_prec_scale
+                      NULL,                    // expected_auto_unique_value
+                      std::wstring(L"float"),  // expected_local_type_name
+                      NULL,                    // expected_min_scale
+                      NULL,                    // expected_max_scale
+                      SQL_FLOAT,               // expected_sql_data_type
+                      NULL,                    // expected_sql_datetime_sub
+                      NULL,                    // expected_num_prec_radix
+                      NULL);                   // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check double data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"double"),  // expectedTypeName
-                      SQL_DOUBLE,               // expectedDataType
-                      15,                       // expectedColumnSize
-                      std::nullopt,             // expectedLiteralPrefix
-                      std::nullopt,             // expectedLiteralSuffix
-                      std::nullopt,             // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      SQL_FALSE,                // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"double"),  // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_DOUBLE,               // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"double"),  // expected_type_name
+                      SQL_DOUBLE,               // expected_data_type
+                      15,                       // expected_column_size
+                      std::nullopt,             // expected_literal_prefix
+                      std::nullopt,             // expected_literal_suffix
+                      std::nullopt,             // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      SQL_FALSE,                // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"double"),  // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_DOUBLE,               // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check numeric data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Mock server treats numeric data type as a double type
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"numeric"),  // expectedTypeName
-                      SQL_DOUBLE,                // expectedDataType
-                      15,                        // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"numeric"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_DOUBLE,                // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"numeric"),  // expected_type_name
+                      SQL_DOUBLE,                // expected_data_type
+                      15,                        // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"numeric"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_DOUBLE,                // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check varchar data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"varchar"),  // expectedTypeName
-                      SQL_WVARCHAR,              // expectedDataType
-                      255,                       // expectedColumnSize
-                      std::wstring(L"'"),        // expectedLiteralPrefix
-                      std::wstring(L"'"),        // expectedLiteralSuffix
-                      std::wstring(L"length"),   // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"varchar"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_WVARCHAR,              // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"varchar"),  // expected_type_name
+                      SQL_WVARCHAR,              // expected_data_type
+                      255,                       // expected_column_size
+                      std::wstring(L"'"),        // expected_literal_prefix
+                      std::wstring(L"'"),        // expected_literal_suffix
+                      std::wstring(L"length"),   // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"varchar"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_WVARCHAR,              // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check date data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"date"),  // expectedTypeName
-                      SQL_TYPE_DATE,          // expectedDataType
-                      10,                     // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"date"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      SQL_CODE_DATE,          // expectedSqlDatetimeSub
-                      NULL,                   // expectedNumPrecRadix
-                      NULL);                  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"date"),  // expected_type_name
+                      SQL_TYPE_DATE,          // expected_data_type
+                      10,                     // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"date"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      SQL_CODE_DATE,          // expected_sql_datetime_sub
+                      NULL,                   // expected_num_prec_radix
+                      NULL);                  // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check time data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"time"),  // expectedTypeName
-                      SQL_TYPE_TIME,          // expectedDataType
-                      8,                      // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"time"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      SQL_CODE_TIME,          // expectedSqlDatetimeSub
-                      NULL,                   // expectedNumPrecRadix
-                      NULL);                  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"time"),  // expected_type_name
+                      SQL_TYPE_TIME,          // expected_data_type
+                      8,                      // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"time"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      SQL_CODE_TIME,          // expected_sql_datetime_sub
+                      NULL,                   // expected_num_prec_radix
+                      NULL);                  // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check timestamp data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"timestamp"),  // expectedTypeName
-                      SQL_TYPE_TIMESTAMP,          // expectedDataType
-                      32,                          // expectedColumnSize
-                      std::wstring(L"'"),          // expectedLiteralPrefix
-                      std::wstring(L"'"),          // expectedLiteralSuffix
-                      std::nullopt,                // expectedCreateParams
-                      SQL_NULLABLE,                // expectedNullable
-                      SQL_FALSE,                   // expectedCaseSensitive
-                      SQL_SEARCHABLE,              // expectedSearchable
-                      SQL_FALSE,                   // expectedUnsignedAttr
-                      SQL_FALSE,                   // expectedFixedPrecScale
-                      NULL,                        // expectedAutoUniqueValue
-                      std::wstring(L"timestamp"),  // expectedLocalTypeName
-                      NULL,                        // expectedMinScale
-                      NULL,                        // expectedMaxScale
-                      SQL_DATETIME,                // expectedSqlDataType
-                      SQL_CODE_TIMESTAMP,          // expectedSqlDatetimeSub
-                      NULL,                        // expectedNumPrecRadix
-                      NULL);                       // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"timestamp"),  // expected_type_name
+                      SQL_TYPE_TIMESTAMP,          // expected_data_type
+                      32,                          // expected_column_size
+                      std::wstring(L"'"),          // expected_literal_prefix
+                      std::wstring(L"'"),          // expected_literal_suffix
+                      std::nullopt,                // expected_create_params
+                      SQL_NULLABLE,                // expected_nullable
+                      SQL_FALSE,                   // expected_case_sensitive
+                      SQL_SEARCHABLE,              // expected_searchable
+                      SQL_FALSE,                   // expected_unsigned_attr
+                      SQL_FALSE,                   // expected_fixed_prec_scale
+                      NULL,                        // expected_auto_unique_value
+                      std::wstring(L"timestamp"),  // expected_local_type_name
+                      NULL,                        // expected_min_scale
+                      NULL,                        // expected_max_scale
+                      SQL_DATETIME,                // expected_sql_data_type
+                      SQL_CODE_TIMESTAMP,          // expected_sql_datetime_sub
+                      NULL,                        // expected_num_prec_radix
+                      NULL);                       // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_ALL_TYPES);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -668,470 +670,470 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"bit"),  // expectedTypeName
-                      SQL_BIT,               // expectedDataType
-                      1,                     // expectedColumnSize
-                      std::nullopt,          // expectedLiteralPrefix
-                      std::nullopt,          // expectedLiteralSuffix
-                      std::nullopt,          // expectedCreateParams
-                      SQL_NULLABLE,          // expectedNullable
-                      SQL_FALSE,             // expectedCaseSensitive
-                      SQL_SEARCHABLE,        // expectedSearchable
-                      NULL,                  // expectedUnsignedAttr
-                      SQL_FALSE,             // expectedFixedPrecScale
-                      NULL,                  // expectedAutoUniqueValue
-                      std::wstring(L"bit"),  // expectedLocalTypeName
-                      NULL,                  // expectedMinScale
-                      NULL,                  // expectedMaxScale
-                      SQL_BIT,               // expectedSqlDataType
-                      NULL,                  // expectedSqlDatetimeSub
-                      NULL,                  // expectedNumPrecRadix
-                      NULL);                 // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"bit"),  // expected_type_name
+                      SQL_BIT,               // expected_data_type
+                      1,                     // expected_column_size
+                      std::nullopt,          // expected_literal_prefix
+                      std::nullopt,          // expected_literal_suffix
+                      std::nullopt,          // expected_create_params
+                      SQL_NULLABLE,          // expected_nullable
+                      SQL_FALSE,             // expected_case_sensitive
+                      SQL_SEARCHABLE,        // expected_searchable
+                      NULL,                  // expected_unsigned_attr
+                      SQL_FALSE,             // expected_fixed_prec_scale
+                      NULL,                  // expected_auto_unique_value
+                      std::wstring(L"bit"),  // expected_local_type_name
+                      NULL,                  // expected_min_scale
+                      NULL,                  // expected_max_scale
+                      SQL_BIT,               // expected_sql_data_type
+                      NULL,                  // expected_sql_datetime_sub
+                      NULL,                  // expected_num_prec_radix
+                      NULL);                 // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check tinyint data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"tinyint"),  // expectedTypeName
-                      SQL_TINYINT,               // expectedDataType
-                      3,                         // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"tinyint"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_TINYINT,               // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"tinyint"),  // expected_type_name
+                      SQL_TINYINT,               // expected_data_type
+                      3,                         // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"tinyint"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_TINYINT,               // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check bigint data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"bigint"),  // expectedTypeName
-                      SQL_BIGINT,               // expectedDataType
-                      19,                       // expectedColumnSize
-                      std::nullopt,             // expectedLiteralPrefix
-                      std::nullopt,             // expectedLiteralSuffix
-                      std::nullopt,             // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      SQL_FALSE,                // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"bigint"),  // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_BIGINT,               // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"bigint"),  // expected_type_name
+                      SQL_BIGINT,               // expected_data_type
+                      19,                       // expected_column_size
+                      std::nullopt,             // expected_literal_prefix
+                      std::nullopt,             // expected_literal_suffix
+                      std::nullopt,             // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      SQL_FALSE,                // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"bigint"),  // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_BIGINT,               // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check longvarbinary data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"longvarbinary"),  // expectedTypeName
-                      SQL_LONGVARBINARY,               // expectedDataType
-                      65536,                           // expectedColumnSize
-                      std::nullopt,                    // expectedLiteralPrefix
-                      std::nullopt,                    // expectedLiteralSuffix
-                      std::nullopt,                    // expectedCreateParams
-                      SQL_NULLABLE,                    // expectedNullable
-                      SQL_FALSE,                       // expectedCaseSensitive
-                      SQL_SEARCHABLE,                  // expectedSearchable
-                      NULL,                            // expectedUnsignedAttr
-                      SQL_FALSE,                       // expectedFixedPrecScale
-                      NULL,                            // expectedAutoUniqueValue
-                      std::wstring(L"longvarbinary"),  // expectedLocalTypeName
-                      NULL,                            // expectedMinScale
-                      NULL,                            // expectedMaxScale
-                      SQL_LONGVARBINARY,               // expectedSqlDataType
-                      NULL,                            // expectedSqlDatetimeSub
-                      NULL,                            // expectedNumPrecRadix
-                      NULL);                           // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"longvarbinary"),  // expected_type_name
+                      SQL_LONGVARBINARY,               // expected_data_type
+                      65536,                           // expected_column_size
+                      std::nullopt,                    // expected_literal_prefix
+                      std::nullopt,                    // expected_literal_suffix
+                      std::nullopt,                    // expected_create_params
+                      SQL_NULLABLE,                    // expected_nullable
+                      SQL_FALSE,                       // expected_case_sensitive
+                      SQL_SEARCHABLE,                  // expected_searchable
+                      NULL,                            // expected_unsigned_attr
+                      SQL_FALSE,                       // expected_fixed_prec_scale
+                      NULL,                            // expected_auto_unique_value
+                      std::wstring(L"longvarbinary"),  // expected_local_type_name
+                      NULL,                            // expected_min_scale
+                      NULL,                            // expected_max_scale
+                      SQL_LONGVARBINARY,               // expected_sql_data_type
+                      NULL,                            // expected_sql_datetime_sub
+                      NULL,                            // expected_num_prec_radix
+                      NULL);                           // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check varbinary data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"varbinary"),  // expectedTypeName
-                      SQL_VARBINARY,               // expectedDataType
-                      255,                         // expectedColumnSize
-                      std::nullopt,                // expectedLiteralPrefix
-                      std::nullopt,                // expectedLiteralSuffix
-                      std::nullopt,                // expectedCreateParams
-                      SQL_NULLABLE,                // expectedNullable
-                      SQL_FALSE,                   // expectedCaseSensitive
-                      SQL_SEARCHABLE,              // expectedSearchable
-                      NULL,                        // expectedUnsignedAttr
-                      SQL_FALSE,                   // expectedFixedPrecScale
-                      NULL,                        // expectedAutoUniqueValue
-                      std::wstring(L"varbinary"),  // expectedLocalTypeName
-                      NULL,                        // expectedMinScale
-                      NULL,                        // expectedMaxScale
-                      SQL_VARBINARY,               // expectedSqlDataType
-                      NULL,                        // expectedSqlDatetimeSub
-                      NULL,                        // expectedNumPrecRadix
-                      NULL);                       // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"varbinary"),  // expected_type_name
+                      SQL_VARBINARY,               // expected_data_type
+                      255,                         // expected_column_size
+                      std::nullopt,                // expected_literal_prefix
+                      std::nullopt,                // expected_literal_suffix
+                      std::nullopt,                // expected_create_params
+                      SQL_NULLABLE,                // expected_nullable
+                      SQL_FALSE,                   // expected_case_sensitive
+                      SQL_SEARCHABLE,              // expected_searchable
+                      NULL,                        // expected_unsigned_attr
+                      SQL_FALSE,                   // expected_fixed_prec_scale
+                      NULL,                        // expected_auto_unique_value
+                      std::wstring(L"varbinary"),  // expected_local_type_name
+                      NULL,                        // expected_min_scale
+                      NULL,                        // expected_max_scale
+                      SQL_VARBINARY,               // expected_sql_data_type
+                      NULL,                        // expected_sql_datetime_sub
+                      NULL,                        // expected_num_prec_radix
+                      NULL);                       // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check text data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"text"),    // expectedTypeName
-                      SQL_WLONGVARCHAR,         // expectedDataType
-                      65536,                    // expectedColumnSize
-                      std::wstring(L"'"),       // expectedLiteralPrefix
-                      std::wstring(L"'"),       // expectedLiteralSuffix
-                      std::wstring(L"length"),  // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      NULL,                     // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"text"),    // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_WLONGVARCHAR,         // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"text"),    // expected_type_name
+                      SQL_WLONGVARCHAR,         // expected_data_type
+                      65536,                    // expected_column_size
+                      std::wstring(L"'"),       // expected_literal_prefix
+                      std::wstring(L"'"),       // expected_literal_suffix
+                      std::wstring(L"length"),  // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      NULL,                     // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"text"),    // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_WLONGVARCHAR,         // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check longvarchar data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"longvarchar"),  // expectedTypeName
-                      SQL_WLONGVARCHAR,              // expectedDataType
-                      65536,                         // expectedColumnSize
-                      std::wstring(L"'"),            // expectedLiteralPrefix
-                      std::wstring(L"'"),            // expectedLiteralSuffix
-                      std::wstring(L"length"),       // expectedCreateParams
-                      SQL_NULLABLE,                  // expectedNullable
-                      SQL_FALSE,                     // expectedCaseSensitive
-                      SQL_SEARCHABLE,                // expectedSearchable
-                      NULL,                          // expectedUnsignedAttr
-                      SQL_FALSE,                     // expectedFixedPrecScale
-                      NULL,                          // expectedAutoUniqueValue
-                      std::wstring(L"longvarchar"),  // expectedLocalTypeName
-                      NULL,                          // expectedMinScale
-                      NULL,                          // expectedMaxScale
-                      SQL_WLONGVARCHAR,              // expectedSqlDataType
-                      NULL,                          // expectedSqlDatetimeSub
-                      NULL,                          // expectedNumPrecRadix
-                      NULL);                         // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"longvarchar"),  // expected_type_name
+                      SQL_WLONGVARCHAR,              // expected_data_type
+                      65536,                         // expected_column_size
+                      std::wstring(L"'"),            // expected_literal_prefix
+                      std::wstring(L"'"),            // expected_literal_suffix
+                      std::wstring(L"length"),       // expected_create_params
+                      SQL_NULLABLE,                  // expected_nullable
+                      SQL_FALSE,                     // expected_case_sensitive
+                      SQL_SEARCHABLE,                // expected_searchable
+                      NULL,                          // expected_unsigned_attr
+                      SQL_FALSE,                     // expected_fixed_prec_scale
+                      NULL,                          // expected_auto_unique_value
+                      std::wstring(L"longvarchar"),  // expected_local_type_name
+                      NULL,                          // expected_min_scale
+                      NULL,                          // expected_max_scale
+                      SQL_WLONGVARCHAR,              // expected_sql_data_type
+                      NULL,                          // expected_sql_datetime_sub
+                      NULL,                          // expected_num_prec_radix
+                      NULL);                         // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check char data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"char"),    // expectedTypeName
-                      SQL_WCHAR,                // expectedDataType
-                      255,                      // expectedColumnSize
-                      std::wstring(L"'"),       // expectedLiteralPrefix
-                      std::wstring(L"'"),       // expectedLiteralSuffix
-                      std::wstring(L"length"),  // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      NULL,                     // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"char"),    // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_WCHAR,                // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"char"),    // expected_type_name
+                      SQL_WCHAR,                // expected_data_type
+                      255,                      // expected_column_size
+                      std::wstring(L"'"),       // expected_literal_prefix
+                      std::wstring(L"'"),       // expected_literal_suffix
+                      std::wstring(L"length"),  // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      NULL,                     // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"char"),    // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_WCHAR,                // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check integer data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"integer"),  // expectedTypeName
-                      SQL_INTEGER,               // expectedDataType
-                      9,                         // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"integer"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_INTEGER,               // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"integer"),  // expected_type_name
+                      SQL_INTEGER,               // expected_data_type
+                      9,                         // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"integer"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_INTEGER,               // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check smallint data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"smallint"),  // expectedTypeName
-                      SQL_SMALLINT,               // expectedDataType
-                      5,                          // expectedColumnSize
-                      std::nullopt,               // expectedLiteralPrefix
-                      std::nullopt,               // expectedLiteralSuffix
-                      std::nullopt,               // expectedCreateParams
-                      SQL_NULLABLE,               // expectedNullable
-                      SQL_FALSE,                  // expectedCaseSensitive
-                      SQL_SEARCHABLE,             // expectedSearchable
-                      SQL_FALSE,                  // expectedUnsignedAttr
-                      SQL_FALSE,                  // expectedFixedPrecScale
-                      NULL,                       // expectedAutoUniqueValue
-                      std::wstring(L"smallint"),  // expectedLocalTypeName
-                      NULL,                       // expectedMinScale
-                      NULL,                       // expectedMaxScale
-                      SQL_SMALLINT,               // expectedSqlDataType
-                      NULL,                       // expectedSqlDatetimeSub
-                      NULL,                       // expectedNumPrecRadix
-                      NULL);                      // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"smallint"),  // expected_type_name
+                      SQL_SMALLINT,               // expected_data_type
+                      5,                          // expected_column_size
+                      std::nullopt,               // expected_literal_prefix
+                      std::nullopt,               // expected_literal_suffix
+                      std::nullopt,               // expected_create_params
+                      SQL_NULLABLE,               // expected_nullable
+                      SQL_FALSE,                  // expected_case_sensitive
+                      SQL_SEARCHABLE,             // expected_searchable
+                      SQL_FALSE,                  // expected_unsigned_attr
+                      SQL_FALSE,                  // expected_fixed_prec_scale
+                      NULL,                       // expected_auto_unique_value
+                      std::wstring(L"smallint"),  // expected_local_type_name
+                      NULL,                       // expected_min_scale
+                      NULL,                       // expected_max_scale
+                      SQL_SMALLINT,               // expected_sql_data_type
+                      NULL,                       // expected_sql_datetime_sub
+                      NULL,                       // expected_num_prec_radix
+                      NULL);                      // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check float data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"float"),  // expectedTypeName
-                      SQL_FLOAT,               // expectedDataType
-                      7,                       // expectedColumnSize
-                      std::nullopt,            // expectedLiteralPrefix
-                      std::nullopt,            // expectedLiteralSuffix
-                      std::nullopt,            // expectedCreateParams
-                      SQL_NULLABLE,            // expectedNullable
-                      SQL_FALSE,               // expectedCaseSensitive
-                      SQL_SEARCHABLE,          // expectedSearchable
-                      SQL_FALSE,               // expectedUnsignedAttr
-                      SQL_FALSE,               // expectedFixedPrecScale
-                      NULL,                    // expectedAutoUniqueValue
-                      std::wstring(L"float"),  // expectedLocalTypeName
-                      NULL,                    // expectedMinScale
-                      NULL,                    // expectedMaxScale
-                      SQL_FLOAT,               // expectedSqlDataType
-                      NULL,                    // expectedSqlDatetimeSub
-                      NULL,                    // expectedNumPrecRadix
-                      NULL);                   // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"float"),  // expected_type_name
+                      SQL_FLOAT,               // expected_data_type
+                      7,                       // expected_column_size
+                      std::nullopt,            // expected_literal_prefix
+                      std::nullopt,            // expected_literal_suffix
+                      std::nullopt,            // expected_create_params
+                      SQL_NULLABLE,            // expected_nullable
+                      SQL_FALSE,               // expected_case_sensitive
+                      SQL_SEARCHABLE,          // expected_searchable
+                      SQL_FALSE,               // expected_unsigned_attr
+                      SQL_FALSE,               // expected_fixed_prec_scale
+                      NULL,                    // expected_auto_unique_value
+                      std::wstring(L"float"),  // expected_local_type_name
+                      NULL,                    // expected_min_scale
+                      NULL,                    // expected_max_scale
+                      SQL_FLOAT,               // expected_sql_data_type
+                      NULL,                    // expected_sql_datetime_sub
+                      NULL,                    // expected_num_prec_radix
+                      NULL);                   // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check double data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"double"),  // expectedTypeName
-                      SQL_DOUBLE,               // expectedDataType
-                      15,                       // expectedColumnSize
-                      std::nullopt,             // expectedLiteralPrefix
-                      std::nullopt,             // expectedLiteralSuffix
-                      std::nullopt,             // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      SQL_FALSE,                // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"double"),  // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_DOUBLE,               // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"double"),  // expected_type_name
+                      SQL_DOUBLE,               // expected_data_type
+                      15,                       // expected_column_size
+                      std::nullopt,             // expected_literal_prefix
+                      std::nullopt,             // expected_literal_suffix
+                      std::nullopt,             // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      SQL_FALSE,                // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"double"),  // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_DOUBLE,               // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check numeric data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Mock server treats numeric data type as a double type
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"numeric"),  // expectedTypeName
-                      SQL_DOUBLE,                // expectedDataType
-                      15,                        // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"numeric"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_DOUBLE,                // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"numeric"),  // expected_type_name
+                      SQL_DOUBLE,                // expected_data_type
+                      15,                        // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"numeric"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_DOUBLE,                // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check varchar data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"varchar"),  // expectedTypeName
-                      SQL_WVARCHAR,              // expectedDataType
-                      255,                       // expectedColumnSize
-                      std::wstring(L"'"),        // expectedLiteralPrefix
-                      std::wstring(L"'"),        // expectedLiteralSuffix
-                      std::wstring(L"length"),   // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"varchar"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_WVARCHAR,              // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"varchar"),  // expected_type_name
+                      SQL_WVARCHAR,              // expected_data_type
+                      255,                       // expected_column_size
+                      std::wstring(L"'"),        // expected_literal_prefix
+                      std::wstring(L"'"),        // expected_literal_suffix
+                      std::wstring(L"length"),   // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"varchar"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_WVARCHAR,              // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check date data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"date"),  // expectedTypeName
-                      SQL_DATE,               // expectedDataType
-                      10,                     // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"date"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      NULL,   // expectedSqlDatetimeSub, driver returns NULL for Ver2
-                      NULL,   // expectedNumPrecRadix
-                      NULL);  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"date"),  // expected_type_name
+                      SQL_DATE,               // expected_data_type
+                      10,                     // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"date"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
+                      NULL,   // expected_num_prec_radix
+                      NULL);  // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check time data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"time"),  // expectedTypeName
-                      SQL_TIME,               // expectedDataType
-                      8,                      // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"time"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      NULL,   // expectedSqlDatetimeSub, driver returns NULL for Ver2
-                      NULL,   // expectedNumPrecRadix
-                      NULL);  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"time"),  // expected_type_name
+                      SQL_TIME,               // expected_data_type
+                      8,                      // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"time"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
+                      NULL,   // expected_num_prec_radix
+                      NULL);  // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check timestamp data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"timestamp"),  // expectedTypeName
-                      SQL_TIMESTAMP,               // expectedDataType
-                      32,                          // expectedColumnSize
-                      std::wstring(L"'"),          // expectedLiteralPrefix
-                      std::wstring(L"'"),          // expectedLiteralSuffix
-                      std::nullopt,                // expectedCreateParams
-                      SQL_NULLABLE,                // expectedNullable
-                      SQL_FALSE,                   // expectedCaseSensitive
-                      SQL_SEARCHABLE,              // expectedSearchable
-                      SQL_FALSE,                   // expectedUnsignedAttr
-                      SQL_FALSE,                   // expectedFixedPrecScale
-                      NULL,                        // expectedAutoUniqueValue
-                      std::wstring(L"timestamp"),  // expectedLocalTypeName
-                      NULL,                        // expectedMinScale
-                      NULL,                        // expectedMaxScale
-                      SQL_DATETIME,                // expectedSqlDataType
-                      NULL,   // expectedSqlDatetimeSub, driver returns NULL for Ver2
-                      NULL,   // expectedNumPrecRadix
-                      NULL);  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"timestamp"),  // expected_type_name
+                      SQL_TIMESTAMP,               // expected_data_type
+                      32,                          // expected_column_size
+                      std::wstring(L"'"),          // expected_literal_prefix
+                      std::wstring(L"'"),          // expected_literal_suffix
+                      std::nullopt,                // expected_create_params
+                      SQL_NULLABLE,                // expected_nullable
+                      SQL_FALSE,                   // expected_case_sensitive
+                      SQL_SEARCHABLE,              // expected_searchable
+                      SQL_FALSE,                   // expected_unsigned_attr
+                      SQL_FALSE,                   // expected_fixed_prec_scale
+                      NULL,                        // expected_auto_unique_value
+                      std::wstring(L"timestamp"),  // expected_local_type_name
+                      NULL,                        // expected_min_scale
+                      NULL,                        // expected_max_scale
+                      SQL_DATETIME,                // expected_sql_data_type
+                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
+                      NULL,   // expected_num_prec_radix
+                      NULL);  // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoBit) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_BIT);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1140,38 +1142,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoBit) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"bit"),  // expectedTypeName
-                      SQL_BIT,               // expectedDataType
-                      1,                     // expectedColumnSize
-                      std::nullopt,          // expectedLiteralPrefix
-                      std::nullopt,          // expectedLiteralSuffix
-                      std::nullopt,          // expectedCreateParams
-                      SQL_NULLABLE,          // expectedNullable
-                      SQL_FALSE,             // expectedCaseSensitive
-                      SQL_SEARCHABLE,        // expectedSearchable
-                      NULL,                  // expectedUnsignedAttr
-                      SQL_FALSE,             // expectedFixedPrecScale
-                      NULL,                  // expectedAutoUniqueValue
-                      std::wstring(L"bit"),  // expectedLocalTypeName
-                      NULL,                  // expectedMinScale
-                      NULL,                  // expectedMaxScale
-                      SQL_BIT,               // expectedSqlDataType
-                      NULL,                  // expectedSqlDatetimeSub
-                      NULL,                  // expectedNumPrecRadix
-                      NULL);                 // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"bit"),  // expected_type_name
+                      SQL_BIT,               // expected_data_type
+                      1,                     // expected_column_size
+                      std::nullopt,          // expected_literal_prefix
+                      std::nullopt,          // expected_literal_suffix
+                      std::nullopt,          // expected_create_params
+                      SQL_NULLABLE,          // expected_nullable
+                      SQL_FALSE,             // expected_case_sensitive
+                      SQL_SEARCHABLE,        // expected_searchable
+                      NULL,                  // expected_unsigned_attr
+                      SQL_FALSE,             // expected_fixed_prec_scale
+                      NULL,                  // expected_auto_unique_value
+                      std::wstring(L"bit"),  // expected_local_type_name
+                      NULL,                  // expected_min_scale
+                      NULL,                  // expected_max_scale
+                      SQL_BIT,               // expected_sql_data_type
+                      NULL,                  // expected_sql_datetime_sub
+                      NULL,                  // expected_num_prec_radix
+                      NULL);                 // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoTinyInt) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TINYINT);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1180,38 +1182,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoTinyInt) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"tinyint"),  // expectedTypeName
-                      SQL_TINYINT,               // expectedDataType
-                      3,                         // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"tinyint"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_TINYINT,               // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"tinyint"),  // expected_type_name
+                      SQL_TINYINT,               // expected_data_type
+                      3,                         // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"tinyint"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_TINYINT,               // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoBigInt) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_BIGINT);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1220,38 +1222,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoBigInt) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"bigint"),  // expectedTypeName
-                      SQL_BIGINT,               // expectedDataType
-                      19,                       // expectedColumnSize
-                      std::nullopt,             // expectedLiteralPrefix
-                      std::nullopt,             // expectedLiteralSuffix
-                      std::nullopt,             // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      SQL_FALSE,                // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"bigint"),  // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_BIGINT,               // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"bigint"),  // expected_type_name
+                      SQL_BIGINT,               // expected_data_type
+                      19,                       // expected_column_size
+                      std::nullopt,             // expected_literal_prefix
+                      std::nullopt,             // expected_literal_suffix
+                      std::nullopt,             // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      SQL_FALSE,                // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"bigint"),  // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_BIGINT,               // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarbinary) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_LONGVARBINARY);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1260,38 +1262,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarbinary) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"longvarbinary"),  // expectedTypeName
-                      SQL_LONGVARBINARY,               // expectedDataType
-                      65536,                           // expectedColumnSize
-                      std::nullopt,                    // expectedLiteralPrefix
-                      std::nullopt,                    // expectedLiteralSuffix
-                      std::nullopt,                    // expectedCreateParams
-                      SQL_NULLABLE,                    // expectedNullable
-                      SQL_FALSE,                       // expectedCaseSensitive
-                      SQL_SEARCHABLE,                  // expectedSearchable
-                      NULL,                            // expectedUnsignedAttr
-                      SQL_FALSE,                       // expectedFixedPrecScale
-                      NULL,                            // expectedAutoUniqueValue
-                      std::wstring(L"longvarbinary"),  // expectedLocalTypeName
-                      NULL,                            // expectedMinScale
-                      NULL,                            // expectedMaxScale
-                      SQL_LONGVARBINARY,               // expectedSqlDataType
-                      NULL,                            // expectedSqlDatetimeSub
-                      NULL,                            // expectedNumPrecRadix
-                      NULL);                           // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"longvarbinary"),  // expected_type_name
+                      SQL_LONGVARBINARY,               // expected_data_type
+                      65536,                           // expected_column_size
+                      std::nullopt,                    // expected_literal_prefix
+                      std::nullopt,                    // expected_literal_suffix
+                      std::nullopt,                    // expected_create_params
+                      SQL_NULLABLE,                    // expected_nullable
+                      SQL_FALSE,                       // expected_case_sensitive
+                      SQL_SEARCHABLE,                  // expected_searchable
+                      NULL,                            // expected_unsigned_attr
+                      SQL_FALSE,                       // expected_fixed_prec_scale
+                      NULL,                            // expected_auto_unique_value
+                      std::wstring(L"longvarbinary"),  // expected_local_type_name
+                      NULL,                            // expected_min_scale
+                      NULL,                            // expected_max_scale
+                      SQL_LONGVARBINARY,               // expected_sql_data_type
+                      NULL,                            // expected_sql_datetime_sub
+                      NULL,                            // expected_num_prec_radix
+                      NULL);                           // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoVarbinary) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_VARBINARY);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1300,36 +1302,36 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoVarbinary) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"varbinary"),  // expectedTypeName
-                      SQL_VARBINARY,               // expectedDataType
-                      255,                         // expectedColumnSize
-                      std::nullopt,                // expectedLiteralPrefix
-                      std::nullopt,                // expectedLiteralSuffix
-                      std::nullopt,                // expectedCreateParams
-                      SQL_NULLABLE,                // expectedNullable
-                      SQL_FALSE,                   // expectedCaseSensitive
-                      SQL_SEARCHABLE,              // expectedSearchable
-                      NULL,                        // expectedUnsignedAttr
-                      SQL_FALSE,                   // expectedFixedPrecScale
-                      NULL,                        // expectedAutoUniqueValue
-                      std::wstring(L"varbinary"),  // expectedLocalTypeName
-                      NULL,                        // expectedMinScale
-                      NULL,                        // expectedMaxScale
-                      SQL_VARBINARY,               // expectedSqlDataType
-                      NULL,                        // expectedSqlDatetimeSub
-                      NULL,                        // expectedNumPrecRadix
-                      NULL);                       // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"varbinary"),  // expected_type_name
+                      SQL_VARBINARY,               // expected_data_type
+                      255,                         // expected_column_size
+                      std::nullopt,                // expected_literal_prefix
+                      std::nullopt,                // expected_literal_suffix
+                      std::nullopt,                // expected_create_params
+                      SQL_NULLABLE,                // expected_nullable
+                      SQL_FALSE,                   // expected_case_sensitive
+                      SQL_SEARCHABLE,              // expected_searchable
+                      NULL,                        // expected_unsigned_attr
+                      SQL_FALSE,                   // expected_fixed_prec_scale
+                      NULL,                        // expected_auto_unique_value
+                      std::wstring(L"varbinary"),  // expected_local_type_name
+                      NULL,                        // expected_min_scale
+                      NULL,                        // expected_max_scale
+                      SQL_VARBINARY,               // expected_sql_data_type
+                      NULL,                        // expected_sql_datetime_sub
+                      NULL,                        // expected_num_prec_radix
+                      NULL);                       // expected_interval_prec
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarchar) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_WLONGVARCHAR);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1339,65 +1341,65 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarchar) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"text"),    // expectedTypeName
-                      SQL_WLONGVARCHAR,         // expectedDataType
-                      65536,                    // expectedColumnSize
-                      std::wstring(L"'"),       // expectedLiteralPrefix
-                      std::wstring(L"'"),       // expectedLiteralSuffix
-                      std::wstring(L"length"),  // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      NULL,                     // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"text"),    // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_WLONGVARCHAR,         // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"text"),    // expected_type_name
+                      SQL_WLONGVARCHAR,         // expected_data_type
+                      65536,                    // expected_column_size
+                      std::wstring(L"'"),       // expected_literal_prefix
+                      std::wstring(L"'"),       // expected_literal_suffix
+                      std::wstring(L"length"),  // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      NULL,                     // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"text"),    // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_WLONGVARCHAR,         // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check longvarchar data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"longvarchar"),  // expectedTypeName
-                      SQL_WLONGVARCHAR,              // expectedDataType
-                      65536,                         // expectedColumnSize
-                      std::wstring(L"'"),            // expectedLiteralPrefix
-                      std::wstring(L"'"),            // expectedLiteralSuffix
-                      std::wstring(L"length"),       // expectedCreateParams
-                      SQL_NULLABLE,                  // expectedNullable
-                      SQL_FALSE,                     // expectedCaseSensitive
-                      SQL_SEARCHABLE,                // expectedSearchable
-                      NULL,                          // expectedUnsignedAttr
-                      SQL_FALSE,                     // expectedFixedPrecScale
-                      NULL,                          // expectedAutoUniqueValue
-                      std::wstring(L"longvarchar"),  // expectedLocalTypeName
-                      NULL,                          // expectedMinScale
-                      NULL,                          // expectedMaxScale
-                      SQL_WLONGVARCHAR,              // expectedSqlDataType
-                      NULL,                          // expectedSqlDatetimeSub
-                      NULL,                          // expectedNumPrecRadix
-                      NULL);                         // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"longvarchar"),  // expected_type_name
+                      SQL_WLONGVARCHAR,              // expected_data_type
+                      65536,                         // expected_column_size
+                      std::wstring(L"'"),            // expected_literal_prefix
+                      std::wstring(L"'"),            // expected_literal_suffix
+                      std::wstring(L"length"),       // expected_create_params
+                      SQL_NULLABLE,                  // expected_nullable
+                      SQL_FALSE,                     // expected_case_sensitive
+                      SQL_SEARCHABLE,                // expected_searchable
+                      NULL,                          // expected_unsigned_attr
+                      SQL_FALSE,                     // expected_fixed_prec_scale
+                      NULL,                          // expected_auto_unique_value
+                      std::wstring(L"longvarchar"),  // expected_local_type_name
+                      NULL,                          // expected_min_scale
+                      NULL,                          // expected_max_scale
+                      SQL_WLONGVARCHAR,              // expected_sql_data_type
+                      NULL,                          // expected_sql_datetime_sub
+                      NULL,                          // expected_num_prec_radix
+                      NULL);                         // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoChar) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_WCHAR);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1407,38 +1409,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoChar) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"char"),    // expectedTypeName
-                      SQL_WCHAR,                // expectedDataType
-                      255,                      // expectedColumnSize
-                      std::wstring(L"'"),       // expectedLiteralPrefix
-                      std::wstring(L"'"),       // expectedLiteralSuffix
-                      std::wstring(L"length"),  // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      NULL,                     // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"char"),    // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_WCHAR,                // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"char"),    // expected_type_name
+                      SQL_WCHAR,                // expected_data_type
+                      255,                      // expected_column_size
+                      std::wstring(L"'"),       // expected_literal_prefix
+                      std::wstring(L"'"),       // expected_literal_suffix
+                      std::wstring(L"length"),  // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      NULL,                     // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"char"),    // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_WCHAR,                // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoInteger) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_INTEGER);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1447,38 +1449,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoInteger) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"integer"),  // expectedTypeName
-                      SQL_INTEGER,               // expectedDataType
-                      9,                         // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"integer"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_INTEGER,               // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"integer"),  // expected_type_name
+                      SQL_INTEGER,               // expected_data_type
+                      9,                         // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"integer"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_INTEGER,               // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSmallInt) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_SMALLINT);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1487,38 +1489,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSmallInt) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"smallint"),  // expectedTypeName
-                      SQL_SMALLINT,               // expectedDataType
-                      5,                          // expectedColumnSize
-                      std::nullopt,               // expectedLiteralPrefix
-                      std::nullopt,               // expectedLiteralSuffix
-                      std::nullopt,               // expectedCreateParams
-                      SQL_NULLABLE,               // expectedNullable
-                      SQL_FALSE,                  // expectedCaseSensitive
-                      SQL_SEARCHABLE,             // expectedSearchable
-                      SQL_FALSE,                  // expectedUnsignedAttr
-                      SQL_FALSE,                  // expectedFixedPrecScale
-                      NULL,                       // expectedAutoUniqueValue
-                      std::wstring(L"smallint"),  // expectedLocalTypeName
-                      NULL,                       // expectedMinScale
-                      NULL,                       // expectedMaxScale
-                      SQL_SMALLINT,               // expectedSqlDataType
-                      NULL,                       // expectedSqlDatetimeSub
-                      NULL,                       // expectedNumPrecRadix
-                      NULL);                      // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"smallint"),  // expected_type_name
+                      SQL_SMALLINT,               // expected_data_type
+                      5,                          // expected_column_size
+                      std::nullopt,               // expected_literal_prefix
+                      std::nullopt,               // expected_literal_suffix
+                      std::nullopt,               // expected_create_params
+                      SQL_NULLABLE,               // expected_nullable
+                      SQL_FALSE,                  // expected_case_sensitive
+                      SQL_SEARCHABLE,             // expected_searchable
+                      SQL_FALSE,                  // expected_unsigned_attr
+                      SQL_FALSE,                  // expected_fixed_prec_scale
+                      NULL,                       // expected_auto_unique_value
+                      std::wstring(L"smallint"),  // expected_local_type_name
+                      NULL,                       // expected_min_scale
+                      NULL,                       // expected_max_scale
+                      SQL_SMALLINT,               // expected_sql_data_type
+                      NULL,                       // expected_sql_datetime_sub
+                      NULL,                       // expected_num_prec_radix
+                      NULL);                      // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoFloat) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_FLOAT);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1527,38 +1529,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoFloat) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"float"),  // expectedTypeName
-                      SQL_FLOAT,               // expectedDataType
-                      7,                       // expectedColumnSize
-                      std::nullopt,            // expectedLiteralPrefix
-                      std::nullopt,            // expectedLiteralSuffix
-                      std::nullopt,            // expectedCreateParams
-                      SQL_NULLABLE,            // expectedNullable
-                      SQL_FALSE,               // expectedCaseSensitive
-                      SQL_SEARCHABLE,          // expectedSearchable
-                      SQL_FALSE,               // expectedUnsignedAttr
-                      SQL_FALSE,               // expectedFixedPrecScale
-                      NULL,                    // expectedAutoUniqueValue
-                      std::wstring(L"float"),  // expectedLocalTypeName
-                      NULL,                    // expectedMinScale
-                      NULL,                    // expectedMaxScale
-                      SQL_FLOAT,               // expectedSqlDataType
-                      NULL,                    // expectedSqlDatetimeSub
-                      NULL,                    // expectedNumPrecRadix
-                      NULL);                   // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"float"),  // expected_type_name
+                      SQL_FLOAT,               // expected_data_type
+                      7,                       // expected_column_size
+                      std::nullopt,            // expected_literal_prefix
+                      std::nullopt,            // expected_literal_suffix
+                      std::nullopt,            // expected_create_params
+                      SQL_NULLABLE,            // expected_nullable
+                      SQL_FALSE,               // expected_case_sensitive
+                      SQL_SEARCHABLE,          // expected_searchable
+                      SQL_FALSE,               // expected_unsigned_attr
+                      SQL_FALSE,               // expected_fixed_prec_scale
+                      NULL,                    // expected_auto_unique_value
+                      std::wstring(L"float"),  // expected_local_type_name
+                      NULL,                    // expected_min_scale
+                      NULL,                    // expected_max_scale
+                      SQL_FLOAT,               // expected_sql_data_type
+                      NULL,                    // expected_sql_datetime_sub
+                      NULL,                    // expected_num_prec_radix
+                      NULL);                   // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDouble) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_DOUBLE);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1567,66 +1569,66 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDouble) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"double"),  // expectedTypeName
-                      SQL_DOUBLE,               // expectedDataType
-                      15,                       // expectedColumnSize
-                      std::nullopt,             // expectedLiteralPrefix
-                      std::nullopt,             // expectedLiteralSuffix
-                      std::nullopt,             // expectedCreateParams
-                      SQL_NULLABLE,             // expectedNullable
-                      SQL_FALSE,                // expectedCaseSensitive
-                      SQL_SEARCHABLE,           // expectedSearchable
-                      SQL_FALSE,                // expectedUnsignedAttr
-                      SQL_FALSE,                // expectedFixedPrecScale
-                      NULL,                     // expectedAutoUniqueValue
-                      std::wstring(L"double"),  // expectedLocalTypeName
-                      NULL,                     // expectedMinScale
-                      NULL,                     // expectedMaxScale
-                      SQL_DOUBLE,               // expectedSqlDataType
-                      NULL,                     // expectedSqlDatetimeSub
-                      NULL,                     // expectedNumPrecRadix
-                      NULL);                    // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"double"),  // expected_type_name
+                      SQL_DOUBLE,               // expected_data_type
+                      15,                       // expected_column_size
+                      std::nullopt,             // expected_literal_prefix
+                      std::nullopt,             // expected_literal_suffix
+                      std::nullopt,             // expected_create_params
+                      SQL_NULLABLE,             // expected_nullable
+                      SQL_FALSE,                // expected_case_sensitive
+                      SQL_SEARCHABLE,           // expected_searchable
+                      SQL_FALSE,                // expected_unsigned_attr
+                      SQL_FALSE,                // expected_fixed_prec_scale
+                      NULL,                     // expected_auto_unique_value
+                      std::wstring(L"double"),  // expected_local_type_name
+                      NULL,                     // expected_min_scale
+                      NULL,                     // expected_max_scale
+                      SQL_DOUBLE,               // expected_sql_data_type
+                      NULL,                     // expected_sql_datetime_sub
+                      NULL,                     // expected_num_prec_radix
+                      NULL);                    // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check numeric data type
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Mock server treats numeric data type as a double type
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"numeric"),  // expectedTypeName
-                      SQL_DOUBLE,                // expectedDataType
-                      15,                        // expectedColumnSize
-                      std::nullopt,              // expectedLiteralPrefix
-                      std::nullopt,              // expectedLiteralSuffix
-                      std::nullopt,              // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"numeric"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_DOUBLE,                // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"numeric"),  // expected_type_name
+                      SQL_DOUBLE,                // expected_data_type
+                      15,                        // expected_column_size
+                      std::nullopt,              // expected_literal_prefix
+                      std::nullopt,              // expected_literal_suffix
+                      std::nullopt,              // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"numeric"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_DOUBLE,                // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoVarchar) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_WVARCHAR);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1636,38 +1638,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoVarchar) {
   EXPECT_EQ(ret, SQL_SUCCESS);
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"varchar"),  // expectedTypeName
-                      SQL_WVARCHAR,              // expectedDataType
-                      255,                       // expectedColumnSize
-                      std::wstring(L"'"),        // expectedLiteralPrefix
-                      std::wstring(L"'"),        // expectedLiteralSuffix
-                      std::wstring(L"length"),   // expectedCreateParams
-                      SQL_NULLABLE,              // expectedNullable
-                      SQL_FALSE,                 // expectedCaseSensitive
-                      SQL_SEARCHABLE,            // expectedSearchable
-                      SQL_FALSE,                 // expectedUnsignedAttr
-                      SQL_FALSE,                 // expectedFixedPrecScale
-                      NULL,                      // expectedAutoUniqueValue
-                      std::wstring(L"varchar"),  // expectedLocalTypeName
-                      NULL,                      // expectedMinScale
-                      NULL,                      // expectedMaxScale
-                      SQL_WVARCHAR,              // expectedSqlDataType
-                      NULL,                      // expectedSqlDatetimeSub
-                      NULL,                      // expectedNumPrecRadix
-                      NULL);                     // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"varchar"),  // expected_type_name
+                      SQL_WVARCHAR,              // expected_data_type
+                      255,                       // expected_column_size
+                      std::wstring(L"'"),        // expected_literal_prefix
+                      std::wstring(L"'"),        // expected_literal_suffix
+                      std::wstring(L"length"),   // expected_create_params
+                      SQL_NULLABLE,              // expected_nullable
+                      SQL_FALSE,                 // expected_case_sensitive
+                      SQL_SEARCHABLE,            // expected_searchable
+                      SQL_FALSE,                 // expected_unsigned_attr
+                      SQL_FALSE,                 // expected_fixed_prec_scale
+                      NULL,                      // expected_auto_unique_value
+                      std::wstring(L"varchar"),  // expected_local_type_name
+                      NULL,                      // expected_min_scale
+                      NULL,                      // expected_max_scale
+                      SQL_WVARCHAR,              // expected_sql_data_type
+                      NULL,                      // expected_sql_datetime_sub
+                      NULL,                      // expected_num_prec_radix
+                      NULL);                     // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeDate) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_DATE);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1676,38 +1678,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeDate) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"date"),  // expectedTypeName
-                      SQL_TYPE_DATE,          // expectedDataType
-                      10,                     // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"date"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      SQL_CODE_DATE,          // expectedSqlDatetimeSub
-                      NULL,                   // expectedNumPrecRadix
-                      NULL);                  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"date"),  // expected_type_name
+                      SQL_TYPE_DATE,          // expected_data_type
+                      10,                     // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"date"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      SQL_CODE_DATE,          // expected_sql_datetime_sub
+                      NULL,                   // expected_num_prec_radix
+                      NULL);                  // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLDate) {
-  this->connect();
+  this->Connect();
 
   // Pass ODBC Ver 2 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_DATE);
@@ -1717,38 +1719,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLDate) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"date"),  // expectedTypeName
-                      SQL_TYPE_DATE,          // expectedDataType
-                      10,                     // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"date"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      SQL_CODE_DATE,          // expectedSqlDatetimeSub
-                      NULL,                   // expectedNumPrecRadix
-                      NULL);                  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"date"),  // expected_type_name
+                      SQL_TYPE_DATE,          // expected_data_type
+                      10,                     // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"date"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      SQL_CODE_DATE,          // expected_sql_datetime_sub
+                      NULL,                   // expected_num_prec_radix
+                      NULL);                  // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDateODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_DATE);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1757,38 +1759,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDateODBCVer2) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"date"),  // expectedTypeName
-                      SQL_DATE,               // expectedDataType
-                      10,                     // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"date"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      NULL,   // expectedSqlDatetimeSub, driver returns NULL for Ver2
-                      NULL,   // expectedNumPrecRadix
-                      NULL);  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"date"),  // expected_type_name
+                      SQL_DATE,               // expected_data_type
+                      10,                     // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"date"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
+                      NULL,   // expected_num_prec_radix
+                      NULL);  // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeDateODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   // Pass ODBC Ver 3 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_DATE);
@@ -1798,11 +1800,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeDateODBCVer2) {
   // Driver manager returns SQL data type out of range error state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_S1004);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTime) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_TIME);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1811,38 +1813,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTime) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"time"),  // expectedTypeName
-                      SQL_TYPE_TIME,          // expectedDataType
-                      8,                      // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"time"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      SQL_CODE_TIME,          // expectedSqlDatetimeSub
-                      NULL,                   // expectedNumPrecRadix
-                      NULL);                  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"time"),  // expected_type_name
+                      SQL_TYPE_TIME,          // expected_data_type
+                      8,                      // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"time"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      SQL_CODE_TIME,          // expected_sql_datetime_sub
+                      NULL,                   // expected_num_prec_radix
+                      NULL);                  // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTime) {
-  this->connect();
+  this->Connect();
 
   // Pass ODBC Ver 2 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TIME);
@@ -1852,38 +1854,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTime) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"time"),  // expectedTypeName
-                      SQL_TYPE_TIME,          // expectedDataType
-                      8,                      // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"time"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      SQL_CODE_TIME,          // expectedSqlDatetimeSub
-                      NULL,                   // expectedNumPrecRadix
-                      NULL);                  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"time"),  // expected_type_name
+                      SQL_TYPE_TIME,          // expected_data_type
+                      8,                      // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"time"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      SQL_CODE_TIME,          // expected_sql_datetime_sub
+                      NULL,                   // expected_num_prec_radix
+                      NULL);                  // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoTimeODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TIME);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1892,38 +1894,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoTimeODBCVer2) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"time"),  // expectedTypeName
-                      SQL_TIME,               // expectedDataType
-                      8,                      // expectedColumnSize
-                      std::wstring(L"'"),     // expectedLiteralPrefix
-                      std::wstring(L"'"),     // expectedLiteralSuffix
-                      std::nullopt,           // expectedCreateParams
-                      SQL_NULLABLE,           // expectedNullable
-                      SQL_FALSE,              // expectedCaseSensitive
-                      SQL_SEARCHABLE,         // expectedSearchable
-                      SQL_FALSE,              // expectedUnsignedAttr
-                      SQL_FALSE,              // expectedFixedPrecScale
-                      NULL,                   // expectedAutoUniqueValue
-                      std::wstring(L"time"),  // expectedLocalTypeName
-                      NULL,                   // expectedMinScale
-                      NULL,                   // expectedMaxScale
-                      SQL_DATETIME,           // expectedSqlDataType
-                      NULL,   // expectedSqlDatetimeSub, driver returns NULL for Ver2
-                      NULL,   // expectedNumPrecRadix
-                      NULL);  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"time"),  // expected_type_name
+                      SQL_TIME,               // expected_data_type
+                      8,                      // expected_column_size
+                      std::wstring(L"'"),     // expected_literal_prefix
+                      std::wstring(L"'"),     // expected_literal_suffix
+                      std::nullopt,           // expected_create_params
+                      SQL_NULLABLE,           // expected_nullable
+                      SQL_FALSE,              // expected_case_sensitive
+                      SQL_SEARCHABLE,         // expected_searchable
+                      SQL_FALSE,              // expected_unsigned_attr
+                      SQL_FALSE,              // expected_fixed_prec_scale
+                      NULL,                   // expected_auto_unique_value
+                      std::wstring(L"time"),  // expected_local_type_name
+                      NULL,                   // expected_min_scale
+                      NULL,                   // expected_max_scale
+                      SQL_DATETIME,           // expected_sql_data_type
+                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
+                      NULL,   // expected_num_prec_radix
+                      NULL);  // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimeODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   // Pass ODBC Ver 3 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_TIME);
@@ -1933,11 +1935,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimeODBCVer2) {
   // Driver manager returns SQL data type out of range error state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_S1004);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimestamp) {
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_TIMESTAMP);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -1946,38 +1948,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimestamp) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"timestamp"),  // expectedTypeName
-                      SQL_TYPE_TIMESTAMP,          // expectedDataType
-                      32,                          // expectedColumnSize
-                      std::wstring(L"'"),          // expectedLiteralPrefix
-                      std::wstring(L"'"),          // expectedLiteralSuffix
-                      std::nullopt,                // expectedCreateParams
-                      SQL_NULLABLE,                // expectedNullable
-                      SQL_FALSE,                   // expectedCaseSensitive
-                      SQL_SEARCHABLE,              // expectedSearchable
-                      SQL_FALSE,                   // expectedUnsignedAttr
-                      SQL_FALSE,                   // expectedFixedPrecScale
-                      NULL,                        // expectedAutoUniqueValue
-                      std::wstring(L"timestamp"),  // expectedLocalTypeName
-                      NULL,                        // expectedMinScale
-                      NULL,                        // expectedMaxScale
-                      SQL_DATETIME,                // expectedSqlDataType
-                      SQL_CODE_TIMESTAMP,          // expectedSqlDatetimeSub
-                      NULL,                        // expectedNumPrecRadix
-                      NULL);                       // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"timestamp"),  // expected_type_name
+                      SQL_TYPE_TIMESTAMP,          // expected_data_type
+                      32,                          // expected_column_size
+                      std::wstring(L"'"),          // expected_literal_prefix
+                      std::wstring(L"'"),          // expected_literal_suffix
+                      std::nullopt,                // expected_create_params
+                      SQL_NULLABLE,                // expected_nullable
+                      SQL_FALSE,                   // expected_case_sensitive
+                      SQL_SEARCHABLE,              // expected_searchable
+                      SQL_FALSE,                   // expected_unsigned_attr
+                      SQL_FALSE,                   // expected_fixed_prec_scale
+                      NULL,                        // expected_auto_unique_value
+                      std::wstring(L"timestamp"),  // expected_local_type_name
+                      NULL,                        // expected_min_scale
+                      NULL,                        // expected_max_scale
+                      SQL_DATETIME,                // expected_sql_data_type
+                      SQL_CODE_TIMESTAMP,          // expected_sql_datetime_sub
+                      NULL,                        // expected_num_prec_radix
+                      NULL);                       // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTimestamp) {
-  this->connect();
+  this->Connect();
 
   // Pass ODBC Ver 2 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TIMESTAMP);
@@ -1987,38 +1989,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTimestamp) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"timestamp"),  // expectedTypeName
-                      SQL_TYPE_TIMESTAMP,          // expectedDataType
-                      32,                          // expectedColumnSize
-                      std::wstring(L"'"),          // expectedLiteralPrefix
-                      std::wstring(L"'"),          // expectedLiteralSuffix
-                      std::nullopt,                // expectedCreateParams
-                      SQL_NULLABLE,                // expectedNullable
-                      SQL_FALSE,                   // expectedCaseSensitive
-                      SQL_SEARCHABLE,              // expectedSearchable
-                      SQL_FALSE,                   // expectedUnsignedAttr
-                      SQL_FALSE,                   // expectedFixedPrecScale
-                      NULL,                        // expectedAutoUniqueValue
-                      std::wstring(L"timestamp"),  // expectedLocalTypeName
-                      NULL,                        // expectedMinScale
-                      NULL,                        // expectedMaxScale
-                      SQL_DATETIME,                // expectedSqlDataType
-                      SQL_CODE_TIMESTAMP,          // expectedSqlDatetimeSub
-                      NULL,                        // expectedNumPrecRadix
-                      NULL);                       // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"timestamp"),  // expected_type_name
+                      SQL_TYPE_TIMESTAMP,          // expected_data_type
+                      32,                          // expected_column_size
+                      std::wstring(L"'"),          // expected_literal_prefix
+                      std::wstring(L"'"),          // expected_literal_suffix
+                      std::nullopt,                // expected_create_params
+                      SQL_NULLABLE,                // expected_nullable
+                      SQL_FALSE,                   // expected_case_sensitive
+                      SQL_SEARCHABLE,              // expected_searchable
+                      SQL_FALSE,                   // expected_unsigned_attr
+                      SQL_FALSE,                   // expected_fixed_prec_scale
+                      NULL,                        // expected_auto_unique_value
+                      std::wstring(L"timestamp"),  // expected_local_type_name
+                      NULL,                        // expected_min_scale
+                      NULL,                        // expected_max_scale
+                      SQL_DATETIME,                // expected_sql_data_type
+                      SQL_CODE_TIMESTAMP,          // expected_sql_datetime_sub
+                      NULL,                        // expected_num_prec_radix
+                      NULL);                       // expected_interval_prec
 
-  checkSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TIMESTAMP);
   EXPECT_EQ(ret, SQL_SUCCESS);
@@ -2027,38 +2029,38 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_SUCCESS);
 
-  checkSQLGetTypeInfo(this->stmt,
-                      std::wstring(L"timestamp"),  // expectedTypeName
-                      SQL_TIMESTAMP,               // expectedDataType
-                      32,                          // expectedColumnSize
-                      std::wstring(L"'"),          // expectedLiteralPrefix
-                      std::wstring(L"'"),          // expectedLiteralSuffix
-                      std::nullopt,                // expectedCreateParams
-                      SQL_NULLABLE,                // expectedNullable
-                      SQL_FALSE,                   // expectedCaseSensitive
-                      SQL_SEARCHABLE,              // expectedSearchable
-                      SQL_FALSE,                   // expectedUnsignedAttr
-                      SQL_FALSE,                   // expectedFixedPrecScale
-                      NULL,                        // expectedAutoUniqueValue
-                      std::wstring(L"timestamp"),  // expectedLocalTypeName
-                      NULL,                        // expectedMinScale
-                      NULL,                        // expectedMaxScale
-                      SQL_DATETIME,                // expectedSqlDataType
-                      NULL,   // expectedSqlDatetimeSub, driver returns NULL for Ver2
-                      NULL,   // expectedNumPrecRadix
-                      NULL);  // expectedIntervalPrec
+  CheckSQLGetTypeInfo(this->stmt,
+                      std::wstring(L"timestamp"),  // expected_type_name
+                      SQL_TIMESTAMP,               // expected_data_type
+                      32,                          // expected_column_size
+                      std::wstring(L"'"),          // expected_literal_prefix
+                      std::wstring(L"'"),          // expected_literal_suffix
+                      std::nullopt,                // expected_create_params
+                      SQL_NULLABLE,                // expected_nullable
+                      SQL_FALSE,                   // expected_case_sensitive
+                      SQL_SEARCHABLE,              // expected_searchable
+                      SQL_FALSE,                   // expected_unsigned_attr
+                      SQL_FALSE,                   // expected_fixed_prec_scale
+                      NULL,                        // expected_auto_unique_value
+                      std::wstring(L"timestamp"),  // expected_local_type_name
+                      NULL,                        // expected_min_scale
+                      NULL,                        // expected_max_scale
+                      SQL_DATETIME,                // expected_sql_data_type
+                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
+                      NULL,   // expected_num_prec_radix
+                      NULL);  // expected_interval_prec
 
-  checkSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // No more data
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimestampODBCVer2) {
-  this->connect(SQL_OV_ODBC2);
+  this->Connect(SQL_OV_ODBC2);
 
   // Pass ODBC Ver 3 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_TIMESTAMP);
@@ -2068,24 +2070,24 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimestampODBCVer2) {
   // Driver manager returns SQL data type out of range error state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_S1004);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoInvalidDataType) {
-  this->connect();
+  this->Connect();
 
-  SQLSMALLINT invalidDataType = -114;
-  SQLRETURN ret = SQLGetTypeInfo(this->stmt, invalidDataType);
+  SQLSMALLINT invalid_data_type = -114;
+  SQLRETURN ret = SQLGetTypeInfo(this->stmt, invalid_data_type);
 
   EXPECT_EQ(ret, SQL_ERROR);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY004);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetTypeInfoUnsupportedDataType) {
   // Assumes mock and remote server don't support GUID data type
-  this->connect();
+  this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_GUID);
 
@@ -2095,7 +2097,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetTypeInfoUnsupportedDataType) {
   ret = SQLFetch(this->stmt);
   EXPECT_EQ(ret, SQL_NO_DATA);
 
-  this->disconnect();
+  this->Disconnect();
 }
 
 }  // namespace arrow::flight::sql::odbc


### PR DESCRIPTION
### Rationale for this change
We want our code to adhere to Arrow's expected naming conventions

### What changes are included in this PR?
Functions are renamed to be PascalCase and variables are renamed to be snake_case.

### Are there any user-facing changes?
No