### PR TITLE
Fix member variable naming

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
@@ -148,15 +148,15 @@ void Configuration::LoadDsn(const std::string& dsn) {
   }
 }
 
-void Configuration::Clear() { this->properties.clear(); }
+void Configuration::Clear() { this->properties_.clear(); }
 
 bool Configuration::IsSet(const std::string_view& key) const {
-  return 0 != this->properties.count(std::string(key));
+  return 0 != this->properties_.count(std::string(key));
 }
 
 const std::string& Configuration::Get(const std::string_view& key) const {
-  const auto itr = this->properties.find(std::string(key));
-  if (itr == this->properties.cend()) {
+  const auto itr = this->properties_.find(std::string(key));
+  if (itr == this->properties_.cend()) {
     static const std::string empty("");
     return empty;
   }
@@ -171,25 +171,25 @@ void Configuration::Set(const std::string_view& key, const std::wstring& wValue)
 void Configuration::Set(const std::string_view& key, const std::string& value) {
   const std::string copy = boost::trim_copy(value);
   if (!copy.empty()) {
-    this->properties[std::string(key)] = value;
+    this->properties_[std::string(key)] = value;
   }
 }
 
 void Configuration::Emplace(const std::string_view& key, std::string&& value) {
   const std::string copy = boost::trim_copy(value);
   if (!copy.empty()) {
-    this->properties.emplace(
+    this->properties_.emplace(
         std::make_pair(std::move(std::string(key)), std::move(value)));
   }
 }
 
 const driver::odbcabstraction::Connection::ConnPropertyMap& Configuration::GetProperties()
     const {
-  return this->properties;
+  return this->properties_;
 }
 
 std::vector<std::string> Configuration::GetCustomKeys() const {
-  driver::odbcabstraction::Connection::ConnPropertyMap copy_props(properties);
+  driver::odbcabstraction::Connection::ConnPropertyMap copy_props(properties_);
   for (auto& key : FlightSqlConnection::ALL_KEYS) {
     copy_props.erase(std::string(key));
   }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/config/connection_string_parser.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/config/connection_string_parser.cc
@@ -31,7 +31,7 @@ namespace driver {
 namespace flight_sql {
 namespace config {
 
-ConnectionStringParser::ConnectionStringParser(Configuration& cfg) : cfg(cfg) {
+ConnectionStringParser::ConnectionStringParser(Configuration& cfg) : cfg_(cfg) {
   // No-op.
 }
 
@@ -73,7 +73,7 @@ void ConnectionStringParser::ParseConnectionString(const char* str, size_t len,
         value = value.substr(1, value.size() - 2);
       }
 
-      cfg.Set(key, value);
+      cfg_.Set(key, value);
     }
 
     if (!attr_begin) break;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
@@ -204,9 +204,9 @@ void FlightSqlConnection::Connect(const ConnPropertyMap& properties,
 
 void FlightSqlConnection::PopulateMetadataSettings(
     const Connection::ConnPropertyMap& conn_property_map) {
-  metadata_settings_.string_column_length_ = GetStringColumnLength(conn_property_map);
-  metadata_settings_.use_wide_char_ = GetUseWideChar(conn_property_map);
-  metadata_settings_.chunk_buffer_capacity_ = GetChunkBufferCapacity(conn_property_map);
+  metadata_settings_.string_column_length = GetStringColumnLength(conn_property_map);
+  metadata_settings_.use_wide_char = GetUseWideChar(conn_property_map);
+  metadata_settings_.chunk_buffer_capacity = GetChunkBufferCapacity(conn_property_map);
 }
 
 boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.cc
@@ -52,7 +52,7 @@ FlightSqlResultSet::FlightSqlResultSet(
     const odbcabstraction::MetadataSettings& metadata_settings)
     : metadata_settings_(metadata_settings),
       chunk_buffer_(flight_sql_client, client_options, call_options, flight_info,
-                    metadata_settings_.chunk_buffer_capacity_),
+                    metadata_settings_.chunk_buffer_capacity),
       transformer_(transformer),
       metadata_(transformer
                     ? new FlightSqlResultSetMetadata(transformer->GetTransformedSchema(),
@@ -72,7 +72,7 @@ FlightSqlResultSet::FlightSqlResultSet(
   }
 
   for (size_t i = 0; i < columns_.size(); ++i) {
-    columns_[i] = FlightSqlResultSetColumn(metadata_settings.use_wide_char_);
+    columns_[i] = FlightSqlResultSetColumn(metadata_settings.use_wide_char);
   }
 }
 
@@ -124,10 +124,10 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
 
     for (auto& column : columns_) {
       // There can be unbound columns.
-      if (!column.is_bound_) continue;
+      if (!column.is_bound) continue;
 
       auto* accessor = column.GetAccessorForBinding();
-      ColumnBinding shifted_binding = column.binding_;
+      ColumnBinding shifted_binding = column.binding;
       uint16_t* shifted_row_status_array =
           row_status_array ? &row_status_array[fetched_rows] : nullptr;
 
@@ -267,14 +267,14 @@ void FlightSqlResultSet::BindColumn(int column_n, int16_t target_type, int preci
                                     ssize_t* str_len_buffer) {
   auto& column = columns_[column_n - 1];
   if (buffer == nullptr) {
-    if (column.is_bound_) {
+    if (column.is_bound) {
       num_binding_--;
     }
     column.ResetBinding();
     return;
   }
 
-  if (!column.is_bound_) {
+  if (!column.is_bound) {
     num_binding_++;
   }
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_column.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_column.cc
@@ -50,7 +50,7 @@ std::unique_ptr<Accessor> FlightSqlResultSetColumn::CreateAccessor(
 Accessor* FlightSqlResultSetColumn::GetAccessorForTargetType(CDataType target_type) {
   // Cast the original array to a type matching the target_type.
   if (target_type == odbcabstraction::CDataType_DEFAULT) {
-    target_type = ConvertArrowTypeToC(original_array_->type_id(), use_wide_char_);
+    target_type = ConvertArrowTypeToC(original_array_->type_id(), use_wide_char);
   }
 
   cached_accessor_ = CreateAccessor(target_type);
@@ -58,33 +58,33 @@ Accessor* FlightSqlResultSetColumn::GetAccessorForTargetType(CDataType target_ty
 }
 
 FlightSqlResultSetColumn::FlightSqlResultSetColumn(bool use_wide_char)
-    : use_wide_char_(use_wide_char), is_bound_(false) {}
+    : use_wide_char(use_wide_char), is_bound(false) {}
 
 void FlightSqlResultSetColumn::SetBinding(const ColumnBinding& new_binding,
                                           arrow::Type::type arrow_type) {
-  binding_ = new_binding;
-  is_bound_ = true;
+  binding = new_binding;
+  is_bound = true;
 
-  if (binding_.target_type == odbcabstraction::CDataType_DEFAULT) {
-    binding_.target_type = ConvertArrowTypeToC(arrow_type, use_wide_char_);
+  if (binding.target_type == odbcabstraction::CDataType_DEFAULT) {
+    binding.target_type = ConvertArrowTypeToC(arrow_type, use_wide_char);
   }
 
   // Overwrite the binding if the caller is using SQL_C_NUMERIC and has used zero
   // precision if it is zero (this is precision unset and will always fail).
-  if (binding_.precision == 0 &&
-      binding_.target_type == odbcabstraction::CDataType_NUMERIC) {
-    binding_.precision = arrow::Decimal128Type::kMaxPrecision;
+  if (binding.precision == 0 &&
+      binding.target_type == odbcabstraction::CDataType_NUMERIC) {
+    binding.precision = arrow::Decimal128Type::kMaxPrecision;
   }
 
   // Rebuild the accessor and casted array if the target type changed.
   if (original_array_ &&
-      (!cached_casted_array_ || cached_accessor_->target_type_ != binding_.target_type)) {
-    cached_accessor_ = CreateAccessor(binding_.target_type);
+      (!cached_casted_array_ || cached_accessor_->target_type_ != binding.target_type)) {
+    cached_accessor_ = CreateAccessor(binding.target_type);
   }
 }
 
 void FlightSqlResultSetColumn::ResetBinding() {
-  is_bound_ = false;
+  is_bound = false;
   cached_casted_array_.reset();
   cached_accessor_.reset();
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_column.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_column.h
@@ -40,15 +40,15 @@ class FlightSqlResultSetColumn {
   FlightSqlResultSetColumn() = default;
   explicit FlightSqlResultSetColumn(bool use_wide_char);
 
-  ColumnBinding binding_;
-  bool use_wide_char_;
-  bool is_bound_;
+  ColumnBinding binding;
+  bool use_wide_char;
+  bool is_bound;
 
   inline Accessor* GetAccessorForBinding() { return cached_accessor_.get(); }
 
   inline Accessor* GetAccessorForGetData(CDataType target_type) {
     if (target_type == odbcabstraction::CDataType_DEFAULT) {
-      target_type = ConvertArrowTypeToC(original_array_->type_id(), use_wide_char_);
+      target_type = ConvertArrowTypeToC(original_array_->type_id(), use_wide_char);
     }
 
     if (cached_accessor_ && cached_accessor_->target_type_ == target_type) {
@@ -65,8 +65,8 @@ class FlightSqlResultSetColumn {
     original_array_ = std::move(array);
     if (cached_accessor_) {
       cached_accessor_ = CreateAccessor(cached_accessor_->target_type_);
-    } else if (is_bound_) {
-      cached_accessor_ = CreateAccessor(binding_.target_type);
+    } else if (is_bound) {
+      cached_accessor_ = CreateAccessor(binding.target_type);
     } else {
       cached_casted_array_.reset();
       cached_accessor_.reset();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_metadata.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_metadata.cc
@@ -68,7 +68,7 @@ size_t FlightSqlResultSetMetadata::GetPrecision(int column_position) {
 
   int32_t column_size = GetFieldPrecision(field).ValueOrElse([] { return 0; });
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return GetColumnSize(data_type_v3, column_size).value_or(0);
 }
@@ -79,7 +79,7 @@ size_t FlightSqlResultSetMetadata::GetScale(int column_position) {
 
   int32_t type_scale = metadata.GetScale().ValueOrElse([] { return 0; });
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return GetTypeScale(data_type_v3, type_scale).value_or(0);
 }
@@ -87,7 +87,7 @@ size_t FlightSqlResultSetMetadata::GetScale(int column_position) {
 uint16_t FlightSqlResultSetMetadata::GetDataType(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
   const SqlDataType concise_type =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
   return GetNonConciseDataType(concise_type);
 }
 
@@ -126,10 +126,10 @@ std::string FlightSqlResultSetMetadata::GetColumnLabel(int column_position) {
 size_t FlightSqlResultSetMetadata::GetColumnDisplaySize(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
 
-  int32_t column_size = metadata_settings_.string_column_length_.value_or(
+  int32_t column_size = metadata_settings_.string_column_length.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return GetDisplaySize(data_type_v3, column_size).value_or(odbcabstraction::NO_TOTAL);
 }
@@ -148,17 +148,17 @@ uint16_t FlightSqlResultSetMetadata::GetConciseType(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
 
   const SqlDataType sqlColumnType =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
   return sqlColumnType;
 }
 
 size_t FlightSqlResultSetMetadata::GetLength(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
 
-  int32_t column_size = metadata_settings_.string_column_length_.value_or(
+  int32_t column_size = metadata_settings_.string_column_length.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return flight_sql::GetLength(data_type_v3, column_size)
       .value_or(DefaultLengthForVariableLengthColumns);
@@ -185,7 +185,7 @@ std::string FlightSqlResultSetMetadata::GetLocalTypeName(int column_position) {
 size_t FlightSqlResultSetMetadata::GetNumPrecRadix(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return GetRadixFromSqlDataType(data_type_v3).value_or(odbcabstraction::NO_TOTAL);
 }
@@ -194,10 +194,10 @@ size_t FlightSqlResultSetMetadata::GetOctetLength(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
   arrow::flight::sql::ColumnMetadata metadata = GetMetadata(field);
 
-  int32_t column_size = metadata_settings_.string_column_length_.value_or(
+  int32_t column_size = metadata_settings_.string_column_length.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   // Workaround to get the precision for Decimal and Numeric types, since server doesn't
   // return it currently.

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_columns.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_columns.cc
@@ -113,7 +113,7 @@ Result<std::shared_ptr<RecordBatch>> TransformInner(
       }
 
       odbcabstraction::SqlDataType data_type_v3 =
-          GetDataTypeFromArrowFieldV3(field, metadata_settings.use_wide_char_);
+          GetDataTypeFromArrowFieldV3(field, metadata_settings.use_wide_char);
 
       ColumnMetadata metadata(field->metadata());
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.cc
@@ -90,7 +90,7 @@ Result<std::shared_ptr<RecordBatch>> TransformInner(
   while (reader.Next()) {
     auto data_type_v3 = EnsureRightSqlCharType(
         static_cast<odbcabstraction::SqlDataType>(reader.GetDataType()),
-        metadata_settings_.use_wide_char_);
+        metadata_settings_.use_wide_char);
     int16_t data_type_v2 = ConvertSqlDataTypeFromV3ToV2(data_type_v3);
 
     if (data_type != odbcabstraction::ALL_TYPES && data_type_v3 != data_type &&
@@ -126,7 +126,7 @@ Result<std::shared_ptr<RecordBatch>> TransformInner(
     data.maximum_scale = reader.GetMaximumScale();
     data.sql_data_type = GetNonConciseDataType(EnsureRightSqlCharType(
         static_cast<odbcabstraction::SqlDataType>(reader.GetSqlDataType()),
-        metadata_settings_.use_wide_char_));
+        metadata_settings_.use_wide_char));
     data.sql_datetime_sub =
         GetSqlDateTimeSubCode(static_cast<odbcabstraction::SqlDataType>(data.data_type));
     data.num_prec_radix = reader.GetNumPrecRadix();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/configuration.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/configuration.h
@@ -66,7 +66,7 @@ class Configuration {
   std::vector<std::string> GetCustomKeys() const;
 
  private:
-  driver::odbcabstraction::Connection::ConnPropertyMap properties;
+  driver::odbcabstraction::Connection::ConnPropertyMap properties_;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/connection_string_parser.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/connection_string_parser.h
@@ -70,7 +70,7 @@ class ConnectionStringParser {
   ConnectionStringParser& operator=(const ConnectionStringParser&) = delete;
 
   /** Configuration. */
-  Configuration& cfg;
+  Configuration& cfg_;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
@@ -85,32 +85,32 @@ class AddPropertyWindow : public CustomWindow {
 
   void CheckEnableOk();
 
-  std::vector<std::unique_ptr<Window> > labels;
+  std::vector<std::unique_ptr<Window> > labels_;
 
   /** Ok button. */
-  std::unique_ptr<Window> ok_button;
+  std::unique_ptr<Window> ok_button_;
 
   /** Cancel button. */
-  std::unique_ptr<Window> cancel_button;
+  std::unique_ptr<Window> cancel_button_;
 
-  std::unique_ptr<Window> key_edit;
+  std::unique_ptr<Window> key_edit_;
 
-  std::unique_ptr<Window> value_edit;
+  std::unique_ptr<Window> value_edit_;
 
-  std::wstring key;
+  std::wstring key_;
 
-  std::wstring value;
+  std::wstring value_;
 
   /** Window width. */
-  int width;
+  int width_;
 
   /** Window height. */
-  int height;
+  int height_;
 
   /** Flag indicating whether OK option was selected. */
-  bool accepted;
+  bool accepted_;
 
-  bool is_initialized;
+  bool is_initialized_;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h
@@ -142,79 +142,75 @@ class DsnConfigurationWindow : public CustomWindow {
   void SaveParameters(Configuration& target_config);
 
   /** Window width. */
-  int width;
+  int width_;
 
   /** Window height. */
-  int height;
+  int height_;
 
-  std::unique_ptr<Window> tab_control;
-
-  std::unique_ptr<Window> common_content;
-
-  std::unique_ptr<Window> advanced_content;
+  std::unique_ptr<Window> tab_control_;
 
   /** Connection settings group box. */
-  std::unique_ptr<Window> connection_settings_group_box;
+  std::unique_ptr<Window> connection_settings_group_box_;
 
   /** Authentication settings group box. */
-  std::unique_ptr<Window> auth_settings_group_box;
+  std::unique_ptr<Window> auth_settings_group_box_;
 
   /** Encryption settings group box. */
-  std::unique_ptr<Window> encryption_settings_group_box;
+  std::unique_ptr<Window> encryption_settings_group_box_;
 
-  std::vector<std::unique_ptr<Window> > labels;
+  std::vector<std::unique_ptr<Window> > labels_;
 
   /** Test button. */
-  std::unique_ptr<Window> test_button;
+  std::unique_ptr<Window> test_button_;
 
   /** Ok button. */
-  std::unique_ptr<Window> ok_button;
+  std::unique_ptr<Window> ok_button_;
 
   /** Cancel button. */
-  std::unique_ptr<Window> cancel_button;
+  std::unique_ptr<Window> cancel_button_;
 
   /** DSN name edit field. */
-  std::unique_ptr<Window> name_edit;
+  std::unique_ptr<Window> name_edit_;
 
-  std::unique_ptr<Window> server_edit;
+  std::unique_ptr<Window> server_edit_;
 
-  std::unique_ptr<Window> port_edit;
+  std::unique_ptr<Window> port_edit_;
 
-  std::unique_ptr<Window> auth_type_combo_box;
+  std::unique_ptr<Window> auth_type_combo_box_;
 
   /** User edit. */
-  std::unique_ptr<Window> user_edit;
+  std::unique_ptr<Window> user_edit_;
 
   /** Password edit. */
-  std::unique_ptr<Window> password_edit;
+  std::unique_ptr<Window> password_edit_;
 
-  std::unique_ptr<Window> auth_token_edit;
+  std::unique_ptr<Window> auth_token_edit_;
 
-  std::unique_ptr<Window> enable_encryption_check_box;
+  std::unique_ptr<Window> enable_encryption_check_box_;
 
-  std::unique_ptr<Window> certificate_edit;
+  std::unique_ptr<Window> certificate_edit_;
 
-  std::unique_ptr<Window> certificate_browse_button;
+  std::unique_ptr<Window> certificate_browse_button_;
 
-  std::unique_ptr<Window> use_system_cert_store_check_box;
+  std::unique_ptr<Window> use_system_cert_store_check_box_;
 
-  std::unique_ptr<Window> disable_cert_verification_check_box;
+  std::unique_ptr<Window> disable_cert_verification_check_box_;
 
-  std::unique_ptr<Window> property_group_box;
+  std::unique_ptr<Window> property_group_box_;
 
-  std::unique_ptr<Window> property_list;
+  std::unique_ptr<Window> property_list_;
 
-  std::unique_ptr<Window> add_button;
+  std::unique_ptr<Window> add_button_;
 
-  std::unique_ptr<Window> delete_button;
+  std::unique_ptr<Window> delete_button_;
 
   /** Configuration. */
-  Configuration& config;
+  Configuration& config_;
 
   /** Flag indicating whether OK option was selected. */
-  bool accepted;
+  bool accepted_;
 
-  bool is_initialized;
+  bool is_initialized_;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h
@@ -198,7 +198,7 @@ class Window {
    *
    * @return Window handle.
    */
-  HWND GetHandle() const { return handle; }
+  HWND GetHandle() const { return handle_; }
 
   void SetVisible(bool isVisible);
 
@@ -283,22 +283,22 @@ class Window {
    *
    * @param value Window handle.
    */
-  void SetHandle(HWND value) { handle = value; }
+  void SetHandle(HWND value) { handle_ = value; }
 
   /** Window class name. */
-  std::wstring class_name;
+  std::wstring class_name_;
 
   /** Window title. */
-  std::wstring title;
+  std::wstring title_;
 
   /** Window handle. */
-  HWND handle;
+  HWND handle_;
 
   /** Window parent. */
-  Window* parent;
+  Window* parent_;
 
   /** Specifies whether window has been created by the thread and needs destruction. */
-  bool created;
+  bool created_;
 
  private:
   Window(const Window& window) = delete;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
@@ -34,10 +34,10 @@ namespace config {
 
 AddPropertyWindow::AddPropertyWindow(Window* parent)
     : CustomWindow(parent, L"AddProperty", L"Add Property"),
-      width(300),
-      height(120),
-      accepted(false),
-      is_initialized(false) {
+      width_(300),
+      height_(120),
+      accepted_(false),
+      is_initialized_(false) {
   // No-op.
 }
 
@@ -48,13 +48,15 @@ AddPropertyWindow::~AddPropertyWindow() {
 void AddPropertyWindow::Create() {
   // Finding out parent position.
   RECT parent_rect;
-  GetWindowRect(parent->GetHandle(), &parent_rect);
+  GetWindowRect(parent_->GetHandle(), &parent_rect);
 
   // Positioning window to the center of parent window.
-  const int pos_x = parent_rect.left + (parent_rect.right - parent_rect.left - width) / 2;
-  const int pos_y = parent_rect.top + (parent_rect.bottom - parent_rect.top - height) / 2;
+  const int pos_x =
+      parent_rect.left + (parent_rect.right - parent_rect.left - width_) / 2;
+  const int pos_y =
+      parent_rect.top + (parent_rect.bottom - parent_rect.top - height_) / 2;
 
-  RECT desired_rect = {pos_x, pos_y, pos_x + width, pos_y + height};
+  RECT desired_rect = {pos_x, pos_y, pos_x + width_, pos_y + height_};
   AdjustWindowRect(&desired_rect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
                    FALSE);
 
@@ -62,7 +64,7 @@ void AddPropertyWindow::Create() {
                  desired_rect.right - desired_rect.left,
                  desired_rect.bottom - desired_rect.top, 0);
 
-  if (!handle) {
+  if (!handle_) {
     std::stringstream buf;
     buf << "Can not create window, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
@@ -70,9 +72,9 @@ void AddPropertyWindow::Create() {
 }
 
 bool AddPropertyWindow::GetProperty(std::wstring& key, std::wstring& value) {
-  if (accepted) {
-    key = this->key;
-    value = this->value;
+  if (accepted_) {
+    key = this->key_;
+    value = this->value_;
     return true;
   }
   return false;
@@ -80,18 +82,18 @@ bool AddPropertyWindow::GetProperty(std::wstring& key, std::wstring& value) {
 
 void AddPropertyWindow::OnCreate() {
   int group_pos_y = MARGIN;
-  int group_size_y = width - 2 * MARGIN;
+  int group_size_y = width_ - 2 * MARGIN;
 
   group_pos_y += INTERVAL + CreateEdits(MARGIN, group_pos_y, group_size_y);
 
-  int cancel_pos_x = width - MARGIN - BUTTON_WIDTH;
+  int cancel_pos_x = width_ - MARGIN - BUTTON_WIDTH;
   int ok_pos_x = cancel_pos_x - INTERVAL - BUTTON_WIDTH;
 
-  ok_button = CreateButton(ok_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, L"Ok",
-                           ChildId::OK_BUTTON, BS_DEFPUSHBUTTON);
-  cancel_button = CreateButton(cancel_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
-                               L"Cancel", ChildId::CANCEL_BUTTON);
-  is_initialized = true;
+  ok_button_ = CreateButton(ok_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, L"Ok",
+                            ChildId::OK_BUTTON, BS_DEFPUSHBUTTON);
+  cancel_button_ = CreateButton(cancel_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
+                                L"Cancel", ChildId::CANCEL_BUTTON);
+  is_initialized_ = true;
   CheckEnableOk();
 }
 
@@ -103,16 +105,16 @@ int AddPropertyWindow::CreateEdits(int pos_x, int pos_y, int size_x) {
 
   int row_pos = pos_y;
 
-  labels.push_back(
+  labels_.push_back(
       CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"Key:", ChildId::KEY_LABEL));
-  key_edit =
+  key_edit_ =
       CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, L"", ChildId::KEY_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  labels.push_back(CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"Value:",
-                               ChildId::VALUE_LABEL));
-  value_edit =
+  labels_.push_back(CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"Value:",
+                                ChildId::VALUE_LABEL));
+  value_edit_ =
       CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, L"", ChildId::VALUE_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
@@ -121,11 +123,11 @@ int AddPropertyWindow::CreateEdits(int pos_x, int pos_y, int size_x) {
 }
 
 void AddPropertyWindow::CheckEnableOk() {
-  if (!is_initialized) {
+  if (!is_initialized_) {
     return;
   }
 
-  ok_button->SetEnabled(!key_edit->IsTextEmpty() && !value_edit->IsTextEmpty());
+  ok_button_->SetEnabled(!key_edit_->IsTextEmpty() && !value_edit_->IsTextEmpty());
 }
 
 bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
@@ -133,9 +135,9 @@ bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
     case WM_COMMAND: {
       switch (LOWORD(wparam)) {
         case ChildId::OK_BUTTON: {
-          key_edit->GetText(key);
-          value_edit->GetText(value);
-          accepted = true;
+          key_edit_->GetText(key_);
+          value_edit_->GetText(value_);
+          accepted_ = true;
           PostMessage(GetHandle(), WM_CLOSE, 0, 0);
 
           break;
@@ -163,7 +165,7 @@ bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
     }
 
     case WM_DESTROY: {
-      PostQuitMessage(accepted ? Result::OK : Result::CANCEL);
+      PostQuitMessage(accepted_ ? Result::OK : Result::CANCEL);
 
       break;
     }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
@@ -107,7 +107,7 @@ CustomWindow::CustomWindow(Window* parent, const wchar_t* class_name,
   }
 }
 
-CustomWindow::~CustomWindow() { UnregisterClass(class_name.c_str(), GetHInstance()); }
+CustomWindow::~CustomWindow() { UnregisterClass(class_name_.c_str(), GetHInstance()); }
 
 }  // namespace config
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
@@ -59,11 +59,11 @@ namespace config {
 DsnConfigurationWindow::DsnConfigurationWindow(Window* parent,
                                                config::Configuration& config)
     : CustomWindow(parent, L"FlightConfigureDSN", L"Configure Apache Arrow Flight SQL"),
-      width(480),
-      height(375),
-      config(config),
-      accepted(false),
-      is_initialized(false) {
+      width_(480),
+      height_(375),
+      config_(config),
+      accepted_(false),
+      is_initialized_(false) {
   // No-op.
 }
 
@@ -74,13 +74,15 @@ DsnConfigurationWindow::~DsnConfigurationWindow() {
 void DsnConfigurationWindow::Create() {
   // Finding out parent position.
   RECT parent_rect;
-  GetWindowRect(parent->GetHandle(), &parent_rect);
+  GetWindowRect(parent_->GetHandle(), &parent_rect);
 
   // Positioning window to the center of parent window.
-  const int pos_x = parent_rect.left + (parent_rect.right - parent_rect.left - width) / 2;
-  const int pos_y = parent_rect.top + (parent_rect.bottom - parent_rect.top - height) / 2;
+  const int pos_x =
+      parent_rect.left + (parent_rect.right - parent_rect.left - width_) / 2;
+  const int pos_y =
+      parent_rect.top + (parent_rect.bottom - parent_rect.top - height_) / 2;
 
-  RECT desired_rect = {pos_x, pos_y, pos_x + width, pos_y + height};
+  RECT desired_rect = {pos_x, pos_y, pos_x + width_, pos_y + height_};
   AdjustWindowRect(&desired_rect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
                    FALSE);
 
@@ -88,7 +90,7 @@ void DsnConfigurationWindow::Create() {
                  desired_rect.right - desired_rect.left,
                  desired_rect.bottom - desired_rect.top, 0);
 
-  if (!handle) {
+  if (!handle_) {
     std::stringstream buf;
     buf << "Can not create window, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
@@ -96,12 +98,12 @@ void DsnConfigurationWindow::Create() {
 }
 
 void DsnConfigurationWindow::OnCreate() {
-  tab_control = CreateTabControl(ChildId::TAB_CONTROL);
-  tab_control->AddTab(L"Common", COMMON_TAB);
-  tab_control->AddTab(L"Advanced", ADVANCED_TAB);
+  tab_control_ = CreateTabControl(ChildId::TAB_CONTROL);
+  tab_control_->AddTab(L"Common", COMMON_TAB);
+  tab_control_->AddTab(L"Advanced", ADVANCED_TAB);
 
   int group_pos_y = 3 * MARGIN;
-  int group_size_y = width - 2 * MARGIN;
+  int group_size_y = width_ - 2 * MARGIN;
 
   int common_group_pos_y = group_pos_y;
   common_group_pos_y +=
@@ -116,17 +118,17 @@ void DsnConfigurationWindow::OnCreate() {
       INTERVAL + CreatePropertiesGroup(MARGIN, advanced_group_pos_y, group_size_y);
 
   int test_pos_x = MARGIN;
-  int cancel_pos_x = width - MARGIN - BUTTON_WIDTH;
+  int cancel_pos_x = width_ - MARGIN - BUTTON_WIDTH;
   int ok_pos_x = cancel_pos_x - INTERVAL - BUTTON_WIDTH;
 
   int button_pos_y = std::max(common_group_pos_y, advanced_group_pos_y);
-  test_button = CreateButton(test_pos_x, button_pos_y, BUTTON_WIDTH + 20, BUTTON_HEIGHT,
-                             L"Test Connection", ChildId::TEST_CONNECTION_BUTTON);
-  ok_button = CreateButton(ok_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, L"Ok",
-                           ChildId::OK_BUTTON);
-  cancel_button = CreateButton(cancel_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
-                               L"Cancel", ChildId::CANCEL_BUTTON);
-  is_initialized = true;
+  test_button_ = CreateButton(test_pos_x, button_pos_y, BUTTON_WIDTH + 20, BUTTON_HEIGHT,
+                              L"Test Connection", ChildId::TEST_CONNECTION_BUTTON);
+  ok_button_ = CreateButton(ok_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, L"Ok",
+                            ChildId::OK_BUTTON);
+  cancel_button_ = CreateButton(cancel_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
+                                L"Cancel", ChildId::CANCEL_BUTTON);
+  is_initialized_ = true;
   CheckEnableOk();
   SelectTab(COMMON_TAB);
 }
@@ -142,34 +144,34 @@ int DsnConfigurationWindow::CreateConnectionSettingsGroup(int pos_x, int pos_y,
 
   int row_pos = pos_y + 2 * INTERVAL;
 
-  std::string val = config.Get(FlightSqlConnection::DSN);
+  std::string val = config_.Get(FlightSqlConnection::DSN);
   std::wstring wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               L"Data Source Name:", ChildId::NAME_LABEL));
-  name_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
-                         ChildId::NAME_EDIT);
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                L"Data Source Name:", ChildId::NAME_LABEL));
+  name_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                          ChildId::NAME_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::HOST);
+  val = config_.Get(FlightSqlConnection::HOST);
   wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               L"Host Name:", ChildId::SERVER_LABEL));
-  server_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
-                           ChildId::SERVER_EDIT);
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                L"Host Name:", ChildId::SERVER_LABEL));
+  server_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                            ChildId::SERVER_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::PORT);
+  val = config_.Get(FlightSqlConnection::PORT);
   wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"Port:",
-                               ChildId::PORT_LABEL));
-  port_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
-                         ChildId::PORT_EDIT, ES_NUMBER);
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"Port:",
+                                ChildId::PORT_LABEL));
+  port_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                          ChildId::PORT_EDIT, ES_NUMBER);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  connection_settings_group_box =
+  connection_settings_group_box_ =
       CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, L"Connection settings",
                      ChildId::CONNECTION_SETTINGS_GROUP_BOX);
 
@@ -186,50 +188,50 @@ int DsnConfigurationWindow::CreateAuthSettingsGroup(int pos_x, int pos_y, int si
 
   int row_pos = pos_y + 2 * INTERVAL;
 
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               L"Authentication Type:", ChildId::AUTH_TYPE_LABEL));
-  auth_type_combo_box =
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                L"Authentication Type:", ChildId::AUTH_TYPE_LABEL));
+  auth_type_combo_box_ =
       CreateComboBox(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT,
                      L"Authentication Type:", ChildId::AUTH_TYPE_COMBOBOX);
-  auth_type_combo_box->AddString(L"Basic Authentication");
-  auth_type_combo_box->AddString(L"Token Authentication");
+  auth_type_combo_box_->AddString(L"Basic Authentication");
+  auth_type_combo_box_->AddString(L"Token Authentication");
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  std::string val = config.Get(FlightSqlConnection::UID);
+  std::string val = config_.Get(FlightSqlConnection::UID);
   std::wstring wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
 
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"User:",
-                               ChildId::USER_LABEL));
-  user_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
-                         ChildId::USER_EDIT);
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, L"User:",
+                                ChildId::USER_LABEL));
+  user_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                          ChildId::USER_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::PWD);
+  val = config_.Get(FlightSqlConnection::PWD);
   wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               L"Password:", ChildId::PASSWORD_LABEL));
-  password_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
-                             ChildId::USER_EDIT, ES_PASSWORD);
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                L"Password:", ChildId::PASSWORD_LABEL));
+  password_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
+                              ChildId::USER_EDIT, ES_PASSWORD);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  const auto& token = config.Get(FlightSqlConnection::TOKEN);
+  const auto& token = config_.Get(FlightSqlConnection::TOKEN);
   wval = arrow::util::UTF8ToWideString(token).ValueOr(L"");
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               L"Authentication Token:", ChildId::AUTH_TOKEN_LABEL));
-  auth_token_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, wval.c_str(),
-                               ChildId::AUTH_TOKEN_EDIT);
-  auth_token_edit->SetEnabled(false);
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                L"Authentication Token:", ChildId::AUTH_TOKEN_LABEL));
+  auth_token_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT,
+                                wval.c_str(), ChildId::AUTH_TOKEN_EDIT);
+  auth_token_edit_->SetEnabled(false);
 
   // Ensure the right elements are selected.
-  auth_type_combo_box->SetSelection(token.empty() ? 0 : 1);
+  auth_type_combo_box_->SetSelection(token.empty() ? 0 : 1);
   CheckAuthType();
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  auth_settings_group_box =
+  auth_settings_group_box_ =
       CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, L"Authentication settings",
                      ChildId::AUTH_SETTINGS_GROUP_BOX);
 
@@ -247,65 +249,65 @@ int DsnConfigurationWindow::CreateEncryptionSettingsGroup(int pos_x, int pos_y,
 
   int row_pos = pos_y + 2 * INTERVAL;
 
-  std::string val = config.Get(FlightSqlConnection::USE_ENCRYPTION);
+  std::string val = config_.Get(FlightSqlConnection::USE_ENCRYPTION);
 
   // Enable encryption default value is true
   const bool enable_encryption = driver::odbcabstraction::AsBool(val).value_or(true);
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               L"Use Encryption:", ChildId::ENABLE_ENCRYPTION_LABEL));
-  enable_encryption_check_box =
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                L"Use Encryption:", ChildId::ENABLE_ENCRYPTION_LABEL));
+  enable_encryption_check_box_ =
       CreateCheckBox(edit_pos_x, row_pos - 2, edit_size_x, ROW_HEIGHT, L"",
                      ChildId::ENABLE_ENCRYPTION_CHECKBOX, enable_encryption);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::TRUSTED_CERTS);
+  val = config_.Get(FlightSqlConnection::TRUSTED_CERTS);
   std::wstring wval = arrow::util::UTF8ToWideString(val).ValueOr(L"");
 
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               L"Certificate:", ChildId::CERTIFICATE_LABEL));
-  certificate_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x - MARGIN - BUTTON_WIDTH,
-                                ROW_HEIGHT, wval.c_str(), ChildId::CERTIFICATE_EDIT);
-  certificate_browse_button =
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                L"Certificate:", ChildId::CERTIFICATE_LABEL));
+  certificate_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x - MARGIN - BUTTON_WIDTH,
+                                 ROW_HEIGHT, wval.c_str(), ChildId::CERTIFICATE_EDIT);
+  certificate_browse_button_ =
       CreateButton(edit_pos_x + edit_size_x - BUTTON_WIDTH, row_pos - 2, BUTTON_WIDTH,
                    BUTTON_HEIGHT, L"Browse", ChildId::CERTIFICATE_BROWSE_BUTTON);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::USE_SYSTEM_TRUST_STORE).c_str();
+  val = config_.Get(FlightSqlConnection::USE_SYSTEM_TRUST_STORE).c_str();
 
   // System trust store default value is true
   const bool use_system_cert_store = driver::odbcabstraction::AsBool(val).value_or(true);
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
-                               L"Use System Certificate Store:",
-                               ChildId::USE_SYSTEM_CERT_STORE_LABEL));
-  use_system_cert_store_check_box =
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
+                                L"Use System Certificate Store:",
+                                ChildId::USE_SYSTEM_CERT_STORE_LABEL));
+  use_system_cert_store_check_box_ =
       CreateCheckBox(edit_pos_x, row_pos - 2, 20, 2 * ROW_HEIGHT, L"",
                      ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX, use_system_cert_store);
 
