### PR TITLE
Address code review comments for Arrow#40939

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include "arrow/array.h"
 
 namespace driver {
@@ -44,7 +45,7 @@ inline RowStatus MoveSingleCellToBinaryBuffer(ColumnBinding* binding, BinaryArra
 
   auto* byte_buffer =
       static_cast<unsigned char*>(binding->buffer) + i * binding->buffer_length;
-  memcpy(byte_buffer, ((char*)value) + value_offset, value_length);
+  std::memcpy(byte_buffer, ((char*)value) + value_offset, value_length);
 
   if (remaining_length > binding->buffer_length) {
     result = odbcabstraction::RowStatus_SUCCESS_WITH_INFO;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
@@ -44,7 +44,7 @@ inline size_t CopyFromArrayValuesToBinding(ARRAY_TYPE* array, ColumnBinding* bin
       }
     }
   } else {
-    // Duplicate above for loop to exit early when null value is found
+    // Duplicate above for-loop to exit early when null value is found
     for (int64_t i = starting_row; i < starting_row + cells; ++i) {
       if (array->IsNull(i)) {
         throw odbcabstraction::NullWithoutIndicatorException();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include "arrow/array.h"
 #include "arrow/flight/sql/odbc/flight_sql/accessors/types.h"
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/diagnostics.h"
@@ -55,7 +56,7 @@ inline size_t CopyFromArrayValuesToBinding(ARRAY_TYPE* array, ColumnBinding* bin
   // Note that the array should already have been sliced down to the same number
   // of elements in the ODBC data array by the point in which this function is called.
   const auto* values = array->raw_values();
-  memcpy(binding->buffer, &values[starting_row], element_size * cells);
+  std::memcpy(binding->buffer, &values[starting_row], element_size * cells);
 
   return cells;
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
@@ -43,7 +43,7 @@ inline size_t CopyFromArrayValuesToBinding(ARRAY_TYPE* array, ColumnBinding* bin
       }
     }
   } else {
-    // Duplicate this loop to avoid null checks within the loop.
+    // Duplicate above for loop to exit early when null value is found
     for (int64_t i = starting_row; i < starting_row + cells; ++i) {
       if (array->IsNull(i)) {
         throw odbcabstraction::NullWithoutIndicatorException();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.cc
@@ -18,6 +18,7 @@
 #include "arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.h"
 
 #include <boost/locale.hpp>
+#include <cstring>
 #include "arrow/array.h"
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/encoding.h"
 
@@ -88,7 +89,7 @@ inline RowStatus MoveSingleCellToCharBuffer(std::vector<uint8_t>& buffer,
 
   auto* byte_buffer = static_cast<char*>(binding->buffer) + i * binding->buffer_length;
   auto* char_buffer = (CHAR_TYPE*)byte_buffer;
-  memcpy(char_buffer, ((char*)value) + value_offset, value_length);
+  std::memcpy(char_buffer, ((char*)value) + value_offset, value_length);
 
   // Write a NUL terminator
   if (binding->buffer_length >= remaining_length + sizeof(CHAR_TYPE)) {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/get_info_cache.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/get_info_cache.cc
@@ -954,21 +954,21 @@ bool GetInfoCache::LoadInfoFromServer() {
               break;
             }
             case SqlInfoOptions::SQL_SUPPORTED_RESULT_SET_TYPES:
-              // Ignored. Warpdrive supports forward-only only.
+              // Ignored. Arrow ODBC supports forward-only only.
               break;
             case SqlInfoOptions::SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_UNSPECIFIED:
-              // Ignored. Warpdrive supports forward-only only.
+              // Ignored. Arrow ODBC supports forward-only only.
               break;
             case SqlInfoOptions::SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_FORWARD_ONLY:
-              // Ignored. Warpdrive supports forward-only only.
+              // Ignored. Arrow ODBC supports forward-only only.
               break;
             case SqlInfoOptions::
                 SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_SCROLL_SENSITIVE:
-              // Ignored. Warpdrive supports forward-only only.
+              // Ignored. Arrow ODBC supports forward-only only.
               break;
             case SqlInfoOptions::
                 SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_SCROLL_INSENSITIVE:
-              // Ignored. Warpdrive supports forward-only only.
+              // Ignored. Arrow ODBC supports forward-only only.
               break;
 
             // List<string> properties

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
@@ -50,7 +50,7 @@ inline SQLRETURN GetAttributeUTF8(const std::string_view& attribute_value,
   if (output) {
     size_t output_len_before_null =
         std::min(static_cast<O>(attribute_value.size()), static_cast<O>(output_size - 1));
-    memcpy(output, attribute_value.data(), output_len_before_null);
+    std::memcpy(output, attribute_value.data(), output_len_before_null);
     reinterpret_cast<char*>(output)[output_len_before_null] = '\0';
   }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/encoding_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/encoding_utils.h
@@ -45,7 +45,7 @@ inline size_t ConvertToSqlWChar(const std::string_view& str, SQLWCHAR* buffer,
   SQLLEN value_length_in_bytes = wstr.size();
 
   if (buffer) {
-    memcpy(buffer, wstr.data(),
+    std::memcpy(buffer, wstr.data(),
            std::min(static_cast<SQLLEN>(wstr.size()), buffer_size_in_bytes));
 
     // Write a NUL terminator

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/encoding_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/encoding_utils.h
@@ -46,7 +46,7 @@ inline size_t ConvertToSqlWChar(const std::string_view& str, SQLWCHAR* buffer,
 
   if (buffer) {
     std::memcpy(buffer, wstr.data(),
-           std::min(static_cast<SQLLEN>(wstr.size()), buffer_size_in_bytes));
+                std::min(static_cast<SQLLEN>(wstr.size()), buffer_size_in_bytes));
 
     // Write a NUL terminator
     if (buffer_size_in_bytes >=

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
@@ -251,7 +251,7 @@ void ODBCStatement::CopyAttributesFromConnection(ODBCConnection& connection) {
   ODBCStatement& tracking_statement = connection.GetTrackingStatement();
 
   // Get abstraction attributes and copy to this spi_statement_.
-  // Possible ODBC attributes are below, but many of these are not supported by warpdrive
+  // Possible ODBC attributes are below, but many of these are not supported by Arrow ODBC
   // or ODBCAbstaction:
   // SQL_ATTR_ASYNC_ENABLE:
   // SQL_ATTR_METADATA_ID:

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(ARROW_FLIGHT_SQL_MOCK_SERVER_SRCS
 add_arrow_test(flight_sql_odbc_test
                SOURCES
                columns_test.cc
+               connection_test.cc
                connection_attr_test.cc
                connection_info_test.cc
                errors_test.cc
@@ -40,8 +41,6 @@ add_arrow_test(flight_sql_odbc_test
                statement_test.cc
                tables_test.cc
                type_info_test.cc
-               # Connection test needs to be put last to resolve segfault issue
-               connection_test.cc
                odbc_test_suite.cc
                odbc_test_suite.h
                # Enable Protobuf cleanup after test execution

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -32,7 +32,6 @@ set(ARROW_FLIGHT_SQL_MOCK_SERVER_SRCS
 add_arrow_test(flight_sql_odbc_test
                SOURCES
                columns_test.cc
-               connection_test.cc
                connection_attr_test.cc
                connection_info_test.cc
                errors_test.cc
@@ -41,6 +40,8 @@ add_arrow_test(flight_sql_odbc_test
                statement_test.cc
                tables_test.cc
                type_info_test.cc
+               # Connection test needs to be put last to resolve segfault issue
+               connection_test.cc
                odbc_test_suite.cc
                odbc_test_suite.h
                # Enable Protobuf cleanup after test execution


### PR DESCRIPTION
Addresses the following code review comments:
https://github.com/apache/arrow/pull/40939#discussion_r2099120394

> What does this comment mean? It seems there is a null check inside the loop. 

https://github.com/apache/arrow/pull/40939#discussion_r2099120764 

> nits, but (1) std::memcpy, (2) include cstring?

https://github.com/apache/arrow/pull/40939#discussion_r2099146199 

> nit, but is the non-const reference meant to be an in-out parameter? I think that is OK but this function confusingly uses a mix of pointers and non-const references