-  val = config.Get(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION).c_str();
+  val = config_.Get(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION).c_str();
 
   const int right_pos_x = label_pos_x + (size_x - (2 * INTERVAL)) / 2;
   const int right_check_pos_x = right_pos_x + (edit_pos_x - label_pos_x);
   const bool disable_cert_verification =
       driver::odbcabstraction::AsBool(val).value_or(false);
-  labels.push_back(CreateLabel(right_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
-                               L"Disable Certificate Verification:",
-                               ChildId::DISABLE_CERT_VERIFICATION_LABEL));
-  disable_cert_verification_check_box = CreateCheckBox(
+  labels_.push_back(CreateLabel(right_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
+                                L"Disable Certificate Verification:",
+                                ChildId::DISABLE_CERT_VERIFICATION_LABEL));
+  disable_cert_verification_check_box_ = CreateCheckBox(
       right_check_pos_x, row_pos - 2, 20, 2 * ROW_HEIGHT, L"",
       ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX, disable_cert_verification);
 
   row_pos += INTERVAL + static_cast<int>(1.5 * static_cast<int>(ROW_HEIGHT));
 
-  encryption_settings_group_box =
+  encryption_settings_group_box_ =
       CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, L"Encryption settings",
                      ChildId::AUTH_SETTINGS_GROUP_BOX);
 
-  certificate_edit->SetEnabled(enable_encryption);
-  certificate_browse_button->SetEnabled(enable_encryption);
-  use_system_cert_store_check_box->SetEnabled(enable_encryption);
-  disable_cert_verification_check_box->SetEnabled(enable_encryption);
+  certificate_edit_->SetEnabled(enable_encryption);
+  certificate_browse_button_->SetEnabled(enable_encryption);
+  use_system_cert_store_check_box_->SetEnabled(enable_encryption);
+  disable_cert_verification_check_box_->SetEnabled(enable_encryption);
 
   return row_pos - pos_y;
 }
@@ -320,34 +322,34 @@ int DsnConfigurationWindow::CreatePropertiesGroup(int pos_x, int pos_y, int size
   int row_pos = pos_y + 2 * INTERVAL;
   const int list_height = 5 * ROW_HEIGHT;
 
-  property_list =
+  property_list_ =
       CreateList(label_pos_x, row_pos, list_size, list_height, ChildId::PROPERTY_LIST);
-  property_list->ListAddColumn(L"Key", 0, column_size);
-  property_list->ListAddColumn(L"Value", 1, column_size);
+  property_list_->ListAddColumn(L"Key", 0, column_size);
+  property_list_->ListAddColumn(L"Value", 1, column_size);
 
-  const auto keys = config.GetCustomKeys();
+  const auto keys = config_.GetCustomKeys();
   for (const auto& key : keys) {
     std::wstring wkey = arrow::util::UTF8ToWideString(key).ValueOr(L"");
-    std::wstring wval = arrow::util::UTF8ToWideString(config.Get(key)).ValueOr(L"");
+    std::wstring wval = arrow::util::UTF8ToWideString(config_.Get(key)).ValueOr(L"");
 
-    property_list->ListAddItem({wkey, wval});
+    property_list_->ListAddItem({wkey, wval});
   }
 
-  SendMessage(property_list->GetHandle(), LVM_SETEXTENDEDLISTVIEWSTYLE,
+  SendMessage(property_list_->GetHandle(), LVM_SETEXTENDEDLISTVIEWSTYLE,
               LVS_EX_FULLROWSELECT, LVS_EX_FULLROWSELECT);
 
   row_pos += INTERVAL + list_height;
 
-  int delete_pos_x = width - INTERVAL - MARGIN - BUTTON_WIDTH;
+  int delete_pos_x = width_ - INTERVAL - MARGIN - BUTTON_WIDTH;
   int add_pos_x = delete_pos_x - INTERVAL - BUTTON_WIDTH;
-  add_button = CreateButton(add_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT, L"Add",
-                            ChildId::ADD_BUTTON);
-  delete_button = CreateButton(delete_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT,
-                               L"Delete", ChildId::DELETE_BUTTON);
+  add_button_ = CreateButton(add_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT, L"Add",
+                             ChildId::ADD_BUTTON);
+  delete_button_ = CreateButton(delete_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT,
+                                L"Delete", ChildId::DELETE_BUTTON);
 
   row_pos += INTERVAL + BUTTON_HEIGHT;
 
-  property_group_box =
+  property_group_box_ =
       CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, L"Advanced properties",
                      ChildId::PROPERTY_GROUP_BOX);
 
@@ -355,66 +357,66 @@ int DsnConfigurationWindow::CreatePropertiesGroup(int pos_x, int pos_y, int size
 }
 
 void DsnConfigurationWindow::SelectTab(int tab_index) {
-  if (!is_initialized) {
+  if (!is_initialized_) {
     return;
   }
 
-  connection_settings_group_box->SetVisible(COMMON_TAB == tab_index);
-  auth_settings_group_box->SetVisible(COMMON_TAB == tab_index);
-  name_edit->SetVisible(COMMON_TAB == tab_index);
-  server_edit->SetVisible(COMMON_TAB == tab_index);
-  port_edit->SetVisible(COMMON_TAB == tab_index);
-  auth_type_combo_box->SetVisible(COMMON_TAB == tab_index);
-  user_edit->SetVisible(COMMON_TAB == tab_index);
-  password_edit->SetVisible(COMMON_TAB == tab_index);
-  auth_token_edit->SetVisible(COMMON_TAB == tab_index);
+  connection_settings_group_box_->SetVisible(COMMON_TAB == tab_index);
+  auth_settings_group_box_->SetVisible(COMMON_TAB == tab_index);
+  name_edit_->SetVisible(COMMON_TAB == tab_index);
+  server_edit_->SetVisible(COMMON_TAB == tab_index);
+  port_edit_->SetVisible(COMMON_TAB == tab_index);
+  auth_type_combo_box_->SetVisible(COMMON_TAB == tab_index);
+  user_edit_->SetVisible(COMMON_TAB == tab_index);
+  password_edit_->SetVisible(COMMON_TAB == tab_index);
+  auth_token_edit_->SetVisible(COMMON_TAB == tab_index);
   for (size_t i = 0; i < 7; ++i) {
-    labels[i]->SetVisible(COMMON_TAB == tab_index);
+    labels_[i]->SetVisible(COMMON_TAB == tab_index);
   }
 
-  encryption_settings_group_box->SetVisible(ADVANCED_TAB == tab_index);
-  enable_encryption_check_box->SetVisible(ADVANCED_TAB == tab_index);
-  certificate_edit->SetVisible(ADVANCED_TAB == tab_index);
-  certificate_browse_button->SetVisible(ADVANCED_TAB == tab_index);
-  use_system_cert_store_check_box->SetVisible(ADVANCED_TAB == tab_index);
-  disable_cert_verification_check_box->SetVisible(ADVANCED_TAB == tab_index);
-  property_group_box->SetVisible(ADVANCED_TAB == tab_index);
-  property_list->SetVisible(ADVANCED_TAB == tab_index);
-  add_button->SetVisible(ADVANCED_TAB == tab_index);
-  delete_button->SetVisible(ADVANCED_TAB == tab_index);
-  for (size_t i = 7; i < labels.size(); ++i) {
-    labels[i]->SetVisible(ADVANCED_TAB == tab_index);
+  encryption_settings_group_box_->SetVisible(ADVANCED_TAB == tab_index);
+  enable_encryption_check_box_->SetVisible(ADVANCED_TAB == tab_index);
+  certificate_edit_->SetVisible(ADVANCED_TAB == tab_index);
+  certificate_browse_button_->SetVisible(ADVANCED_TAB == tab_index);
+  use_system_cert_store_check_box_->SetVisible(ADVANCED_TAB == tab_index);
+  disable_cert_verification_check_box_->SetVisible(ADVANCED_TAB == tab_index);
+  property_group_box_->SetVisible(ADVANCED_TAB == tab_index);
+  property_list_->SetVisible(ADVANCED_TAB == tab_index);
+  add_button_->SetVisible(ADVANCED_TAB == tab_index);
+  delete_button_->SetVisible(ADVANCED_TAB == tab_index);
+  for (size_t i = 7; i < labels_.size(); ++i) {
+    labels_[i]->SetVisible(ADVANCED_TAB == tab_index);
   }
 }
 
 void DsnConfigurationWindow::CheckEnableOk() {
-  if (!is_initialized) {
+  if (!is_initialized_) {
     return;
   }
 
-  bool enable_ok = !name_edit->IsTextEmpty();
-  enable_ok = enable_ok && !server_edit->IsTextEmpty();
-  enable_ok = enable_ok && !port_edit->IsTextEmpty();
-  if (auth_token_edit->IsEnabled()) {
-    enable_ok = enable_ok && !auth_token_edit->IsTextEmpty();
+  bool enable_ok = !name_edit_->IsTextEmpty();
+  enable_ok = enable_ok && !server_edit_->IsTextEmpty();
+  enable_ok = enable_ok && !port_edit_->IsTextEmpty();
+  if (auth_token_edit_->IsEnabled()) {
+    enable_ok = enable_ok && !auth_token_edit_->IsTextEmpty();
   } else {
-    enable_ok = enable_ok && !user_edit->IsTextEmpty();
-    enable_ok = enable_ok && !password_edit->IsTextEmpty();
+    enable_ok = enable_ok && !user_edit_->IsTextEmpty();
+    enable_ok = enable_ok && !password_edit_->IsTextEmpty();
   }
 
-  test_button->SetEnabled(enable_ok);
-  ok_button->SetEnabled(enable_ok);
+  test_button_->SetEnabled(enable_ok);
+  ok_button_->SetEnabled(enable_ok);
 }
 
 void DsnConfigurationWindow::SaveParameters(Configuration& target_config) {
   target_config.Clear();
 
   std::wstring text;
-  name_edit->GetText(text);
+  name_edit_->GetText(text);
   target_config.Set(FlightSqlConnection::DSN, text);
-  server_edit->GetText(text);
+  server_edit_->GetText(text);
   target_config.Set(FlightSqlConnection::HOST, text);
-  port_edit->GetText(text);
+  port_edit_->GetText(text);
   try {
     const int port_int = std::stoi(text);
     if (0 > port_int || USHRT_MAX < port_int) {
@@ -427,26 +429,26 @@ void DsnConfigurationWindow::SaveParameters(Configuration& target_config) {
     throw odbcabstraction::DriverException("Invalid port value.");
   }
 
-  if (0 == auth_type_combo_box->GetSelection()) {
-    user_edit->GetText(text);
+  if (0 == auth_type_combo_box_->GetSelection()) {
+    user_edit_->GetText(text);
     target_config.Set(FlightSqlConnection::UID, text);
-    password_edit->GetText(text);
+    password_edit_->GetText(text);
     target_config.Set(FlightSqlConnection::PWD, text);
   } else {
-    auth_token_edit->GetText(text);
+    auth_token_edit_->GetText(text);
     target_config.Set(FlightSqlConnection::TOKEN, text);
   }
 
-  if (enable_encryption_check_box->IsChecked()) {
+  if (enable_encryption_check_box_->IsChecked()) {
     target_config.Set(FlightSqlConnection::USE_ENCRYPTION, TRUE_STR);
-    certificate_edit->GetText(text);
+    certificate_edit_->GetText(text);
     target_config.Set(FlightSqlConnection::TRUSTED_CERTS, text);
     target_config.Set(
         FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
-        use_system_cert_store_check_box->IsChecked() ? TRUE_STR : FALSE_STR);
+        use_system_cert_store_check_box_->IsChecked() ? TRUE_STR : FALSE_STR);
     target_config.Set(
         FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
-        disable_cert_verification_check_box->IsChecked() ? TRUE_STR : FALSE_STR);
+        disable_cert_verification_check_box_->IsChecked() ? TRUE_STR : FALSE_STR);
   } else {
     // System trust store verification requires encryption
     target_config.Set(FlightSqlConnection::USE_ENCRYPTION, FALSE_STR);
@@ -454,7 +456,7 @@ void DsnConfigurationWindow::SaveParameters(Configuration& target_config) {
   }
 
   // Get all the list properties.
-  const auto properties = property_list->ListGetAll();
+  const auto properties = property_list_->ListGetAll();
   for (const auto& property : properties) {
     std::string property_key = arrow::util::WideStringToUTF8(property[0]).ValueOr("");
     std::string property_value = arrow::util::WideStringToUTF8(property[1]).ValueOr("");
@@ -463,10 +465,10 @@ void DsnConfigurationWindow::SaveParameters(Configuration& target_config) {
 }
 
 void DsnConfigurationWindow::CheckAuthType() {
-  const bool is_basic = COMMON_TAB == auth_type_combo_box->GetSelection();
-  user_edit->SetEnabled(is_basic);
-  password_edit->SetEnabled(is_basic);
-  auth_token_edit->SetEnabled(!is_basic);
+  const bool is_basic = COMMON_TAB == auth_type_combo_box_->GetSelection();
+  user_edit_->SetEnabled(is_basic);
+  password_edit_->SetEnabled(is_basic);
+  auth_token_edit_->SetEnabled(!is_basic);
 }
 
 bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
@@ -479,7 +481,7 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
         }
 
         case TCN_SELCHANGE: {
-          SelectTab(TabCtrl_GetCurSel(tab_control->GetHandle()));
+          SelectTab(TabCtrl_GetCurSel(tab_control_->GetHandle()));
           break;
         }
       }
@@ -508,8 +510,8 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
         }
         case ChildId::OK_BUTTON: {
           try {
-            SaveParameters(config);
-            accepted = true;
+            SaveParameters(config_);
+            accepted_ = true;
             PostMessage(GetHandle(), WM_CLOSE, 0, 0);
           } catch (odbcabstraction::DriverException& err) {
             std::wstring w_message_text =
@@ -546,12 +548,12 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
         }
 
         case ChildId::ENABLE_ENCRYPTION_CHECKBOX: {
-          const bool toggle = !enable_encryption_check_box->IsChecked();
-          enable_encryption_check_box->SetChecked(toggle);
-          certificate_edit->SetEnabled(toggle);
-          certificate_browse_button->SetEnabled(toggle);
-          use_system_cert_store_check_box->SetEnabled(toggle);
-          disable_cert_verification_check_box->SetEnabled(toggle);
+          const bool toggle = !enable_encryption_check_box_->IsChecked();
+          enable_encryption_check_box_->SetChecked(toggle);
+          certificate_edit_->SetEnabled(toggle);
+          certificate_browse_button_->SetEnabled(toggle);
+          use_system_cert_store_check_box_->SetEnabled(toggle);
+          disable_cert_verification_check_box_->SetEnabled(toggle);
           break;
         }
 
@@ -574,25 +576,25 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
           open_file_name.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
           if (GetOpenFileName(&open_file_name)) {
-            certificate_edit->SetText(file_name);
+            certificate_edit_->SetText(file_name);
           }
           break;
         }
 
         case ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX: {
-          use_system_cert_store_check_box->SetChecked(
-              !use_system_cert_store_check_box->IsChecked());
+          use_system_cert_store_check_box_->SetChecked(
+              !use_system_cert_store_check_box_->IsChecked());
           break;
         }
 
         case ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX: {
-          disable_cert_verification_check_box->SetChecked(
-              !disable_cert_verification_check_box->IsChecked());
+          disable_cert_verification_check_box_->SetChecked(
+              !disable_cert_verification_check_box_->IsChecked());
           break;
         }
 
         case ChildId::DELETE_BUTTON: {
-          property_list->ListDeleteSelectedItem();
+          property_list_->ListDeleteSelectedItem();
           break;
         }
 
@@ -606,7 +608,7 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
             std::wstring key;
             std::wstring value;
             add_window.GetProperty(key, value);
-            property_list->ListAddItem({key, value});
+            property_list_->ListAddItem({key, value});
           }
           break;
         }
@@ -619,7 +621,7 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
     }
 
     case WM_DESTROY: {
-      PostQuitMessage(accepted ? Result::OK : Result::CANCEL);
+      PostQuitMessage(accepted_ ? Result::OK : Result::CANCEL);
 
       break;
     }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/window.cc
@@ -50,38 +50,42 @@ HINSTANCE GetHInstance() {
 }
 
 Window::Window(Window* parent, const wchar_t* class_name, const wchar_t* title)
-    : class_name(class_name), title(title), handle(NULL), parent(parent), created(false) {
+    : class_name_(class_name),
+      title_(title),
+      handle_(NULL),
+      parent_(parent),
+      created_(false) {
   // No-op.
 }
 
 Window::Window(HWND handle)
-    : class_name(), title(), handle(handle), parent(0), created(false) {
+    : class_name_(), title_(), handle_(handle), parent_(0), created_(false) {
   // No-op.
 }
 
 Window::~Window() {
-  if (created) Destroy();
+  if (created_) Destroy();
 }
 
 void Window::Create(DWORD style, int pos_x, int pos_y, int width, int height, int id) {
-  if (handle) {
+  if (handle_) {
     std::stringstream buf;
     buf << "Window already created, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
   }
 
-  handle = CreateWindow(class_name.c_str(), title.c_str(), style, pos_x, pos_y, width,
-                        height, parent ? parent->GetHandle() : NULL,
-                        reinterpret_cast<HMENU>(static_cast<ptrdiff_t>(id)),
-                        GetHInstance(), this);
+  handle_ = CreateWindow(class_name_.c_str(), title_.c_str(), style, pos_x, pos_y, width,
+                         height, parent_ ? parent_->GetHandle() : NULL,
+                         reinterpret_cast<HMENU>(static_cast<ptrdiff_t>(id)),
+                         GetHInstance(), this);
 
-  if (!handle) {
+  if (!handle_) {
     std::stringstream buf;
     buf << "Can not create window, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
   }
 
-  created = true;
+  created_ = true;
 
   const HGDIOBJ hf_default = GetStockObject(DEFAULT_GUI_FONT);
   SendMessage(GetHandle(), WM_SETFONT, (WPARAM)hf_default, MAKELPARAM(FALSE, 0));
@@ -93,7 +97,7 @@ std::unique_ptr<Window> Window::CreateTabControl(int id) {
   // Get the dimensions of the parent window's client area, and
   // create a tab control child window of that size.
   RECT rc_client;
-  GetClientRect(handle, &rc_client);
+  GetClientRect(handle_, &rc_client);
 
   child->Create(WS_CHILD | WS_CLIPSIBLINGS | WS_VISIBLE | WS_TABSTOP, 0, 0,
                 rc_client.right, 20, id);
@@ -173,25 +177,25 @@ std::unique_ptr<Window> Window::CreateComboBox(int pos_x, int pos_y, int size_x,
   return child;
 }
 
-void Window::Show() { ShowWindow(handle, SW_SHOW); }
+void Window::Show() { ShowWindow(handle_, SW_SHOW); }
 
-void Window::Update() { UpdateWindow(handle); }
+void Window::Update() { UpdateWindow(handle_); }
 
 void Window::Destroy() {
-  if (handle) DestroyWindow(handle);
+  if (handle_) DestroyWindow(handle_);
 
-  handle = NULL;
+  handle_ = NULL;
 }
 
 void Window::SetVisible(bool is_visible) {
-  ShowWindow(handle, is_visible ? SW_SHOW : SW_HIDE);
+  ShowWindow(handle_, is_visible ? SW_SHOW : SW_HIDE);
 }
 
 bool Window::IsTextEmpty() const {
   if (!IsEnabled()) {
     return true;
   }
-  int len = GetWindowTextLength(handle);
+  int len = GetWindowTextLength(handle_);
 
   return (len <= 0);
 }
@@ -204,7 +208,7 @@ void Window::ListAddColumn(const std::wstring& name, int index, int width) {
   lvc.pszText = const_cast<wchar_t*>(name.c_str());
   lvc.iSubItem = index;
 
-  if (ListView_InsertColumn(handle, index, &lvc) == -1) {
+  if (ListView_InsertColumn(handle_, index, &lvc) == -1) {
     std::stringstream buf;
     buf << "Can not add list column, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
@@ -216,7 +220,7 @@ void Window::ListAddItem(const std::vector<std::wstring>& items) {
   lvi.mask = LVIF_TEXT;
   lvi.pszText = const_cast<wchar_t*>(items[0].c_str());
 
-  int ret = ListView_InsertItem(handle, &lvi);
+  int ret = ListView_InsertItem(handle_, &lvi);
   if (ret < 0) {
     std::stringstream buf;
     buf << "Can not add list item, error code: " << GetLastError();
@@ -224,15 +228,15 @@ void Window::ListAddItem(const std::vector<std::wstring>& items) {
   }
 
   for (size_t i = 1; i < items.size(); ++i) {
-    ListView_SetItemText(handle, ret, static_cast<int>(i),
+    ListView_SetItemText(handle_, ret, static_cast<int>(i),
                          const_cast<wchar_t*>(items[i].c_str()));
   }
 }
 
 void Window::ListDeleteSelectedItem() {
-  const int row_index = ListView_GetSelectionMark(handle);
+  const int row_index = ListView_GetSelectionMark(handle_);
   if (row_index >= 0) {
-    if (ListView_DeleteItem(handle, row_index) == -1) {
+    if (ListView_DeleteItem(handle_, row_index) == -1) {
       std::stringstream buf;
       buf << "Can not delete list item, error code: " << GetLastError();
       throw odbcabstraction::DriverException(buf.str());
@@ -245,12 +249,12 @@ std::vector<std::vector<std::wstring> > Window::ListGetAll() {
   wchar_t buf[BUF_LEN];
 
   std::vector<std::vector<std::wstring> > values;
-  const int num_columns = Header_GetItemCount(ListView_GetHeader(handle));
-  const int num_items = ListView_GetItemCount(handle);
+  const int num_columns = Header_GetItemCount(ListView_GetHeader(handle_));
+  const int num_items = ListView_GetItemCount(handle_);
   for (int i = 0; i < num_items; ++i) {
     std::vector<std::wstring> row;
     for (int j = 0; j < num_columns; ++j) {
-      ListView_GetItemText(handle, i, j, buf, BUF_LEN);
+      ListView_GetItemText(handle_, i, j, buf, BUF_LEN);
       row.emplace_back(buf);
     }
     values.push_back(row);
@@ -264,7 +268,7 @@ void Window::AddTab(const std::wstring& name, int index) {
   tab_control_item.mask = TCIF_TEXT | TCIF_IMAGE;
   tab_control_item.iImage = -1;
   tab_control_item.pszText = const_cast<wchar_t*>(name.c_str());
-  if (TabCtrl_InsertItem(handle, index, &tab_control_item) == -1) {
+  if (TabCtrl_InsertItem(handle_, index, &tab_control_item) == -1) {
     std::stringstream buf;
     buf << "Can not add tab, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
@@ -278,7 +282,7 @@ void Window::GetText(std::wstring& text) const {
     return;
   }
 
-  int len = GetWindowTextLength(handle);
+  int len = GetWindowTextLength(handle_);
 
   if (len <= 0) {
     text.clear();
@@ -288,34 +292,34 @@ void Window::GetText(std::wstring& text) const {
 
   text.resize(len + 1);
 
-  if (!GetWindowText(handle, &text[0], len + 1)) text.clear();
+  if (!GetWindowText(handle_, &text[0], len + 1)) text.clear();
 
   text.resize(len);
   boost::algorithm::trim(text);
 }
 
 void Window::SetText(const std::wstring& text) const {
-  SNDMSG(handle, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(text.c_str()));
+  SNDMSG(handle_, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(text.c_str()));
 }
 
 bool Window::IsChecked() const {
-  return IsEnabled() && Button_GetCheck(handle) == BST_CHECKED;
+  return IsEnabled() && Button_GetCheck(handle_) == BST_CHECKED;
 }
 
 void Window::SetChecked(bool state) {
-  Button_SetCheck(handle, state ? BST_CHECKED : BST_UNCHECKED);
+  Button_SetCheck(handle_, state ? BST_CHECKED : BST_UNCHECKED);
 }
 
 void Window::AddString(const std::wstring& str) {
-  SNDMSG(handle, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(str.c_str()));
+  SNDMSG(handle_, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(str.c_str()));
 }
 
 void Window::SetSelection(int idx) {
-  SNDMSG(handle, CB_SETCURSEL, static_cast<WPARAM>(idx), 0);
+  SNDMSG(handle_, CB_SETCURSEL, static_cast<WPARAM>(idx), 0);
 }
 
 int Window::GetSelection() const {
-  return static_cast<int>(SNDMSG(handle, CB_GETCURSEL, 0, 0));
+  return static_cast<int>(SNDMSG(handle_, CB_GETCURSEL, 0, 0));
 }
 
 void Window::SetEnabled(bool enabled) { EnableWindow(GetHandle(), enabled); }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/diagnostics.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/diagnostics.cc
@@ -52,7 +52,7 @@ void driver::odbcabstraction::Diagnostics::AddError(
   auto record = std::unique_ptr<DiagnosticsRecord>(new DiagnosticsRecord{
       exception.GetMessageText(), exception.GetSqlState(), exception.GetNativeError()});
   if (version_ == OdbcVersion::V_2) {
-    RewriteSQLStateForODBC2(record->sql_state_);
+    RewriteSQLStateForODBC2(record->sql_state);
   }
   TrackRecord(*record);
   owned_records_.push_back(std::move(record));
@@ -64,7 +64,7 @@ void driver::odbcabstraction::Diagnostics::AddWarning(std::string message,
   auto record = std::unique_ptr<DiagnosticsRecord>(
       new DiagnosticsRecord{std::move(message), std::move(sql_state), native_error});
   if (version_ == OdbcVersion::V_2) {
-    RewriteSQLStateForODBC2(record->sql_state_);
+    RewriteSQLStateForODBC2(record->sql_state);
   }
   TrackRecord(*record);
   owned_records_.push_back(std::move(record));
@@ -78,7 +78,7 @@ std::string driver::odbcabstraction::Diagnostics::GetMessageText(
   }
   const DiagnosticsRecord* rec = GetRecordAtIndex(record_index);
   return message + "[" + data_source_component_ + "] (" +
-         std::to_string(rec->native_error_) + ") " + rec->msg_text_;
+         std::to_string(rec->native_error) + ") " + rec->msg_text;
 }
 
 OdbcVersion Diagnostics::GetOdbcVersion() const { return version_; }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/diagnostics.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/diagnostics.h
@@ -29,9 +29,9 @@ namespace odbcabstraction {
 class Diagnostics {
  public:
   struct DiagnosticsRecord {
-    std::string msg_text_;
-    std::string sql_state_;
-    int32_t native_error_;
+    std::string msg_text;
+    std::string sql_state;
+    int32_t native_error;
   };
 
  private:
@@ -56,7 +56,7 @@ class Diagnostics {
   }
 
   inline void TrackRecord(const DiagnosticsRecord& record) {
-    if (record.sql_state_[0] == '0' && record.sql_state_[1] == '1') {
+    if (record.sql_state[0] == '0' && record.sql_state[1] == '1') {
       warning_records_.push_back(&record);
     } else {
       error_records_.push_back(&record);
@@ -76,11 +76,11 @@ class Diagnostics {
 
   std::string GetMessageText(uint32_t record_index) const;
   std::string GetSQLState(uint32_t record_index) const {
-    return GetRecordAtIndex(record_index)->sql_state_;
+    return GetRecordAtIndex(record_index)->sql_state;
   }
 
   int32_t GetNativeError(uint32_t record_index) const {
-    return GetRecordAtIndex(record_index)->native_error_;
+    return GetRecordAtIndex(record_index)->native_error;
   }
 
   inline size_t GetRecordCount() const {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
@@ -70,7 +70,7 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
 
   ~ODBCConnection() = default;
 
-  inline ODBCStatement& GetTrackingStatement() { return *m_attribute_tracking_statement; }
+  inline ODBCStatement& GetTrackingStatement() { return *attribute_tracking_statement_; }
 
   void Disconnect();
 
@@ -82,7 +82,7 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
   std::shared_ptr<ODBCDescriptor> CreateDescriptor();
   void DropDescriptor(ODBCDescriptor* descriptor);
 
-  inline bool IsOdbc2Connection() const { return m_is_2x_connection; }
+  inline bool IsOdbc2Connection() const { return is_2x_connection_; }
 
   /// @return the DSN or an empty string if the DSN is not found or is found after the
   /// driver
@@ -94,17 +94,17 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
       driver::odbcabstraction::Connection::ConnPropertyMap& properties);
 
  private:
-  ODBCEnvironment& m_environment;
-  std::shared_ptr<driver::odbcabstraction::Connection> m_spi_connection;
+  ODBCEnvironment& environment_;
+  std::shared_ptr<driver::odbcabstraction::Connection> spi_connection_;
   // Extra ODBC statement that's used to track and validate when statement attributes are
   // set through the connection handle. These attributes get copied to new ODBC statements
   // when they are allocated.
-  std::shared_ptr<ODBCStatement> m_attribute_tracking_statement;
-  std::vector<std::shared_ptr<ODBCStatement> > m_statements;
-  std::vector<std::shared_ptr<ODBCDescriptor> > m_descriptors;
-  std::string m_dsn;
-  const bool m_is_2x_connection;
-  bool m_is_connected;
+  std::shared_ptr<ODBCStatement> attribute_tracking_statement_;
+  std::vector<std::shared_ptr<ODBCStatement> > statements_;
+  std::vector<std::shared_ptr<ODBCDescriptor> > descriptors_;
+  std::string dsn_;
+  const bool is_2x_connection_;
+  bool is_connected_;
 };
 
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_descriptor.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_descriptor.h
@@ -38,40 +38,40 @@ class ODBCStatement;
 
 namespace ODBC {
 struct DescriptorRecord {
-  std::string m_base_column_name;
-  std::string m_base_table_name;
-  std::string m_catalog_name;
-  std::string m_label;
-  std::string m_literal_prefix;
-  std::string m_literal_suffix;
-  std::string m_local_type_name;
-  std::string m_name;
-  std::string m_schema_name;
-  std::string m_table_name;
-  std::string m_type_name;
-  SQLPOINTER m_data_ptr = NULL;
-  SQLLEN* m_indicator_ptr = NULL;
-  SQLLEN m_display_size = 0;
-  SQLLEN m_octet_length = 0;
-  SQLULEN m_length = 0;
-  SQLINTEGER m_auto_unique_value;
-  SQLINTEGER m_case_sensitive = SQL_TRUE;
-  SQLINTEGER m_datetime_interval_precision = 0;
-  SQLINTEGER m_num_prec_radix = 0;
-  SQLSMALLINT m_concise_type = SQL_C_DEFAULT;
-  SQLSMALLINT m_datetime_interval_code = 0;
-  SQLSMALLINT m_fixed_prec_scale = 0;
-  SQLSMALLINT m_nullable = SQL_NULLABLE_UNKNOWN;
-  SQLSMALLINT m_param_type = SQL_PARAM_INPUT;
-  SQLSMALLINT m_precision = 0;
-  SQLSMALLINT m_row_ver = 0;
-  SQLSMALLINT m_scale = 0;
-  SQLSMALLINT m_searchable = SQL_SEARCHABLE;
-  SQLSMALLINT m_type = SQL_C_DEFAULT;
-  SQLSMALLINT m_unnamed = SQL_TRUE;
-  SQLSMALLINT m_unsigned = SQL_FALSE;
-  SQLSMALLINT m_updatable = SQL_FALSE;
-  bool m_is_bound = false;
+  std::string base_column_name;
+  std::string base_table_name;
+  std::string catalog_name;
+  std::string label;
+  std::string literal_prefix;
+  std::string literal_suffix;
+  std::string local_type_name;
+  std::string name;
+  std::string schema_name;
+  std::string table_name;
+  std::string type_name;
+  SQLPOINTER data_ptr = NULL;
+  SQLLEN* indicator_ptr = NULL;
+  SQLLEN display_size = 0;
+  SQLLEN octet_length = 0;
+  SQLULEN length = 0;
+  SQLINTEGER auto_unique_value;
+  SQLINTEGER case_sensitive = SQL_TRUE;
+  SQLINTEGER datetime_interval_precision = 0;
+  SQLINTEGER num_prec_radix = 0;
+  SQLSMALLINT concise_type = SQL_C_DEFAULT;
+  SQLSMALLINT datetime_interval_code = 0;
+  SQLSMALLINT fixed_prec_scale = 0;
+  SQLSMALLINT nullable = SQL_NULLABLE_UNKNOWN;
+  SQLSMALLINT param_type = SQL_PARAM_INPUT;
+  SQLSMALLINT precision = 0;
+  SQLSMALLINT row_ver = 0;
+  SQLSMALLINT scale = 0;
+  SQLSMALLINT searchable = SQL_SEARCHABLE;
+  SQLSMALLINT type = SQL_C_DEFAULT;
+  SQLSMALLINT unnamed = SQL_TRUE;
+  SQLSMALLINT is_unsigned = SQL_FALSE;
+  SQLSMALLINT updatable = SQL_FALSE;
+  bool is_bound = false;
 
   void CheckConsistency();
 };
@@ -100,7 +100,7 @@ class ODBCDescriptor : public ODBCHandle<ODBCDescriptor> {
   SQLSMALLINT GetAllocType() const;
   bool IsAppDescriptor() const;
 
-  inline bool HaveBindingsChanged() const { return m_has_bindings_changed; }
+  inline bool HaveBindingsChanged() const { return has_bindings_changed_; }
 
   void RegisterToStatement(ODBCStatement* statement, bool is_apd);
   void DetachFromStatement(ODBCStatement* statement, bool is_apd);
@@ -115,45 +115,45 @@ class ODBCDescriptor : public ODBCHandle<ODBCDescriptor> {
                SQLLEN buffer_length, SQLLEN* indicator_ptr);
   void SetDataPtrOnRecord(SQLPOINTER data_ptr, SQLSMALLINT rec_number);
 
-  inline SQLULEN GetBindOffset() { return m_bind_offset_ptr ? *m_bind_offset_ptr : 0UL; }
+  inline SQLULEN GetBindOffset() { return bind_offset_ptr_ ? *bind_offset_ptr_ : 0UL; }
 
   inline SQLULEN GetBoundStructOffset() {
-    // If this is SQL_BIND_BY_COLUMN, m_bind_type is zero which indicates no offset due to
+    // If this is SQL_BIND_BY_COLUMN, bind_type_ is zero which indicates no offset due to
     // use of a bound struct. If this is non-zero, row-wise binding is being used so the
     // app should set this to sizeof(their struct).
-    return m_bind_type;
+    return bind_type_;
   }
 
-  inline SQLULEN GetArraySize() { return m_array_size; }
+  inline SQLULEN GetArraySize() { return array_size_; }
 
-  inline SQLUSMALLINT* GetArrayStatusPtr() { return m_array_status_ptr; }
+  inline SQLUSMALLINT* GetArrayStatusPtr() { return array_status_ptr_; }
 
   inline void SetRowsProcessed(SQLULEN rows) {
-    if (m_rows_proccessed_ptr) {
-      *m_rows_proccessed_ptr = rows;
+    if (rows_proccessed_ptr_) {
+      *rows_proccessed_ptr_ = rows;
     }
   }
 
-  inline void NotifyBindingsHavePropagated() { m_has_bindings_changed = false; }
+  inline void NotifyBindingsHavePropagated() { has_bindings_changed_ = false; }
 
-  inline void NotifyBindingsHaveChanged() { m_has_bindings_changed = true; }
+  inline void NotifyBindingsHaveChanged() { has_bindings_changed_ = true; }
 
  private:
-  driver::odbcabstraction::Diagnostics m_diagnostics;
-  std::vector<ODBCStatement*> m_registered_on_statements_as_apd;
-  std::vector<ODBCStatement*> m_registered_on_statements_as_ard;
-  std::vector<DescriptorRecord> m_records;
-  ODBCConnection* m_owning_connection;
-  ODBCStatement* m_parent_statement;
-  SQLUSMALLINT* m_array_status_ptr;
-  SQLULEN* m_bind_offset_ptr;
-  SQLULEN* m_rows_proccessed_ptr;
-  SQLULEN m_array_size;
-  SQLINTEGER m_bind_type;
-  SQLSMALLINT m_highest_one_based_bound_record;
-  const bool m_is_2x_connection;
-  bool m_is_app_descriptor;
-  bool m_is_writable;
-  bool m_has_bindings_changed;
+  driver::odbcabstraction::Diagnostics diagnostics_;
+  std::vector<ODBCStatement*> registered_on_statements_as_apd_;
+  std::vector<ODBCStatement*> registered_on_statements_as_ard_;
+  std::vector<DescriptorRecord> records_;
+  ODBCConnection* owning_connection_;
+  ODBCStatement* parent_statement_;
+  SQLUSMALLINT* array_status_ptr_;
+  SQLULEN* bind_offset_ptr_;
+  SQLULEN* rows_proccessed_ptr_;
+  SQLULEN array_size_;
+  SQLINTEGER bind_type_;
+  SQLSMALLINT highest_one_based_bound_record_;
+  const bool is_2x_connection_;
+  bool is_app_descriptor_;
+  bool is_writable_;
+  bool has_bindings_changed_;
 };
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_environment.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_environment.h
@@ -50,11 +50,11 @@ class ODBCEnvironment : public ODBCHandle<ODBCEnvironment> {
   ~ODBCEnvironment() = default;
 
  private:
-  std::vector<std::shared_ptr<ODBCConnection> > m_connections;
-  std::shared_ptr<driver::odbcabstraction::Driver> m_driver;
-  std::unique_ptr<driver::odbcabstraction::Diagnostics> m_diagnostics;
-  SQLINTEGER m_version;
-  SQLINTEGER m_connection_pooling;
+  std::vector<std::shared_ptr<ODBCConnection> > connections_;
+  std::shared_ptr<driver::odbcabstraction::Driver> driver_;
+  std::unique_ptr<driver::odbcabstraction::Diagnostics> diagnostics_;
+  SQLINTEGER version_;
+  SQLINTEGER connection_pooling_;
 };
 
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
@@ -54,7 +54,7 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   ~ODBCStatement() = default;
 
   inline driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl() {
-    return *m_diagnostics;
+    return *diagnostics_;
   }
 
   ODBCConnection& GetConnection();
@@ -84,11 +84,11 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
    */
   void RevertAppDescriptor(bool is_apd);
 
-  inline ODBCDescriptor* GetIRD() { return m_ird.get(); }
+  inline ODBCDescriptor* GetIRD() { return ird_.get(); }
 
-  inline ODBCDescriptor* GetARD() { return m_current_ard; }
+  inline ODBCDescriptor* GetARD() { return current_ard_; }
 
-  inline SQLULEN GetRowsetSize() { return m_rowset_size; }
+  inline SQLULEN GetRowsetSize() { return rowset_size_; }
 
   SQLRETURN GetData(SQLSMALLINT record_number, SQLSMALLINT c_type, SQLPOINTER data_ptr,
                     SQLLEN buffer_length, SQLLEN* indicator_ptr);
@@ -124,21 +124,21 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   void Cancel();
 
  private:
-  ODBCConnection& m_connection;
-  std::shared_ptr<driver::odbcabstraction::Statement> m_spi_statement;
-  std::shared_ptr<driver::odbcabstraction::ResultSet> m_current_result;
-  driver::odbcabstraction::Diagnostics* m_diagnostics;
+  ODBCConnection& connection_;
+  std::shared_ptr<driver::odbcabstraction::Statement> spi_statement_;
+  std::shared_ptr<driver::odbcabstraction::ResultSet> current_result_;
+  driver::odbcabstraction::Diagnostics* diagnostics_;
 
-  std::shared_ptr<ODBCDescriptor> m_built_in_ard;
-  std::shared_ptr<ODBCDescriptor> m_built_in_apd;
-  std::shared_ptr<ODBCDescriptor> m_ipd;
-  std::shared_ptr<ODBCDescriptor> m_ird;
-  ODBCDescriptor* m_current_ard;
-  ODBCDescriptor* m_current_apd;
-  SQLULEN m_row_number;
-  SQLULEN m_max_rows;
-  SQLULEN m_rowset_size;  // Used by SQLExtendedFetch instead of the ARD array size.
-  bool m_is_prepared;
-  bool m_has_reached_end_of_result;
+  std::shared_ptr<ODBCDescriptor> built_in_ard_;
+  std::shared_ptr<ODBCDescriptor> built_in_apd_;
+  std::shared_ptr<ODBCDescriptor> ipd_;
+  std::shared_ptr<ODBCDescriptor> ird_;
+  ODBCDescriptor* current_ard_;
+  ODBCDescriptor* current_apd_;
+  SQLULEN row_number_;
+  SQLULEN max_rows_;
+  SQLULEN rowset_size_;  // Used by SQLExtendedFetch instead of the ARD array size.
+  bool is_prepared_;
+  bool has_reached_end_of_result_;
 };
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
@@ -172,9 +172,9 @@ enum RowStatus : uint16_t {
 };
 
 struct MetadataSettings {
-  boost::optional<int32_t> string_column_length_{boost::none};
-  size_t chunk_buffer_capacity_;
-  bool use_wide_char_;
+  boost::optional<int32_t> string_column_length{boost::none};
+  size_t chunk_buffer_capacity;
+  bool use_wide_char;
 };
 
 }  // namespace odbcabstraction

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
@@ -60,31 +60,31 @@ const boost::xpressive::sregex CONNECTION_STR_REGEX(
 // =========================================================================================
 ODBCConnection::ODBCConnection(ODBCEnvironment& environment,
                                std::shared_ptr<Connection> spi_connection)
-    : m_environment(environment),
-      m_spi_connection(std::move(spi_connection)),
-      m_is_2x_connection(environment.GetODBCVersion() == SQL_OV_ODBC2),
-      m_is_connected(false) {}
+    : environment_(environment),
+      spi_connection_(std::move(spi_connection)),
+      is_2x_connection_(environment.GetODBCVersion() == SQL_OV_ODBC2),
+      is_connected_(false) {}
 
 Diagnostics& ODBCConnection::GetDiagnosticsImpl() {
-  return m_spi_connection->GetDiagnostics();
+  return spi_connection_->GetDiagnostics();
 }
 
-bool ODBCConnection::IsConnected() const { return m_is_connected; }
+bool ODBCConnection::IsConnected() const { return is_connected_; }
 
-const std::string& ODBCConnection::GetDSN() const { return m_dsn; }
+const std::string& ODBCConnection::GetDSN() const { return dsn_; }
 
 void ODBCConnection::Connect(std::string dsn,
                              const Connection::ConnPropertyMap& properties,
                              std::vector<std::string_view>& missing_properties) {
-  if (m_is_connected) {
+  if (is_connected_) {
     throw DriverException("Already connected.", "HY010");
   }
 
-  m_dsn = std::move(dsn);
-  m_spi_connection->Connect(properties, missing_properties);
-  m_is_connected = true;
-  std::shared_ptr<Statement> spi_statement = m_spi_connection->CreateStatement();
-  m_attribute_tracking_statement = std::make_shared<ODBCStatement>(*this, spi_statement);
+  dsn_ = std::move(dsn);
+  spi_connection_->Connect(properties, missing_properties);
+  is_connected_ = true;
+  std::shared_ptr<Statement> spi_statement = spi_connection_->CreateStatement();
+  attribute_tracking_statement_ = std::make_shared<ODBCStatement>(*this, spi_statement);
 }
 
 SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT info_type, SQLPOINTER value,
@@ -117,7 +117,7 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT info_type, SQLPOINTER value,
       GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       return SQL_SUCCESS;
     case SQL_DATA_SOURCE_NAME:
-      return GetStringAttribute(is_unicode, m_dsn, true, value, buffer_length,
+      return GetStringAttribute(is_unicode, dsn_, true, value, buffer_length,
                                 output_length, GetDiagnostics());
     case SQL_DRIVER_ODBC_VER:
       return GetStringAttribute(is_unicode, "03.80", true, value, buffer_length,
@@ -257,7 +257,7 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT info_type, SQLPOINTER value,
     case SQL_PROCEDURES:
     case SQL_SPECIAL_CHARACTERS:
     case SQL_XOPEN_CLI_YEAR: {
-      const auto& info = m_spi_connection->GetInfo(info_type);
+      const auto& info = spi_connection_->GetInfo(info_type);
       const std::string& info_value = boost::get<std::string>(info);
       return GetStringAttribute(is_unicode, info_value, true, value, buffer_length,
                                 output_length, GetDiagnostics());
@@ -347,7 +347,7 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT info_type, SQLPOINTER value,
     case SQL_SQL92_STRING_FUNCTIONS:
     case SQL_SQL92_VALUE_EXPRESSIONS:
     case SQL_STANDARD_CLI_CONFORMANCE: {
-      const auto& info = m_spi_connection->GetInfo(info_type);
+      const auto& info = spi_connection_->GetInfo(info_type);
       uint32_t info_value = boost::get<uint32_t>(info);
       GetAttribute(info_value, value, buffer_length, output_length);
       return SQL_SUCCESS;
@@ -382,7 +382,7 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT info_type, SQLPOINTER value,
     case SQL_MAX_USER_NAME_LEN:
     case SQL_ODBC_SQL_CONFORMANCE:
     case SQL_ODBC_SAG_CLI_CONFORMANCE: {
-      const auto& info = m_spi_connection->GetInfo(info_type);
+      const auto& info = spi_connection_->GetInfo(info_type);
       uint16_t info_value = boost::get<uint16_t>(info);
       GetAttribute(info_value, value, buffer_length, output_length);
       return SQL_SUCCESS;
@@ -390,7 +390,7 @@ SQLRETURN ODBCConnection::GetInfo(SQLUSMALLINT info_type, SQLPOINTER value,
 
     // Special case - SQL_DATABASE_NAME is an alias for SQL_ATTR_CURRENT_CATALOG.
     case SQL_DATABASE_NAME: {
-      const auto& attr = m_spi_connection->GetAttribute(Connection::CURRENT_CATALOG);
+      const auto& attr = spi_connection_->GetAttribute(Connection::CURRENT_CATALOG);
       if (!attr) {
         throw DriverException("Optional feature not supported.", "HYC00");
       }
@@ -465,7 +465,7 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
       } else {
         SetAttributeSQLWCHAR(value, string_length, catalog);
       }
-      if (!m_spi_connection->SetAttribute(Connection::CURRENT_CATALOG, catalog)) {
+      if (!spi_connection_->SetAttribute(Connection::CURRENT_CATALOG, catalog)) {
         throw DriverException("Option value changed.", "01S02");
       }
       return;
@@ -488,29 +488,29 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
     case SQL_ATTR_ROW_BIND_TYPE:
     case SQL_ATTR_SIMULATE_CURSOR:
     case SQL_ATTR_USE_BOOKMARKS:
-      m_attribute_tracking_statement->SetStmtAttr(attribute, value, string_length,
-                                                  is_unicode);
+      attribute_tracking_statement_->SetStmtAttr(attribute, value, string_length,
+                                                 is_unicode);
       return;
 
     case SQL_ATTR_ACCESS_MODE:
       SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spi_connection->SetAttribute(Connection::ACCESS_MODE, attribute_to_write);
+          spi_connection_->SetAttribute(Connection::ACCESS_MODE, attribute_to_write);
       break;
     case SQL_ATTR_CONNECTION_TIMEOUT:
       SetAttribute(value, attribute_to_write);
-      successfully_written = m_spi_connection->SetAttribute(
-          Connection::CONNECTION_TIMEOUT, attribute_to_write);
+      successfully_written = spi_connection_->SetAttribute(Connection::CONNECTION_TIMEOUT,
+                                                           attribute_to_write);
       break;
     case SQL_ATTR_LOGIN_TIMEOUT:
       SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spi_connection->SetAttribute(Connection::LOGIN_TIMEOUT, attribute_to_write);
+          spi_connection_->SetAttribute(Connection::LOGIN_TIMEOUT, attribute_to_write);
       break;
     case SQL_ATTR_PACKET_SIZE:
       SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spi_connection->SetAttribute(Connection::PACKET_SIZE, attribute_to_write);
+          spi_connection_->SetAttribute(Connection::PACKET_SIZE, attribute_to_write);
       break;
     default:
       throw DriverException("Invalid attribute: " + std::to_string(attribute), "HY092");
@@ -588,7 +588,7 @@ SQLRETURN ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
 
     // ODBCAbstraction-level connection attributes.
     case SQL_ATTR_CURRENT_CATALOG: {
-      const auto& catalog = m_spi_connection->GetAttribute(Connection::CURRENT_CATALOG);
+      const auto& catalog = spi_connection_->GetAttribute(Connection::CURRENT_CATALOG);
       if (!catalog) {
         throw DriverException("Optional feature not supported.", "HYC00");
       }
@@ -599,19 +599,19 @@ SQLRETURN ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
 
     // These all are uint32_t attributes.
     case SQL_ATTR_ACCESS_MODE:
-      spi_attribute = m_spi_connection->GetAttribute(Connection::ACCESS_MODE);
+      spi_attribute = spi_connection_->GetAttribute(Connection::ACCESS_MODE);
       break;
     case SQL_ATTR_CONNECTION_DEAD:
-      spi_attribute = m_spi_connection->GetAttribute(Connection::CONNECTION_DEAD);
+      spi_attribute = spi_connection_->GetAttribute(Connection::CONNECTION_DEAD);
       break;
     case SQL_ATTR_CONNECTION_TIMEOUT:
-      spi_attribute = m_spi_connection->GetAttribute(Connection::CONNECTION_TIMEOUT);
+      spi_attribute = spi_connection_->GetAttribute(Connection::CONNECTION_TIMEOUT);
       break;
     case SQL_ATTR_LOGIN_TIMEOUT:
-      spi_attribute = m_spi_connection->GetAttribute(Connection::LOGIN_TIMEOUT);
+      spi_attribute = spi_connection_->GetAttribute(Connection::LOGIN_TIMEOUT);
       break;
     case SQL_ATTR_PACKET_SIZE:
-      spi_attribute = m_spi_connection->GetAttribute(Connection::PACKET_SIZE);
+      spi_attribute = spi_connection_->GetAttribute(Connection::PACKET_SIZE);
       break;
     default:
       throw DriverException("Invalid attribute", "HY092");
@@ -627,54 +627,54 @@ SQLRETURN ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
 }
 
 void ODBCConnection::Disconnect() {
-  if (m_is_connected) {
+  if (is_connected_) {
     // Ensure that all statements (and corresponding SPI statements) get cleaned
     // up before terminating the SPI connection in case they need to be de-allocated in
     // the reverse of the allocation order.
-    m_statements.clear();
-    m_spi_connection->Close();
-    m_is_connected = false;
+    statements_.clear();
+    spi_connection_->Close();
+    is_connected_ = false;
   }
 }
 
 void ODBCConnection::ReleaseConnection() {
   Disconnect();
-  m_environment.DropConnection(this);
+  environment_.DropConnection(this);
 }
 
 std::shared_ptr<ODBCStatement> ODBCConnection::CreateStatement() {
-  std::shared_ptr<Statement> spi_statement = m_spi_connection->CreateStatement();
+  std::shared_ptr<Statement> spi_statement = spi_connection_->CreateStatement();
   std::shared_ptr<ODBCStatement> statement =
       std::make_shared<ODBCStatement>(*this, spi_statement);
-  m_statements.push_back(statement);
+  statements_.push_back(statement);
   statement->CopyAttributesFromConnection(*this);
   return statement;
 }
 
 void ODBCConnection::DropStatement(ODBCStatement* stmt) {
-  auto it = std::find_if(m_statements.begin(), m_statements.end(),
+  auto it = std::find_if(statements_.begin(), statements_.end(),
                          [&stmt](const std::shared_ptr<ODBCStatement>& statement) {
                            return statement.get() == stmt;
                          });
-  if (m_statements.end() != it) {
-    m_statements.erase(it);
+  if (statements_.end() != it) {
+    statements_.erase(it);
   }
 }
 
 std::shared_ptr<ODBCDescriptor> ODBCConnection::CreateDescriptor() {
   std::shared_ptr<ODBCDescriptor> desc = std::make_shared<ODBCDescriptor>(
-      m_spi_connection->GetDiagnostics(), this, nullptr, true, true, false);
-  m_descriptors.push_back(desc);
+      spi_connection_->GetDiagnostics(), this, nullptr, true, true, false);
+  descriptors_.push_back(desc);
   return desc;
 }
 
 void ODBCConnection::DropDescriptor(ODBCDescriptor* desc) {
-  auto it = std::find_if(m_descriptors.begin(), m_descriptors.end(),
+  auto it = std::find_if(descriptors_.begin(), descriptors_.end(),
                          [&desc](const std::shared_ptr<ODBCDescriptor>& descriptor) {
                            return descriptor.get() == desc;
                          });
-  if (m_descriptors.end() != it) {
-    m_descriptors.erase(it);
+  if (descriptors_.end() != it) {
+    descriptors_.erase(it);
   }
 }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
@@ -42,7 +42,7 @@ SQLSMALLINT CalculateHighestBoundRecord(const std::vector<DescriptorRecord>& rec
   // Most applications will bind every column, so optimistically assume that we'll
   // find the next bound record fastest by counting backwards.
   for (size_t i = records.size(); i > 0; --i) {
-    if (records[i - 1].m_is_bound) {
+    if (records[i - 1].is_bound) {
       return i;
     }
   }
@@ -55,36 +55,36 @@ SQLSMALLINT CalculateHighestBoundRecord(const std::vector<DescriptorRecord>& rec
 ODBCDescriptor::ODBCDescriptor(Diagnostics& base_diagnostics, ODBCConnection* conn,
                                ODBCStatement* stmt, bool is_app_descriptor,
                                bool is_writable, bool is_2x_connection)
-    : m_diagnostics(base_diagnostics.GetVendor(),
-                    base_diagnostics.GetDataSourceComponent(),
-                    driver::odbcabstraction::V_3),
-      m_owning_connection(conn),
-      m_parent_statement(stmt),
-      m_array_status_ptr(nullptr),
-      m_bind_offset_ptr(nullptr),
-      m_rows_proccessed_ptr(nullptr),
-      m_array_size(1),
-      m_bind_type(SQL_BIND_BY_COLUMN),
-      m_highest_one_based_bound_record(0),
-      m_is_2x_connection(is_2x_connection),
-      m_is_app_descriptor(is_app_descriptor),
-      m_is_writable(is_writable),
-      m_has_bindings_changed(true) {}
+    : diagnostics_(base_diagnostics.GetVendor(),
+                   base_diagnostics.GetDataSourceComponent(),
+                   driver::odbcabstraction::V_3),
+      owning_connection_(conn),
+      parent_statement_(stmt),
+      array_status_ptr_(nullptr),
+      bind_offset_ptr_(nullptr),
+      rows_proccessed_ptr_(nullptr),
+      array_size_(1),
+      bind_type_(SQL_BIND_BY_COLUMN),
+      highest_one_based_bound_record_(0),
+      is_2x_connection_(is_2x_connection),
+      is_app_descriptor_(is_app_descriptor),
+      is_writable_(is_writable),
+      has_bindings_changed_(true) {}
 
-Diagnostics& ODBCDescriptor::GetDiagnosticsImpl() { return m_diagnostics; }
+Diagnostics& ODBCDescriptor::GetDiagnosticsImpl() { return diagnostics_; }
 
 ODBCConnection& ODBCDescriptor::GetConnection() {
-  if (m_owning_connection) {
-    return *m_owning_connection;
+  if (owning_connection_) {
+    return *owning_connection_;
   }
-  assert(m_parent_statement);
-  return m_parent_statement->GetConnection();
+  assert(parent_statement_);
+  return parent_statement_->GetConnection();
 }
 
 void ODBCDescriptor::SetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
                                     SQLINTEGER buffer_length) {
   // Only these two fields can be set on the IRD.
-  if (!m_is_writable && field_identifier != SQL_DESC_ARRAY_STATUS_PTR &&
+  if (!is_writable_ && field_identifier != SQL_DESC_ARRAY_STATUS_PTR &&
       field_identifier != SQL_DESC_ROWS_PROCESSED_PTR) {
     throw DriverException("Cannot modify read-only descriptor", "HY016");
   }
@@ -93,36 +93,36 @@ void ODBCDescriptor::SetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER val
     case SQL_DESC_ALLOC_TYPE:
       throw DriverException("Invalid descriptor field", "HY091");
     case SQL_DESC_ARRAY_SIZE:
-      SetAttribute(value, m_array_size);
-      m_has_bindings_changed = true;
+      SetAttribute(value, array_size_);
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_ARRAY_STATUS_PTR:
-      SetPointerAttribute(value, m_array_status_ptr);
-      m_has_bindings_changed = true;
+      SetPointerAttribute(value, array_status_ptr_);
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_BIND_OFFSET_PTR:
-      SetPointerAttribute(value, m_bind_offset_ptr);
-      m_has_bindings_changed = true;
+      SetPointerAttribute(value, bind_offset_ptr_);
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_BIND_TYPE:
-      SetAttribute(value, m_bind_type);
-      m_has_bindings_changed = true;
+      SetAttribute(value, bind_type_);
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_ROWS_PROCESSED_PTR:
-      SetPointerAttribute(value, m_rows_proccessed_ptr);
-      m_has_bindings_changed = true;
+      SetPointerAttribute(value, rows_proccessed_ptr_);
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_COUNT: {
       SQLSMALLINT new_count;
       SetAttribute(value, new_count);
-      m_records.resize(new_count);
+      records_.resize(new_count);
 
-      if (m_is_app_descriptor && new_count <= m_highest_one_based_bound_record) {
-        m_highest_one_based_bound_record = CalculateHighestBoundRecord(m_records);
+      if (is_app_descriptor_ && new_count <= highest_one_based_bound_record_) {
+        highest_one_based_bound_record_ = CalculateHighestBoundRecord(records_);
       } else {
-        m_highest_one_based_bound_record = new_count;
+        highest_one_based_bound_record_ = new_count;
       }
-      m_has_bindings_changed = true;
+      has_bindings_changed_ = true;
       break;
     }
     default:
@@ -132,7 +132,7 @@ void ODBCDescriptor::SetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER val
 
 void ODBCDescriptor::SetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier,
                               SQLPOINTER value, SQLINTEGER buffer_length) {
-  if (!m_is_writable) {
+  if (!is_writable_) {
     throw DriverException("Cannot modify read-only descriptor", "HY016");
   }
 
@@ -155,12 +155,12 @@ void ODBCDescriptor::SetField(SQLSMALLINT record_number, SQLSMALLINT field_ident
     throw DriverException("Bookmarks are unsupported.", "07009");
   }
 
-  if (record_number > m_records.size()) {
+  if (record_number > records_.size()) {
     throw DriverException("Invalid descriptor index", "HY009");
   }
 
   SQLSMALLINT zero_based_record = record_number - 1;
-  DescriptorRecord& record = m_records[zero_based_record];
+  DescriptorRecord& record = records_[zero_based_record];
   switch (field_identifier) {
     case SQL_DESC_AUTO_UNIQUE_VALUE:
     case SQL_DESC_BASE_COLUMN_NAME:
@@ -185,61 +185,61 @@ void ODBCDescriptor::SetField(SQLSMALLINT record_number, SQLSMALLINT field_ident
     case SQL_DESC_UPDATABLE:
       throw DriverException("Cannot modify read-only field.", "HY092");
     case SQL_DESC_CONCISE_TYPE:
-      SetAttribute(value, record.m_concise_type);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.concise_type);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_DATA_PTR:
       SetDataPtrOnRecord(value, record_number);
       break;
     case SQL_DESC_DATETIME_INTERVAL_CODE:
-      SetAttribute(value, record.m_datetime_interval_code);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.datetime_interval_code);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_DATETIME_INTERVAL_PRECISION:
-      SetAttribute(value, record.m_datetime_interval_precision);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.datetime_interval_precision);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_INDICATOR_PTR:
     case SQL_DESC_OCTET_LENGTH_PTR:
-      SetPointerAttribute(value, record.m_indicator_ptr);
-      m_has_bindings_changed = true;
+      SetPointerAttribute(value, record.indicator_ptr);
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_LENGTH:
-      SetAttribute(value, record.m_length);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.length);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_NAME:
-      SetAttributeUTF8(value, buffer_length, record.m_name);
-      m_has_bindings_changed = true;
+      SetAttributeUTF8(value, buffer_length, record.name);
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_OCTET_LENGTH:
-      SetAttribute(value, record.m_octet_length);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.octet_length);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_PARAMETER_TYPE:
-      SetAttribute(value, record.m_param_type);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.param_type);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_PRECISION:
-      SetAttribute(value, record.m_precision);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.precision);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_SCALE:
-      SetAttribute(value, record.m_scale);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.scale);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     case SQL_DESC_TYPE:
-      SetAttribute(value, record.m_type);
-      record.m_is_bound = false;
-      m_has_bindings_changed = true;
+      SetAttribute(value, record.type);
+      record.is_bound = false;
+      has_bindings_changed_ = true;
       break;
     default:
       throw DriverException("Invalid descriptor field", "HY091");
@@ -252,7 +252,7 @@ void ODBCDescriptor::GetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER val
   switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE: {
       SQLSMALLINT result;
-      if (m_owning_connection) {
+      if (owning_connection_) {
         result = SQL_DESC_ALLOC_USER;
       } else {
         result = SQL_DESC_ALLOC_AUTO;
@@ -261,23 +261,23 @@ void ODBCDescriptor::GetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER val
       break;
     }
     case SQL_DESC_ARRAY_SIZE:
-      GetAttribute(m_array_size, value, buffer_length, output_length);
+      GetAttribute(array_size_, value, buffer_length, output_length);
       break;
     case SQL_DESC_ARRAY_STATUS_PTR:
-      GetAttribute(m_array_status_ptr, value, buffer_length, output_length);
+      GetAttribute(array_status_ptr_, value, buffer_length, output_length);
       break;
     case SQL_DESC_BIND_OFFSET_PTR:
-      GetAttribute(m_bind_offset_ptr, value, buffer_length, output_length);
+      GetAttribute(bind_offset_ptr_, value, buffer_length, output_length);
       break;
     case SQL_DESC_BIND_TYPE:
-      GetAttribute(m_bind_type, value, buffer_length, output_length);
+      GetAttribute(bind_type_, value, buffer_length, output_length);
       break;
     case SQL_DESC_ROWS_PROCESSED_PTR:
-      GetAttribute(m_rows_proccessed_ptr, value, buffer_length, output_length);
+      GetAttribute(rows_proccessed_ptr_, value, buffer_length, output_length);
       break;
     case SQL_DESC_COUNT: {
-      // m_highest_one_based_bound_record equals number of records + 1
-      GetAttribute(static_cast<SQLSMALLINT>(m_highest_one_based_bound_record - 1), value,
+      // highest_one_based_bound_record_ equals number of records + 1
+      GetAttribute(static_cast<SQLSMALLINT>(highest_one_based_bound_record_ - 1), value,
                    buffer_length, output_length);
       break;
     }
@@ -308,7 +308,7 @@ void ODBCDescriptor::GetField(SQLSMALLINT record_number, SQLSMALLINT field_ident
     throw DriverException("Bookmarks are unsupported.", "07009");
   }
 
-  if (record_number > m_records.size()) {
+  if (record_number > records_.size()) {
     throw DriverException("Invalid descriptor index", "07009");
   }
 
@@ -316,125 +316,125 @@ void ODBCDescriptor::GetField(SQLSMALLINT record_number, SQLSMALLINT field_ident
 
   bool length_in_bytes = true;
   SQLSMALLINT zero_based_record = record_number - 1;
-  const DescriptorRecord& record = m_records[zero_based_record];
+  const DescriptorRecord& record = records_[zero_based_record];
   switch (field_identifier) {
     case SQL_DESC_BASE_COLUMN_NAME:
-      GetAttributeSQLWCHAR(record.m_base_column_name, length_in_bytes, value,
-                           buffer_length, output_length, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.base_column_name, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_BASE_TABLE_NAME:
-      GetAttributeSQLWCHAR(record.m_base_table_name, length_in_bytes, value,
-                           buffer_length, output_length, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.base_table_name, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_CATALOG_NAME:
-      GetAttributeSQLWCHAR(record.m_catalog_name, length_in_bytes, value, buffer_length,
+      GetAttributeSQLWCHAR(record.catalog_name, length_in_bytes, value, buffer_length,
                            output_length, GetDiagnostics());
       break;
     case SQL_DESC_LABEL:
-      GetAttributeSQLWCHAR(record.m_label, length_in_bytes, value, buffer_length,
+      GetAttributeSQLWCHAR(record.label, length_in_bytes, value, buffer_length,
                            output_length, GetDiagnostics());
       break;
     case SQL_DESC_LITERAL_PREFIX:
-      GetAttributeSQLWCHAR(record.m_literal_prefix, length_in_bytes, value, buffer_length,
+      GetAttributeSQLWCHAR(record.literal_prefix, length_in_bytes, value, buffer_length,
                            output_length, GetDiagnostics());
       break;
     case SQL_DESC_LITERAL_SUFFIX:
-      GetAttributeSQLWCHAR(record.m_literal_suffix, length_in_bytes, value, buffer_length,
+      GetAttributeSQLWCHAR(record.literal_suffix, length_in_bytes, value, buffer_length,
                            output_length, GetDiagnostics());
       break;
     case SQL_DESC_LOCAL_TYPE_NAME:
-      GetAttributeSQLWCHAR(record.m_local_type_name, length_in_bytes, value,
-                           buffer_length, output_length, GetDiagnostics());
+      GetAttributeSQLWCHAR(record.local_type_name, length_in_bytes, value, buffer_length,
+                           output_length, GetDiagnostics());
       break;
     case SQL_DESC_NAME:
-      GetAttributeSQLWCHAR(record.m_name, length_in_bytes, value, buffer_length,
+      GetAttributeSQLWCHAR(record.name, length_in_bytes, value, buffer_length,
                            output_length, GetDiagnostics());
       break;
     case SQL_DESC_SCHEMA_NAME:
-      GetAttributeSQLWCHAR(record.m_schema_name, length_in_bytes, value, buffer_length,
+      GetAttributeSQLWCHAR(record.schema_name, length_in_bytes, value, buffer_length,
                            output_length, GetDiagnostics());
       break;
     case SQL_DESC_TABLE_NAME:
-      GetAttributeSQLWCHAR(record.m_table_name, length_in_bytes, value, buffer_length,
+      GetAttributeSQLWCHAR(record.table_name, length_in_bytes, value, buffer_length,
                            output_length, GetDiagnostics());
       break;
     case SQL_DESC_TYPE_NAME:
-      GetAttributeSQLWCHAR(record.m_type_name, length_in_bytes, value, buffer_length,
+      GetAttributeSQLWCHAR(record.type_name, length_in_bytes, value, buffer_length,
                            output_length, GetDiagnostics());
       break;
 
     case SQL_DESC_DATA_PTR:
-      GetAttribute(record.m_data_ptr, value, buffer_length, output_length);
+      GetAttribute(record.data_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_INDICATOR_PTR:
     case SQL_DESC_OCTET_LENGTH_PTR:
-      GetAttribute(record.m_indicator_ptr, value, buffer_length, output_length);
+      GetAttribute(record.indicator_ptr, value, buffer_length, output_length);
       break;
     case SQL_COLUMN_LENGTH:  // ODBC 2.0
     case SQL_DESC_LENGTH:
-      GetAttribute(record.m_length, value, buffer_length, output_length);
+      GetAttribute(record.length, value, buffer_length, output_length);
       break;
     case SQL_DESC_OCTET_LENGTH:
-      GetAttribute(record.m_octet_length, value, buffer_length, output_length);
+      GetAttribute(record.octet_length, value, buffer_length, output_length);
       break;
 
     case SQL_DESC_AUTO_UNIQUE_VALUE:
-      GetAttribute(record.m_auto_unique_value, value, buffer_length, output_length);
+      GetAttribute(record.auto_unique_value, value, buffer_length, output_length);
       break;
     case SQL_DESC_CASE_SENSITIVE:
-      GetAttribute(record.m_case_sensitive, value, buffer_length, output_length);
+      GetAttribute(record.case_sensitive, value, buffer_length, output_length);
       break;
     case SQL_DESC_DATETIME_INTERVAL_PRECISION:
-      GetAttribute(record.m_datetime_interval_precision, value, buffer_length,
+      GetAttribute(record.datetime_interval_precision, value, buffer_length,
                    output_length);
       break;
     case SQL_DESC_NUM_PREC_RADIX:
-      GetAttribute(record.m_num_prec_radix, value, buffer_length, output_length);
+      GetAttribute(record.num_prec_radix, value, buffer_length, output_length);
       break;
 
     case SQL_DESC_CONCISE_TYPE:
-      GetAttribute(record.m_concise_type, value, buffer_length, output_length);
+      GetAttribute(record.concise_type, value, buffer_length, output_length);
       break;
     case SQL_DESC_DATETIME_INTERVAL_CODE:
-      GetAttribute(record.m_datetime_interval_code, value, buffer_length, output_length);
+      GetAttribute(record.datetime_interval_code, value, buffer_length, output_length);
       break;
     case SQL_DESC_DISPLAY_SIZE:
-      GetAttribute(record.m_display_size, value, buffer_length, output_length);
+      GetAttribute(record.display_size, value, buffer_length, output_length);
       break;
     case SQL_DESC_FIXED_PREC_SCALE:
-      GetAttribute(record.m_fixed_prec_scale, value, buffer_length, output_length);
+      GetAttribute(record.fixed_prec_scale, value, buffer_length, output_length);
       break;
     case SQL_DESC_NULLABLE:
-      GetAttribute(record.m_nullable, value, buffer_length, output_length);
+      GetAttribute(record.nullable, value, buffer_length, output_length);
       break;
     case SQL_DESC_PARAMETER_TYPE:
-      GetAttribute(record.m_param_type, value, buffer_length, output_length);
+      GetAttribute(record.param_type, value, buffer_length, output_length);
       break;
     case SQL_COLUMN_PRECISION:  // ODBC 2.0
     case SQL_DESC_PRECISION:
-      GetAttribute(record.m_precision, value, buffer_length, output_length);
+      GetAttribute(record.precision, value, buffer_length, output_length);
       break;
     case SQL_DESC_ROWVER:
-      GetAttribute(record.m_row_ver, value, buffer_length, output_length);
+      GetAttribute(record.row_ver, value, buffer_length, output_length);
       break;
     case SQL_COLUMN_SCALE:  // ODBC 2.0
     case SQL_DESC_SCALE:
-      GetAttribute(record.m_scale, value, buffer_length, output_length);
+      GetAttribute(record.scale, value, buffer_length, output_length);
       break;
     case SQL_DESC_SEARCHABLE:
-      GetAttribute(record.m_searchable, value, buffer_length, output_length);
+      GetAttribute(record.searchable, value, buffer_length, output_length);
       break;
     case SQL_DESC_TYPE:
-      GetAttribute(record.m_type, value, buffer_length, output_length);
+      GetAttribute(record.type, value, buffer_length, output_length);
       break;
     case SQL_DESC_UNNAMED:
-      GetAttribute(record.m_unnamed, value, buffer_length, output_length);
+      GetAttribute(record.unnamed, value, buffer_length, output_length);
       break;
     case SQL_DESC_UNSIGNED:
-      GetAttribute(record.m_unsigned, value, buffer_length, output_length);
+      GetAttribute(record.is_unsigned, value, buffer_length, output_length);
       break;
     case SQL_DESC_UPDATABLE:
-      GetAttribute(record.m_updatable, value, buffer_length, output_length);
+      GetAttribute(record.updatable, value, buffer_length, output_length);
       break;
     default:
       throw DriverException("Invalid descriptor field", "HY091");
@@ -442,22 +442,22 @@ void ODBCDescriptor::GetField(SQLSMALLINT record_number, SQLSMALLINT field_ident
 }
 
 SQLSMALLINT ODBCDescriptor::GetAllocType() const {
-  return m_owning_connection != nullptr ? SQL_DESC_ALLOC_USER : SQL_DESC_ALLOC_AUTO;
+  return owning_connection_ != nullptr ? SQL_DESC_ALLOC_USER : SQL_DESC_ALLOC_AUTO;
 }
 
-bool ODBCDescriptor::IsAppDescriptor() const { return m_is_app_descriptor; }
+bool ODBCDescriptor::IsAppDescriptor() const { return is_app_descriptor_; }
 
 void ODBCDescriptor::RegisterToStatement(ODBCStatement* statement, bool is_apd) {
   if (is_apd) {
-    m_registered_on_statements_as_apd.push_back(statement);
+    registered_on_statements_as_apd_.push_back(statement);
   } else {
-    m_registered_on_statements_as_ard.push_back(statement);
+    registered_on_statements_as_ard_.push_back(statement);
   }
 }
 
 void ODBCDescriptor::DetachFromStatement(ODBCStatement* statement, bool is_apd) {
   auto& vector_to_update =
-      is_apd ? m_registered_on_statements_as_apd : m_registered_on_statements_as_ard;
+      is_apd ? registered_on_statements_as_apd_ : registered_on_statements_as_ard_;
   auto it = std::find(vector_to_update.begin(), vector_to_update.end(), statement);
   if (it != vector_to_update.end()) {
     vector_to_update.erase(it);
@@ -465,118 +465,117 @@ void ODBCDescriptor::DetachFromStatement(ODBCStatement* statement, bool is_apd) 
 }
 
 void ODBCDescriptor::ReleaseDescriptor() {
-  for (ODBCStatement* stmt : m_registered_on_statements_as_apd) {
+  for (ODBCStatement* stmt : registered_on_statements_as_apd_) {
     stmt->RevertAppDescriptor(true);
   }
 
-  for (ODBCStatement* stmt : m_registered_on_statements_as_ard) {
+  for (ODBCStatement* stmt : registered_on_statements_as_ard_) {
     stmt->RevertAppDescriptor(false);
   }
 
-  if (m_owning_connection) {
-    m_owning_connection->DropDescriptor(this);
+  if (owning_connection_) {
+    owning_connection_->DropDescriptor(this);
   }
 }
 
 void ODBCDescriptor::PopulateFromResultSetMetadata(ResultSetMetadata* rsmd) {
-  m_records.assign(rsmd->GetColumnCount(), DescriptorRecord());
-  m_highest_one_based_bound_record = m_records.size() + 1;
+  records_.assign(rsmd->GetColumnCount(), DescriptorRecord());
+  highest_one_based_bound_record_ = records_.size() + 1;
 
-  for (size_t i = 0; i < m_records.size(); ++i) {
+  for (size_t i = 0; i < records_.size(); ++i) {
     size_t one_based_index = i + 1;
     int16_t concise_type = rsmd->GetConciseType(one_based_index);
 
-    m_records[i].m_base_column_name = rsmd->GetBaseColumnName(one_based_index);
-    m_records[i].m_base_table_name = rsmd->GetBaseTableName(one_based_index);
-    m_records[i].m_catalog_name = rsmd->GetCatalogName(one_based_index);
-    m_records[i].m_label = rsmd->GetColumnLabel(one_based_index);
-    m_records[i].m_literal_prefix = rsmd->GetLiteralPrefix(one_based_index);
-    m_records[i].m_literal_suffix = rsmd->GetLiteralSuffix(one_based_index);
-    m_records[i].m_local_type_name = rsmd->GetLocalTypeName(one_based_index);
-    m_records[i].m_name = rsmd->GetName(one_based_index);
-    m_records[i].m_schema_name = rsmd->GetSchemaName(one_based_index);
-    m_records[i].m_table_name = rsmd->GetTableName(one_based_index);
-    m_records[i].m_type_name = rsmd->GetTypeName(one_based_index, concise_type);
-    m_records[i].m_concise_type =
-        GetSqlTypeForODBCVersion(concise_type, m_is_2x_connection);
-    m_records[i].m_data_ptr = nullptr;
-    m_records[i].m_indicator_ptr = nullptr;
-    m_records[i].m_display_size = rsmd->GetColumnDisplaySize(one_based_index);
-    m_records[i].m_octet_length = rsmd->GetOctetLength(one_based_index);
-    m_records[i].m_length = rsmd->GetLength(one_based_index);
-    m_records[i].m_auto_unique_value =
+    records_[i].base_column_name = rsmd->GetBaseColumnName(one_based_index);
+    records_[i].base_table_name = rsmd->GetBaseTableName(one_based_index);
+    records_[i].catalog_name = rsmd->GetCatalogName(one_based_index);
+    records_[i].label = rsmd->GetColumnLabel(one_based_index);
+    records_[i].literal_prefix = rsmd->GetLiteralPrefix(one_based_index);
+    records_[i].literal_suffix = rsmd->GetLiteralSuffix(one_based_index);
+    records_[i].local_type_name = rsmd->GetLocalTypeName(one_based_index);
+    records_[i].name = rsmd->GetName(one_based_index);
+    records_[i].schema_name = rsmd->GetSchemaName(one_based_index);
+    records_[i].table_name = rsmd->GetTableName(one_based_index);
+    records_[i].type_name = rsmd->GetTypeName(one_based_index, concise_type);
+    records_[i].concise_type = GetSqlTypeForODBCVersion(concise_type, is_2x_connection_);
+    records_[i].data_ptr = nullptr;
+    records_[i].indicator_ptr = nullptr;
+    records_[i].display_size = rsmd->GetColumnDisplaySize(one_based_index);
+    records_[i].octet_length = rsmd->GetOctetLength(one_based_index);
+    records_[i].length = rsmd->GetLength(one_based_index);
+    records_[i].auto_unique_value =
         rsmd->IsAutoUnique(one_based_index) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_case_sensitive =
+    records_[i].case_sensitive =
         rsmd->IsCaseSensitive(one_based_index) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_datetime_interval_precision;  // TODO - update when rsmd adds this
+    records_[i].datetime_interval_precision;  // TODO - update when rsmd adds this
     SQLINTEGER num_prec_radix = rsmd->GetNumPrecRadix(one_based_index);
-    m_records[i].m_num_prec_radix = num_prec_radix > 0 ? num_prec_radix : 0;
-    m_records[i].m_datetime_interval_code;  // TODO
-    m_records[i].m_fixed_prec_scale =
+    records_[i].num_prec_radix = num_prec_radix > 0 ? num_prec_radix : 0;
+    records_[i].datetime_interval_code;  // TODO
+    records_[i].fixed_prec_scale =
         rsmd->IsFixedPrecScale(one_based_index) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_nullable = rsmd->IsNullable(one_based_index);
-    m_records[i].m_param_type = SQL_PARAM_INPUT;
-    m_records[i].m_precision = rsmd->GetPrecision(one_based_index);
-    m_records[i].m_row_ver = SQL_FALSE;
-    m_records[i].m_scale = rsmd->GetScale(one_based_index);
-    m_records[i].m_searchable = rsmd->IsSearchable(one_based_index);
-    m_records[i].m_type = rsmd->GetDataType(one_based_index);
-    m_records[i].m_unnamed = m_records[i].m_name.empty() ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_unsigned = rsmd->IsUnsigned(one_based_index) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_updatable = rsmd->GetUpdatable(one_based_index);
+    records_[i].nullable = rsmd->IsNullable(one_based_index);
+    records_[i].param_type = SQL_PARAM_INPUT;
+    records_[i].precision = rsmd->GetPrecision(one_based_index);
+    records_[i].row_ver = SQL_FALSE;
+    records_[i].scale = rsmd->GetScale(one_based_index);
+    records_[i].searchable = rsmd->IsSearchable(one_based_index);
+    records_[i].type = rsmd->GetDataType(one_based_index);
+    records_[i].unnamed = records_[i].name.empty() ? SQL_TRUE : SQL_FALSE;
+    records_[i].is_unsigned = rsmd->IsUnsigned(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    records_[i].updatable = rsmd->GetUpdatable(one_based_index);
   }
 }
 
 const std::vector<DescriptorRecord>& ODBCDescriptor::GetRecords() const {
-  return m_records;
+  return records_;
 }
 
-std::vector<DescriptorRecord>& ODBCDescriptor::GetRecords() { return m_records; }
+std::vector<DescriptorRecord>& ODBCDescriptor::GetRecords() { return records_; }
 
 void ODBCDescriptor::BindCol(SQLSMALLINT record_number, SQLSMALLINT c_type,
                              SQLPOINTER data_ptr, SQLLEN buffer_length,
                              SQLLEN* indicator_ptr) {
-  assert(m_is_app_descriptor);
-  assert(m_is_writable);
+  assert(is_app_descriptor_);
+  assert(is_writable_);
 
   // The set of records auto-expands to the supplied record number.
-  if (m_records.size() < record_number) {
-    m_records.resize(record_number);
+  if (records_.size() < record_number) {
+    records_.resize(record_number);
   }
 
   SQLSMALLINT zero_based_record_index = record_number - 1;
-  DescriptorRecord& record = m_records[zero_based_record_index];
+  DescriptorRecord& record = records_[zero_based_record_index];
 
-  record.m_type = c_type;
-  record.m_indicator_ptr = indicator_ptr;
-  record.m_length = buffer_length;
+  record.type = c_type;
+  record.indicator_ptr = indicator_ptr;
+  record.length = buffer_length;
 
   // Initialize default precision and scale for SQL_C_NUMERIC.
-  if (record.m_type == SQL_C_NUMERIC) {
-    record.m_precision = 38;
-    record.m_scale = 0;
+  if (record.type == SQL_C_NUMERIC) {
+    record.precision = 38;
+    record.scale = 0;
   }
   SetDataPtrOnRecord(data_ptr, record_number);
 }
 
 void ODBCDescriptor::SetDataPtrOnRecord(SQLPOINTER data_ptr, SQLSMALLINT record_number) {
-  assert(record_number <= m_records.size());
-  DescriptorRecord& record = m_records[record_number - 1];
+  assert(record_number <= records_.size());
+  DescriptorRecord& record = records_[record_number - 1];
   if (data_ptr) {
     record.CheckConsistency();
-    record.m_is_bound = true;
+    record.is_bound = true;
   } else {
-    record.m_is_bound = false;
+    record.is_bound = false;
   }
-  record.m_data_ptr = data_ptr;
+  record.data_ptr = data_ptr;
 
   // Bookkeeping on the highest bound record (used for returning SQL_DESC_COUNT)
-  if (m_highest_one_based_bound_record < record_number && data_ptr) {
-    m_highest_one_based_bound_record = record_number;
-  } else if (m_highest_one_based_bound_record == record_number && !data_ptr) {
-    m_highest_one_based_bound_record = CalculateHighestBoundRecord(m_records);
+  if (highest_one_based_bound_record_ < record_number && data_ptr) {
+    highest_one_based_bound_record_ = record_number;
+  } else if (highest_one_based_bound_record_ == record_number && !data_ptr) {
+    highest_one_based_bound_record_ = CalculateHighestBoundRecord(records_);
   }
-  m_has_bindings_changed = true;
+  has_bindings_changed_ = true;
 }
 
 void DescriptorRecord::CheckConsistency() {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_environment.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_environment.cc
@@ -36,49 +36,49 @@ using driver::odbcabstraction::Driver;
 // Public
 // =========================================================================================
 ODBCEnvironment::ODBCEnvironment(std::shared_ptr<Driver> driver)
-    : m_driver(std::move(driver)),
-      m_diagnostics(new Diagnostics(m_driver->GetDiagnostics().GetVendor(),
-                                    m_driver->GetDiagnostics().GetDataSourceComponent(),
-                                    driver::odbcabstraction::V_2)),
-      m_version(SQL_OV_ODBC2),
-      m_connection_pooling(SQL_CP_OFF) {}
+    : driver_(std::move(driver)),
+      diagnostics_(new Diagnostics(driver_->GetDiagnostics().GetVendor(),
+                                   driver_->GetDiagnostics().GetDataSourceComponent(),
+                                   driver::odbcabstraction::V_2)),
+      version_(SQL_OV_ODBC2),
+      connection_pooling_(SQL_CP_OFF) {}
 
-Diagnostics& ODBCEnvironment::GetDiagnosticsImpl() { return *m_diagnostics; }
+Diagnostics& ODBCEnvironment::GetDiagnosticsImpl() { return *diagnostics_; }
 
-SQLINTEGER ODBCEnvironment::GetODBCVersion() const { return m_version; }
+SQLINTEGER ODBCEnvironment::GetODBCVersion() const { return version_; }
 
 void ODBCEnvironment::SetODBCVersion(SQLINTEGER version) {
-  if (version != m_version) {
-    m_version = version;
-    m_diagnostics.reset(new Diagnostics(
-        m_diagnostics->GetVendor(), m_diagnostics->GetDataSourceComponent(),
-        version == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
-                                : driver::odbcabstraction::V_3));
+  if (version != version_) {
+    version_ = version;
+    diagnostics_.reset(
+        new Diagnostics(diagnostics_->GetVendor(), diagnostics_->GetDataSourceComponent(),
+                        version == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
+                                                : driver::odbcabstraction::V_3));
   }
 }
 
-SQLINTEGER ODBCEnvironment::GetConnectionPooling() const { return m_connection_pooling; }
+SQLINTEGER ODBCEnvironment::GetConnectionPooling() const { return connection_pooling_; }
 
 void ODBCEnvironment::SetConnectionPooling(SQLINTEGER connection_pooling) {
-  m_connection_pooling = connection_pooling;
+  connection_pooling_ = connection_pooling;
 }
 
 std::shared_ptr<ODBCConnection> ODBCEnvironment::CreateConnection() {
-  std::shared_ptr<Connection> spi_connection = m_driver->CreateConnection(
-      m_version == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
-                                : driver::odbcabstraction::V_3);
+  std::shared_ptr<Connection> spi_connection =
+      driver_->CreateConnection(version_ == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
+                                                         : driver::odbcabstraction::V_3);
   std::shared_ptr<ODBCConnection> new_conn =
       std::make_shared<ODBCConnection>(*this, spi_connection);
-  m_connections.push_back(new_conn);
+  connections_.push_back(new_conn);
   return new_conn;
 }
 
 void ODBCEnvironment::DropConnection(ODBCConnection* conn) {
-  auto it = std::find_if(m_connections.begin(), m_connections.end(),
+  auto it = std::find_if(connections_.begin(), connections_.end(),
                          [&conn](const std::shared_ptr<ODBCConnection>& connection) {
                            return connection.get() == conn;
                          });
-  if (m_connections.end() != it) {
-    m_connections.erase(it);
+  if (connections_.end() != it) {
+    connections_.erase(it);
   }
 }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
@@ -55,11 +55,11 @@ void DescriptorToHandle(SQLPOINTER output, ODBCDescriptor* descriptor,
 }
 
 size_t GetLength(const DescriptorRecord& record) {
-  switch (record.m_type) {
+  switch (record.type) {
     case SQL_C_CHAR:
     case SQL_C_WCHAR:
     case SQL_C_BINARY:
-      return record.m_length;
+      return record.length;
 
     case SQL_C_BIT:
     case SQL_C_TINYINT:
@@ -113,12 +113,12 @@ size_t GetLength(const DescriptorRecord& record) {
     case SQL_C_INTERVAL_MONTH:
       return sizeof(SQL_INTERVAL_STRUCT);
     default:
-      return record.m_length;
+      return record.length;
   }
 }
 
 SQLSMALLINT getc_typeForSQLType(const DescriptorRecord& record) {
-  switch (record.m_concise_type) {
+  switch (record.concise_type) {
     case SQL_CHAR:
     case SQL_VARCHAR:
     case SQL_LONGVARCHAR:
@@ -138,16 +138,16 @@ SQLSMALLINT getc_typeForSQLType(const DescriptorRecord& record) {
       return SQL_C_BINARY;
 
     case SQL_TINYINT:
-      return record.m_unsigned ? SQL_C_UTINYINT : SQL_C_STINYINT;
+      return record.is_unsigned ? SQL_C_UTINYINT : SQL_C_STINYINT;
 
     case SQL_SMALLINT:
-      return record.m_unsigned ? SQL_C_USHORT : SQL_C_SSHORT;
+      return record.is_unsigned ? SQL_C_USHORT : SQL_C_SSHORT;
 
     case SQL_INTEGER:
-      return record.m_unsigned ? SQL_C_ULONG : SQL_C_SLONG;
+      return record.is_unsigned ? SQL_C_ULONG : SQL_C_SLONG;
 
     case SQL_BIGINT:
-      return record.m_unsigned ? SQL_C_UBIGINT : SQL_C_SBIGINT;
+      return record.is_unsigned ? SQL_C_UBIGINT : SQL_C_SBIGINT;
 
     case SQL_NUMERIC:
     case SQL_DECIMAL:
@@ -203,7 +203,7 @@ SQLSMALLINT getc_typeForSQLType(const DescriptorRecord& record) {
       return SQL_C_INTERVAL_MONTH;
 
     default:
-      throw DriverException("Unknown SQL type: " + std::to_string(record.m_concise_type),
+      throw DriverException("Unknown SQL type: " + std::to_string(record.concise_type),
                             "HY003");
   }
 }
@@ -222,35 +222,35 @@ void CopyAttribute(Statement& source, Statement& target,
 ODBCStatement::ODBCStatement(
     ODBCConnection& connection,
     std::shared_ptr<driver::odbcabstraction::Statement> spi_statement)
-    : m_connection(connection),
-      m_spi_statement(std::move(spi_statement)),
-      m_diagnostics(&m_spi_statement->GetDiagnostics()),
-      m_built_in_ard(std::make_shared<ODBCDescriptor>(m_spi_statement->GetDiagnostics(),
-                                                      nullptr, this, true, true,
-                                                      connection.IsOdbc2Connection())),
-      m_built_in_apd(std::make_shared<ODBCDescriptor>(m_spi_statement->GetDiagnostics(),
-                                                      nullptr, this, true, true,
-                                                      connection.IsOdbc2Connection())),
-      m_ipd(std::make_shared<ODBCDescriptor>(m_spi_statement->GetDiagnostics(), nullptr,
-                                             this, false, true,
-                                             connection.IsOdbc2Connection())),
-      m_ird(std::make_shared<ODBCDescriptor>(m_spi_statement->GetDiagnostics(), nullptr,
-                                             this, false, false,
-                                             connection.IsOdbc2Connection())),
-      m_current_ard(m_built_in_apd.get()),
-      m_current_apd(m_built_in_apd.get()),
-      m_row_number(0),
-      m_max_rows(0),
-      m_rowset_size(1),
-      m_is_prepared(false),
-      m_has_reached_end_of_result(false) {}
+    : connection_(connection),
+      spi_statement_(std::move(spi_statement)),
+      diagnostics_(&spi_statement_->GetDiagnostics()),
+      built_in_ard_(std::make_shared<ODBCDescriptor>(spi_statement_->GetDiagnostics(),
+                                                     nullptr, this, true, true,
+                                                     connection.IsOdbc2Connection())),
+      built_in_apd_(std::make_shared<ODBCDescriptor>(spi_statement_->GetDiagnostics(),
+                                                     nullptr, this, true, true,
+                                                     connection.IsOdbc2Connection())),
+      ipd_(std::make_shared<ODBCDescriptor>(spi_statement_->GetDiagnostics(), nullptr,
+                                            this, false, true,
+                                            connection.IsOdbc2Connection())),
+      ird_(std::make_shared<ODBCDescriptor>(spi_statement_->GetDiagnostics(), nullptr,
+                                            this, false, false,
+                                            connection.IsOdbc2Connection())),
+      current_ard_(built_in_apd_.get()),
+      current_apd_(built_in_apd_.get()),
+      row_number_(0),
+      max_rows_(0),
+      rowset_size_(1),
+      is_prepared_(false),
+      has_reached_end_of_result_(false) {}
 
-ODBCConnection& ODBCStatement::GetConnection() { return m_connection; }
+ODBCConnection& ODBCStatement::GetConnection() { return connection_; }
 
 void ODBCStatement::CopyAttributesFromConnection(ODBCConnection& connection) {
   ODBCStatement& tracking_statement = connection.GetTrackingStatement();
 
-  // Get abstraction attributes and copy to this m_spi_statement.
+  // Get abstraction attributes and copy to this spi_statement_.
   // Possible ODBC attributes are below, but many of these are not supported by warpdrive
   // or ODBCAbstaction:
   // SQL_ATTR_ASYNC_ENABLE:
@@ -265,90 +265,90 @@ void ODBCStatement::CopyAttributesFromConnection(ODBCConnection& connection) {
   // SQL_ATTR_RETRIEVE_DATA:
   // SQL_ATTR_SIMULATE_CURSOR:
   // SQL_ATTR_USE_BOOKMARKS:
-  CopyAttribute(*tracking_statement.m_spi_statement, *m_spi_statement,
+  CopyAttribute(*tracking_statement.spi_statement_, *spi_statement_,
                 Statement::METADATA_ID);
-  CopyAttribute(*tracking_statement.m_spi_statement, *m_spi_statement,
+  CopyAttribute(*tracking_statement.spi_statement_, *spi_statement_,
                 Statement::MAX_LENGTH);
-  CopyAttribute(*tracking_statement.m_spi_statement, *m_spi_statement, Statement::NOSCAN);
-  CopyAttribute(*tracking_statement.m_spi_statement, *m_spi_statement,
+  CopyAttribute(*tracking_statement.spi_statement_, *spi_statement_, Statement::NOSCAN);
+  CopyAttribute(*tracking_statement.spi_statement_, *spi_statement_,
                 Statement::QUERY_TIMEOUT);
 
   // SQL_ATTR_ROW_BIND_TYPE:
-  m_current_ard->SetHeaderField(
+  current_ard_->SetHeaderField(
       SQL_DESC_BIND_TYPE,
       reinterpret_cast<SQLPOINTER>(
-          static_cast<SQLLEN>(tracking_statement.m_current_ard->GetBoundStructOffset())),
+          static_cast<SQLLEN>(tracking_statement.current_ard_->GetBoundStructOffset())),
       0);
 }
 
-bool ODBCStatement::IsPrepared() const { return m_is_prepared; }
+bool ODBCStatement::IsPrepared() const { return is_prepared_; }
 
 void ODBCStatement::Prepare(const std::string& query) {
   boost::optional<std::shared_ptr<ResultSetMetadata> > metadata =
-      m_spi_statement->Prepare(query);
+      spi_statement_->Prepare(query);
 
   if (metadata) {
-    m_ird->PopulateFromResultSetMetadata(metadata->get());
+    ird_->PopulateFromResultSetMetadata(metadata->get());
   }
-  m_is_prepared = true;
+  is_prepared_ = true;
 }
 
 void ODBCStatement::ExecutePrepared() {
-  if (!m_is_prepared) {
+  if (!is_prepared_) {
     throw DriverException("Function sequence error", "HY010");
   }
 
-  if (m_spi_statement->ExecutePrepared()) {
-    m_current_result = m_spi_statement->GetResultSet();
-    m_ird->PopulateFromResultSetMetadata(
-        m_spi_statement->GetResultSet()->GetMetadata().get());
-    m_has_reached_end_of_result = false;
+  if (spi_statement_->ExecutePrepared()) {
+    current_result_ = spi_statement_->GetResultSet();
+    ird_->PopulateFromResultSetMetadata(
+        spi_statement_->GetResultSet()->GetMetadata().get());
+    has_reached_end_of_result_ = false;
   }
 }
 
 void ODBCStatement::ExecuteDirect(const std::string& query) {
-  if (m_spi_statement->Execute(query)) {
-    m_current_result = m_spi_statement->GetResultSet();
-    m_ird->PopulateFromResultSetMetadata(m_current_result->GetMetadata().get());
-    m_has_reached_end_of_result = false;
+  if (spi_statement_->Execute(query)) {
+    current_result_ = spi_statement_->GetResultSet();
+    ird_->PopulateFromResultSetMetadata(current_result_->GetMetadata().get());
+    has_reached_end_of_result_ = false;
   }
 
   // Direct execution wipes out the prepared state.
-  m_is_prepared = false;
+  is_prepared_ = false;
 }
 
 bool ODBCStatement::Fetch(size_t rows, SQLULEN* row_count_ptr,
                           SQLUSMALLINT* row_status_array) {
-  if (m_has_reached_end_of_result) {
-    m_ird->SetRowsProcessed(0);
+  if (has_reached_end_of_result_) {
+    ird_->SetRowsProcessed(0);
     return false;
   }
 
-  if (m_max_rows) {
-    rows = std::min(rows, m_max_rows - m_row_number);
+  if (max_rows_) {
+    rows = std::min(rows, max_rows_ - row_number_);
   }
 
-  if (m_current_ard->HaveBindingsChanged()) {
+  if (current_ard_->HaveBindingsChanged()) {
     // TODO: Deal handle when offset != buffer_length.
 
     // Wipe out all bindings in the ResultSet.
     // Note that the number of ARD records can both be more or less
     // than the number of columns.
-    for (size_t i = 0; i < m_ird->GetRecords().size(); i++) {
-      if (i < m_current_ard->GetRecords().size() &&
-          m_current_ard->GetRecords()[i].m_is_bound) {
-        const DescriptorRecord& ard_record = m_current_ard->GetRecords()[i];
-        m_current_result->BindColumn(i + 1, ard_record.m_type, ard_record.m_precision,
-                                     ard_record.m_scale, ard_record.m_data_ptr,
-                                     GetLength(ard_record), ard_record.m_indicator_ptr);
+    for (size_t i = 0; i < ird_->GetRecords().size(); i++) {
+      if (i < current_ard_->GetRecords().size() &&
+          current_ard_->GetRecords()[i].is_bound) {
+        const DescriptorRecord& ard_record = current_ard_->GetRecords()[i];
+        current_result_->BindColumn(i + 1, ard_record.type, ard_record.precision,
+                                    ard_record.scale, ard_record.data_ptr,
+                                    GetLength(ard_record), ard_record.indicator_ptr);
       } else {
-        m_current_result->BindColumn(i + 1,
-                                     driver::odbcabstraction::CDataType_CHAR
-                                     /* arbitrary type, not used */,
-                                     0, 0, nullptr, 0, nullptr);
+        current_result_->BindColumn(i + 1,
+                                    driver::odbcabstraction::CDataType_CHAR
+                                    /* arbitrary type, not used */,
+                                    0, 0, nullptr, 0, nullptr);
       }
     }
-    m_current_ard->NotifyBindingsHavePropagated();
+    current_ard_->NotifyBindingsHavePropagated();
   }
 
   uint16_t* array_status_ptr;
@@ -356,21 +356,21 @@ bool ODBCStatement::Fetch(size_t rows, SQLULEN* row_count_ptr,
     // For SQLExtendedFetch only
     array_status_ptr = row_status_array;
   } else {
-    array_status_ptr = m_ird->GetArrayStatusPtr();
+    array_status_ptr = ird_->GetArrayStatusPtr();
   }
 
   size_t rows_fetched =
-      m_current_result->Move(rows, m_current_ard->GetBindOffset(),
-                             m_current_ard->GetBoundStructOffset(), array_status_ptr);
-  m_ird->SetRowsProcessed(static_cast<SQLULEN>(rows_fetched));
+      current_result_->Move(rows, current_ard_->GetBindOffset(),
+                            current_ard_->GetBoundStructOffset(), array_status_ptr);
+  ird_->SetRowsProcessed(static_cast<SQLULEN>(rows_fetched));
 
   if (row_count_ptr) {
     // For SQLExtendedFetch only
     *row_count_ptr = rows_fetched;
   }
 
-  m_row_number += rows_fetched;
-  m_has_reached_end_of_result = rows_fetched != rows;
+  row_number_ += rows_fetched;
+  has_reached_end_of_result_ = rows_fetched != rows;
   return rows_fetched != 0;
 }
 
@@ -382,62 +382,58 @@ void ODBCStatement::GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER outpu
   switch (statement_attribute) {
     // Descriptor accessor attributes
     case SQL_ATTR_APP_PARAM_DESC:
-      DescriptorToHandle(output, m_current_apd, str_len_ptr);
+      DescriptorToHandle(output, current_apd_, str_len_ptr);
       return;
     case SQL_ATTR_APP_ROW_DESC:
-      DescriptorToHandle(output, m_current_ard, str_len_ptr);
+      DescriptorToHandle(output, current_ard_, str_len_ptr);
       return;
     case SQL_ATTR_IMP_PARAM_DESC:
-      DescriptorToHandle(output, m_ipd.get(), str_len_ptr);
+      DescriptorToHandle(output, ipd_.get(), str_len_ptr);
       return;
     case SQL_ATTR_IMP_ROW_DESC:
-      DescriptorToHandle(output, m_ird.get(), str_len_ptr);
+      DescriptorToHandle(output, ird_.get(), str_len_ptr);
       return;
 
     // Attributes that are descriptor fields
     case SQL_ATTR_PARAM_BIND_OFFSET_PTR:
-      m_current_apd->GetHeaderField(SQL_DESC_BIND_OFFSET_PTR, output, buffer_size,
-                                    str_len_ptr);
+      current_apd_->GetHeaderField(SQL_DESC_BIND_OFFSET_PTR, output, buffer_size,
+                                   str_len_ptr);
       return;
     case SQL_ATTR_PARAM_BIND_TYPE:
-      m_current_apd->GetHeaderField(SQL_DESC_BIND_TYPE, output, buffer_size, str_len_ptr);
+      current_apd_->GetHeaderField(SQL_DESC_BIND_TYPE, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_PARAM_OPERATION_PTR:
-      m_current_apd->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size,
-                                    str_len_ptr);
+      current_apd_->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size,
+                                   str_len_ptr);
       return;
     case SQL_ATTR_PARAM_STATUS_PTR:
-      m_ipd->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size, str_len_ptr);
+      ipd_->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_PARAMS_PROCESSED_PTR:
-      m_ipd->GetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, output, buffer_size,
-                            str_len_ptr);
+      ipd_->GetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_PARAMSET_SIZE:
-      m_current_apd->GetHeaderField(SQL_DESC_ARRAY_SIZE, output, buffer_size,
-                                    str_len_ptr);
+      current_apd_->GetHeaderField(SQL_DESC_ARRAY_SIZE, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_ROW_ARRAY_SIZE:
-      m_current_ard->GetHeaderField(SQL_DESC_ARRAY_SIZE, output, buffer_size,
-                                    str_len_ptr);
+      current_ard_->GetHeaderField(SQL_DESC_ARRAY_SIZE, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_ROW_BIND_OFFSET_PTR:
-      m_current_ard->GetHeaderField(SQL_DESC_BIND_OFFSET_PTR, output, buffer_size,
-                                    str_len_ptr);
+      current_ard_->GetHeaderField(SQL_DESC_BIND_OFFSET_PTR, output, buffer_size,
+                                   str_len_ptr);
       return;
     case SQL_ATTR_ROW_BIND_TYPE:
-      m_current_ard->GetHeaderField(SQL_DESC_BIND_TYPE, output, buffer_size, str_len_ptr);
+      current_ard_->GetHeaderField(SQL_DESC_BIND_TYPE, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_ROW_OPERATION_PTR:
-      m_current_ard->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size,
-                                    str_len_ptr);
+      current_ard_->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size,
+                                   str_len_ptr);
       return;
     case SQL_ATTR_ROW_STATUS_PTR:
-      m_ird->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size, str_len_ptr);
+      ird_->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_ROWS_FETCHED_PTR:
-      m_ird->GetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, output, buffer_size,
-                            str_len_ptr);
+      ird_->GetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, output, buffer_size, str_len_ptr);
       return;
 
     case SQL_ATTR_ASYNC_ENABLE:
@@ -485,7 +481,7 @@ void ODBCStatement::GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER outpu
       return;
 
     case SQL_ATTR_ROW_NUMBER:
-      GetAttribute(static_cast<SQLULEN>(m_row_number), output, buffer_size, str_len_ptr);
+      GetAttribute(static_cast<SQLULEN>(row_number_), output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_SIMULATE_CURSOR:
       GetAttribute(static_cast<SQLULEN>(SQL_SC_UNIQUE), output, buffer_size, str_len_ptr);
@@ -498,27 +494,27 @@ void ODBCStatement::GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER outpu
                    str_len_ptr);
       return;
     case SQL_ATTR_MAX_ROWS:
-      GetAttribute(static_cast<SQLULEN>(m_max_rows), output, buffer_size, str_len_ptr);
+      GetAttribute(static_cast<SQLULEN>(max_rows_), output, buffer_size, str_len_ptr);
       return;
     case SQL_ATTR_RETRIEVE_DATA:
       GetAttribute(static_cast<SQLULEN>(SQL_RD_ON), output, buffer_size, str_len_ptr);
       return;
     case SQL_ROWSET_SIZE:
-      GetAttribute(static_cast<SQLULEN>(m_rowset_size), output, buffer_size, str_len_ptr);
+      GetAttribute(static_cast<SQLULEN>(rowset_size_), output, buffer_size, str_len_ptr);
       return;
 
     // Driver-level statement attributes. These are all SQLULEN attributes.
     case SQL_ATTR_MAX_LENGTH:
-      spi_attribute = m_spi_statement->GetAttribute(Statement::MAX_LENGTH);
+      spi_attribute = spi_statement_->GetAttribute(Statement::MAX_LENGTH);
       break;
     case SQL_ATTR_METADATA_ID:
-      spi_attribute = m_spi_statement->GetAttribute(Statement::METADATA_ID);
+      spi_attribute = spi_statement_->GetAttribute(Statement::METADATA_ID);
       break;
     case SQL_ATTR_NOSCAN:
-      spi_attribute = m_spi_statement->GetAttribute(Statement::NOSCAN);
+      spi_attribute = spi_statement_->GetAttribute(Statement::NOSCAN);
       break;
     case SQL_ATTR_QUERY_TIMEOUT:
-      spi_attribute = m_spi_statement->GetAttribute(Statement::QUERY_TIMEOUT);
+      spi_attribute = spi_statement_->GetAttribute(Statement::QUERY_TIMEOUT);
       break;
     default:
       throw DriverException(
@@ -543,12 +539,12 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
   switch (statement_attribute) {
     case SQL_ATTR_APP_PARAM_DESC: {
       ODBCDescriptor* desc = static_cast<ODBCDescriptor*>(value);
-      if (m_current_apd != desc) {
-        if (m_current_apd != m_built_in_apd.get()) {
-          m_current_apd->DetachFromStatement(this, true);
+      if (current_apd_ != desc) {
+        if (current_apd_ != built_in_apd_.get()) {
+          current_apd_->DetachFromStatement(this, true);
         }
-        m_current_apd = desc;
-        if (m_current_apd != m_built_in_apd.get()) {
+        current_apd_ = desc;
+        if (current_apd_ != built_in_apd_.get()) {
           desc->RegisterToStatement(this, true);
         }
       }
@@ -556,12 +552,12 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
     }
     case SQL_ATTR_APP_ROW_DESC: {
       ODBCDescriptor* desc = static_cast<ODBCDescriptor*>(value);
-      if (m_current_ard != desc) {
-        if (m_current_ard != m_built_in_ard.get()) {
-          m_current_ard->DetachFromStatement(this, false);
+      if (current_ard_ != desc) {
+        if (current_ard_ != built_in_ard_.get()) {
+          current_ard_->DetachFromStatement(this, false);
         }
-        m_current_ard = desc;
-        if (m_current_ard != m_built_in_ard.get()) {
+        current_ard_ = desc;
+        if (current_ard_ != built_in_ard_.get()) {
           desc->RegisterToStatement(this, false);
         }
       }
@@ -573,40 +569,40 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
       throw DriverException("Cannot assign implementation descriptor.", "HY017");
       // Attributes that are descriptor fields
     case SQL_ATTR_PARAM_BIND_OFFSET_PTR:
-      m_current_apd->SetHeaderField(SQL_DESC_BIND_OFFSET_PTR, value, buffer_size);
+      current_apd_->SetHeaderField(SQL_DESC_BIND_OFFSET_PTR, value, buffer_size);
       return;
     case SQL_ATTR_PARAM_BIND_TYPE:
-      m_current_apd->SetHeaderField(SQL_DESC_BIND_TYPE, value, buffer_size);
+      current_apd_->SetHeaderField(SQL_DESC_BIND_TYPE, value, buffer_size);
       return;
     case SQL_ATTR_PARAM_OPERATION_PTR:
-      m_current_apd->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
+      current_apd_->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
       return;
     case SQL_ATTR_PARAM_STATUS_PTR:
-      m_ipd->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
+      ipd_->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
       return;
     case SQL_ATTR_PARAMS_PROCESSED_PTR:
-      m_ipd->SetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, value, buffer_size);
+      ipd_->SetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, value, buffer_size);
       return;
     case SQL_ATTR_PARAMSET_SIZE:
-      m_current_apd->SetHeaderField(SQL_DESC_ARRAY_SIZE, value, buffer_size);
+      current_apd_->SetHeaderField(SQL_DESC_ARRAY_SIZE, value, buffer_size);
       return;
     case SQL_ATTR_ROW_ARRAY_SIZE:
-      m_current_ard->SetHeaderField(SQL_DESC_ARRAY_SIZE, value, buffer_size);
+      current_ard_->SetHeaderField(SQL_DESC_ARRAY_SIZE, value, buffer_size);
       return;
     case SQL_ATTR_ROW_BIND_OFFSET_PTR:
-      m_current_ard->SetHeaderField(SQL_DESC_BIND_OFFSET_PTR, value, buffer_size);
+      current_ard_->SetHeaderField(SQL_DESC_BIND_OFFSET_PTR, value, buffer_size);
       return;
     case SQL_ATTR_ROW_BIND_TYPE:
-      m_current_ard->SetHeaderField(SQL_DESC_BIND_TYPE, value, buffer_size);
+      current_ard_->SetHeaderField(SQL_DESC_BIND_TYPE, value, buffer_size);
       return;
     case SQL_ATTR_ROW_OPERATION_PTR:
-      m_current_ard->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
+      current_ard_->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
       return;
     case SQL_ATTR_ROW_STATUS_PTR:
-      m_ird->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
+      ird_->SetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, value, buffer_size);
       return;
     case SQL_ATTR_ROWS_FETCHED_PTR:
-      m_ird->SetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, value, buffer_size);
+      ird_->SetHeaderField(SQL_DESC_ROWS_PROCESSED_PTR, value, buffer_size);
       return;
 
     case SQL_ATTR_ASYNC_ENABLE:
@@ -661,7 +657,7 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
       CheckIfAttributeIsSetToOnlyValidValue(value, static_cast<SQLULEN>(SQL_RD_ON));
       return;
     case SQL_ROWSET_SIZE:
-      SetAttribute(value, m_rowset_size);
+      SetAttribute(value, rowset_size_);
       return;
 
     case SQL_ATTR_MAX_ROWS:
@@ -671,22 +667,22 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
     case SQL_ATTR_MAX_LENGTH:
       SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spi_statement->SetAttribute(Statement::MAX_LENGTH, attribute_to_write);
+          spi_statement_->SetAttribute(Statement::MAX_LENGTH, attribute_to_write);
       break;
     case SQL_ATTR_METADATA_ID:
       SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spi_statement->SetAttribute(Statement::METADATA_ID, attribute_to_write);
+          spi_statement_->SetAttribute(Statement::METADATA_ID, attribute_to_write);
       break;
     case SQL_ATTR_NOSCAN:
       SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spi_statement->SetAttribute(Statement::NOSCAN, attribute_to_write);
+          spi_statement_->SetAttribute(Statement::NOSCAN, attribute_to_write);
       break;
     case SQL_ATTR_QUERY_TIMEOUT:
       SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spi_statement->SetAttribute(Statement::QUERY_TIMEOUT, attribute_to_write);
+          spi_statement_->SetAttribute(Statement::QUERY_TIMEOUT, attribute_to_write);
       break;
     default:
       throw DriverException("Invalid attribute: " + std::to_string(attribute_to_write),
@@ -700,26 +696,26 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
 
 void ODBCStatement::RevertAppDescriptor(bool isApd) {
   if (isApd) {
-    m_current_apd = m_built_in_apd.get();
+    current_apd_ = built_in_apd_.get();
   } else {
-    m_current_ard = m_built_in_ard.get();
+    current_ard_ = built_in_ard_.get();
   }
 }
 
 void ODBCStatement::CloseCursor(bool suppress_errors) {
-  if (!suppress_errors && !m_current_result) {
+  if (!suppress_errors && !current_result_) {
     throw DriverException("Invalid cursor state", "24000");
   }
 
-  if (m_current_result) {
-    m_current_result->Close();
-    m_current_result = nullptr;
+  if (current_result_) {
+    current_result_->Close();
+    current_result_ = nullptr;
   }
 
   // Reset the fetching state of this statement.
-  m_current_ard->NotifyBindingsHaveChanged();
-  m_row_number = 0;
-  m_has_reached_end_of_result = false;
+  current_ard_->NotifyBindingsHaveChanged();
+  row_number_ = 0;
+  has_reached_end_of_result_ = false;
 }
 
 SQLRETURN ODBCStatement::GetData(SQLSMALLINT record_number, SQLSMALLINT c_type,
@@ -727,7 +723,7 @@ SQLRETURN ODBCStatement::GetData(SQLSMALLINT record_number, SQLSMALLINT c_type,
                                  SQLLEN* indicator_ptr) {
   if (record_number == 0) {
     throw DriverException("Bookmarks are not supported", "07009");
-  } else if (record_number > m_ird->GetRecords().size()) {
+  } else if (record_number > ird_->GetRecords().size()) {
     throw DriverException("Invalid column index: " + std::to_string(record_number),
                           "07009");
   }
@@ -739,36 +735,36 @@ SQLRETURN ODBCStatement::GetData(SQLSMALLINT record_number, SQLSMALLINT c_type,
   int scale = 0;
 
   if (c_type == SQL_ARD_TYPE) {
-    if (record_number > m_current_ard->GetRecords().size()) {
+    if (record_number > current_ard_->GetRecords().size()) {
       throw DriverException("Invalid column index: " + std::to_string(record_number),
                             "07009");
     }
-    const DescriptorRecord& record = m_current_ard->GetRecords()[record_number - 1];
-    evaluated_c_type = record.m_concise_type;
-    precision = record.m_precision;
-    scale = record.m_scale;
+    const DescriptorRecord& record = current_ard_->GetRecords()[record_number - 1];
+    evaluated_c_type = record.concise_type;
+    precision = record.precision;
+    scale = record.scale;
   }
 
   // Note: this is intentionally not an else if, since the type can be SQL_C_DEFAULT in
   // the ARD.
   if (evaluated_c_type == SQL_C_DEFAULT) {
-    if (record_number <= m_current_ard->GetRecords().size()) {
-      const DescriptorRecord& ard_record = m_current_ard->GetRecords()[record_number - 1];
-      precision = ard_record.m_precision;
-      scale = ard_record.m_scale;
+    if (record_number <= current_ard_->GetRecords().size()) {
+      const DescriptorRecord& ard_record = current_ard_->GetRecords()[record_number - 1];
+      precision = ard_record.precision;
+      scale = ard_record.scale;
     }
 
-    const DescriptorRecord& ird_record = m_ird->GetRecords()[record_number - 1];
+    const DescriptorRecord& ird_record = ird_->GetRecords()[record_number - 1];
     evaluated_c_type = getc_typeForSQLType(ird_record);
   }
 
-  return m_current_result->GetData(record_number, evaluated_c_type, precision, scale,
-                                   data_ptr, buffer_length, indicator_ptr);
+  return current_result_->GetData(record_number, evaluated_c_type, precision, scale,
+                                  data_ptr, buffer_length, indicator_ptr);
 }
 
 SQLRETURN ODBCStatement::GetMoreResults() {
   // Multiple result sets are not supported.
-  if (m_current_result) {
+  if (current_result_) {
     return SQL_NO_DATA;
   } else {
     throw DriverException("Function sequence error", "HY010");
@@ -781,7 +777,7 @@ void ODBCStatement::GetColumnCount(SQLSMALLINT* column_count_ptr) {
     // error
     return;
   }
-  size_t column_count = m_ird->GetRecords().size();
+  size_t column_count = ird_->GetRecords().size();
   *column_count_ptr = static_cast<SQLSMALLINT>(column_count);
 }
 
@@ -797,51 +793,51 @@ void ODBCStatement::GetRowCount(SQLLEN* row_count_ptr) {
 
 void ODBCStatement::ReleaseStatement() {
   CloseCursor(true);
-  m_connection.DropStatement(this);
+  connection_.DropStatement(this);
 }
 
 void ODBCStatement::GetTables(const std::string* catalog, const std::string* schema,
                               const std::string* table, const std::string* tableType) {
   CloseCursor(true);
-  if (m_connection.IsOdbc2Connection()) {
-    m_current_result = m_spi_statement->GetTables_V2(catalog, schema, table, tableType);
+  if (connection_.IsOdbc2Connection()) {
+    current_result_ = spi_statement_->GetTables_V2(catalog, schema, table, tableType);
   } else {
-    m_current_result = m_spi_statement->GetTables_V3(catalog, schema, table, tableType);
+    current_result_ = spi_statement_->GetTables_V3(catalog, schema, table, tableType);
   }
-  m_ird->PopulateFromResultSetMetadata(m_current_result->GetMetadata().get());
-  m_has_reached_end_of_result = false;
+  ird_->PopulateFromResultSetMetadata(current_result_->GetMetadata().get());
+  has_reached_end_of_result_ = false;
 
   // Direct execution wipes out the prepared state.
-  m_is_prepared = false;
+  is_prepared_ = false;
 }
 
 void ODBCStatement::GetColumns(const std::string* catalog, const std::string* schema,
                                const std::string* table, const std::string* column) {
   CloseCursor(true);
-  if (m_connection.IsOdbc2Connection()) {
-    m_current_result = m_spi_statement->GetColumns_V2(catalog, schema, table, column);
+  if (connection_.IsOdbc2Connection()) {
+    current_result_ = spi_statement_->GetColumns_V2(catalog, schema, table, column);
   } else {
-    m_current_result = m_spi_statement->GetColumns_V3(catalog, schema, table, column);
+    current_result_ = spi_statement_->GetColumns_V3(catalog, schema, table, column);
   }
-  m_ird->PopulateFromResultSetMetadata(m_current_result->GetMetadata().get());
-  m_has_reached_end_of_result = false;
+  ird_->PopulateFromResultSetMetadata(current_result_->GetMetadata().get());
+  has_reached_end_of_result_ = false;
 
   // Direct execution wipes out the prepared state.
-  m_is_prepared = false;
+  is_prepared_ = false;
 }
 
 void ODBCStatement::GetTypeInfo(SQLSMALLINT data_type) {
   CloseCursor(true);
-  if (m_connection.IsOdbc2Connection()) {
-    m_current_result = m_spi_statement->GetTypeInfo_V2(data_type);
+  if (connection_.IsOdbc2Connection()) {
+    current_result_ = spi_statement_->GetTypeInfo_V2(data_type);
   } else {
-    m_current_result = m_spi_statement->GetTypeInfo_V3(data_type);
+    current_result_ = spi_statement_->GetTypeInfo_V3(data_type);
   }
-  m_ird->PopulateFromResultSetMetadata(m_current_result->GetMetadata().get());
-  m_has_reached_end_of_result = false;
+  ird_->PopulateFromResultSetMetadata(current_result_->GetMetadata().get());
+  has_reached_end_of_result_ = false;
 
   // Direct execution wipes out the prepared state.
-  m_is_prepared = false;
+  is_prepared_ = false;
 }
 
-void ODBCStatement::Cancel() { m_spi_statement->Cancel(); }
+void ODBCStatement::Cancel() { spi_statement_->Cancel(); }

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -275,7 +275,7 @@ std::wstring FlightSQLODBCMockTestBase::GetQueryAllDataTypes() {
 }
 
 void FlightSQLODBCMockTestBase::CreateTestTables() {
-  ASSERT_OK(server->ExecuteSql(R"(
+  ASSERT_OK(server_->ExecuteSql(R"(
     CREATE TABLE TestTable (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     keyName varchar(100),
@@ -291,7 +291,7 @@ void FlightSQLODBCMockTestBase::CreateTableAllDataType() {
   // Limitation on mock SQLite server:
   // Only int64, float64, binary, and utf8 Arrow Types are supported by
   // SQLiteFlightSqlServer::Impl::DoGetTables
-  ASSERT_OK(server->ExecuteSql(R"(
+  ASSERT_OK(server_->ExecuteSql(R"(
     CREATE TABLE AllTypesTable(
     bigint_col INTEGER PRIMARY KEY AUTOINCREMENT,
     char_col varchar(100),
@@ -320,7 +320,7 @@ void FlightSQLODBCMockTestBase::CreateUnicodeTable() {
     INSERT INTO 数据 (资料) VALUES ('3rd Row');
   )")
                                .ValueOr("");
-  ASSERT_OK(server->ExecuteSql(unicodeSql));
+  ASSERT_OK(server_->ExecuteSql(unicodeSql));
 }
 
 void FlightSQLODBCMockTestBase::SetUp() {
@@ -329,16 +329,16 @@ void FlightSQLODBCMockTestBase::SetUp() {
   options.auth_handler = std::make_unique<NoOpAuthHandler>();
   options.middleware.push_back(
       {"bearer-auth-server", std::make_shared<MockServerMiddlewareFactory>()});
-  ASSERT_OK_AND_ASSIGN(server,
+  ASSERT_OK_AND_ASSIGN(server_,
                        arrow::flight::sql::example::SQLiteFlightSqlServer::Create());
-  ASSERT_OK(server->Init(options));
+  ASSERT_OK(server_->Init(options));
 
-  port = server->port();
+  port = server_->port();
   ASSERT_OK_AND_ASSIGN(location, Location::ForGrpcTcp("localhost", port));
   ASSERT_OK_AND_ASSIGN(auto client, arrow::flight::FlightClient::Connect(location));
 }
 
-void FlightSQLODBCMockTestBase::TearDown() { ASSERT_OK(server->Shutdown()); }
+void FlightSQLODBCMockTestBase::TearDown() { ASSERT_OK(server_->Shutdown()); }
 
 bool CompareConnPropertyMap(Connection::ConnPropertyMap map1,
                             Connection::ConnPropertyMap map2) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -141,7 +141,7 @@ class FlightSQLODBCMockTestBase : public FlightSQLODBCRemoteTestBase {
   void TearDown() override;
 
  private:
-  std::shared_ptr<arrow::flight::sql::example::SQLiteFlightSqlServer> server;
+  std::shared_ptr<arrow::flight::sql::example::SQLiteFlightSqlServer> server_;
 };
 
 template <typename T>


### PR DESCRIPTION
### Rationale for this change
We want our code to adhere to Arrow's expected naming conventions.

### What changes are included in this PR?
Private/protected member variables are renamed from `m_member_var` to `member_var_`.
Public member variables are named `member_var` (without the `m_` prefix or `_` suffix).

### Are these changes tested?
N/A

### Are there any user-facing changes?
No
