### PR TITLE
Replace boost::optional with std::optional

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
@@ -26,6 +26,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 
+#include <optional>
 #include <utility>
 
 namespace arrow::flight::sql::odbc {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
@@ -76,7 +76,7 @@ class UserPasswordAuthMethod : public FlightSqlAuthMethod {
   void Authenticate(FlightSqlConnection& connection,
                     FlightCallOptions& call_options) override {
     FlightCallOptions auth_call_options;
-    const boost::optional<Connection::Attribute>& login_timeout =
+    const std::optional<Connection::Attribute>& login_timeout =
         connection.GetAttribute(Connection::LOGIN_TIMEOUT);
     if (login_timeout && boost::get<uint32_t>(*login_timeout) > 0) {
       // ODBC's LOGIN_TIMEOUT attribute and FlightCallOptions.timeout use

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
@@ -219,7 +219,7 @@ std::optional<int32_t> FlightSqlConnection::GetStringColumnLength(
         "01000", ODBCErrorCodes_GENERAL_WARNING);
   }
 
-  return boost::none;
+  return std::nullopt;
 }
 
 bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap& conn_property_map) {
@@ -398,12 +398,16 @@ std::optional<Connection::Attribute> FlightSqlConnection::GetAttribute(
   switch (attribute) {
     case ACCESS_MODE:
       // FlightSQL does not provide this metadata.
-      return boost::make_optional(Attribute(static_cast<uint32_t>(SQL_MODE_READ_WRITE)));
+      return std::make_optional(Attribute(static_cast<uint32_t>(SQL_MODE_READ_WRITE)));
     case PACKET_SIZE:
-      return boost::make_optional(Attribute(static_cast<uint32_t>(0)));
+      return std::make_optional(Attribute(static_cast<uint32_t>(0)));
     default:
       const auto& it = attribute_.find(attribute);
-      return boost::make_optional(it != attribute_.end(), it->second);
+      if (it != attribute_.end()) {
+        return std::make_optional(it->second);
+      } else {
+        return std::nullopt;
+      }
   }
 }
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
@@ -31,7 +31,6 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/exceptions.h"
 
 #include <sql.h>
@@ -205,7 +204,7 @@ void FlightSqlConnection::PopulateMetadataSettings(
   metadata_settings_.chunk_buffer_capacity = GetChunkBufferCapacity(conn_property_map);
 }
 
-boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(
+std::optional<int32_t> FlightSqlConnection::GetStringColumnLength(
     const Connection::ConnPropertyMap& conn_property_map) {
   const int32_t min_string_column_length = 1;
 
@@ -256,7 +255,7 @@ const FlightCallOptions& FlightSqlConnection::PopulateCallOptions(
     const ConnPropertyMap& props) {
   // Set CONNECTION_TIMEOUT attribute or LOGIN_TIMEOUT depending on if this
   // is the first request.
-  const boost::optional<Connection::Attribute>& connection_timeout =
+  const std::optional<Connection::Attribute>& connection_timeout =
       closed_ ? GetAttribute(LOGIN_TIMEOUT) : GetAttribute(CONNECTION_TIMEOUT);
   if (connection_timeout && boost::get<uint32_t>(*connection_timeout) > 0) {
     call_options_.timeout =
@@ -394,7 +393,7 @@ bool FlightSqlConnection::SetAttribute(Connection::AttributeId attribute,
   }
 }
 
-boost::optional<Connection::Attribute> FlightSqlConnection::GetAttribute(
+std::optional<Connection::Attribute> FlightSqlConnection::GetAttribute(
     Connection::AttributeId attribute) {
   switch (attribute) {
     case ACCESS_MODE:

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
@@ -19,6 +19,7 @@
 
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/connection.h"
 
+#include <optional>
 #include <vector>
 #include "arrow/flight/api.h"
 #include "arrow/flight/sql/api.h"
@@ -119,8 +120,7 @@ class FlightSqlConnection : public Connection {
   /// \note Visible for testing
   void SetClosed(bool is_closed);
 
-  std::optional<int32_t> GetStringColumnLength(
-      const ConnPropertyMap& conn_property_map);
+  std::optional<int32_t> GetStringColumnLength(const ConnPropertyMap& conn_property_map);
 
   bool GetUseWideChar(const ConnPropertyMap& conn_property_map);
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
@@ -91,7 +91,7 @@ class FlightSqlConnection : public Connection {
 
   bool SetAttribute(AttributeId attribute, const Attribute& value) override;
 
-  boost::optional<Connection::Attribute> GetAttribute(
+  std::optional<Connection::Attribute> GetAttribute(
       Connection::AttributeId attribute) override;
 
   Info GetInfo(uint16_t info_type) override;
@@ -119,7 +119,7 @@ class FlightSqlConnection : public Connection {
   /// \note Visible for testing
   void SetClosed(bool is_closed);
 
-  boost::optional<int32_t> GetStringColumnLength(
+  std::optional<int32_t> GetStringColumnLength(
       const ConnPropertyMap& conn_property_map);
 
   bool GetUseWideChar(const ConnPropertyMap& conn_property_map);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
@@ -30,7 +30,7 @@ TEST(AttributeTests, SetAndGetAttribute) {
   connection.SetClosed(false);
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(200));
-  const boost::optional<Connection::Attribute> first_value =
+  const std::optional<Connection::Attribute> first_value =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
   EXPECT_TRUE(first_value);
@@ -39,7 +39,7 @@ TEST(AttributeTests, SetAndGetAttribute) {
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(300));
 
-  const boost::optional<Connection::Attribute> change_value =
+  const std::optional<Connection::Attribute> change_value =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
   EXPECT_TRUE(change_value);
@@ -51,7 +51,7 @@ TEST(AttributeTests, SetAndGetAttribute) {
 TEST(AttributeTests, GetAttributeWithoutSetting) {
   FlightSqlConnection connection(OdbcVersion::V_3);
 
-  const boost::optional<Connection::Attribute> optional =
+  const std::optional<Connection::Attribute> optional =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
   connection.SetClosed(false);
 
@@ -76,7 +76,7 @@ TEST(MetadataSettingsTest, StringColumnLengthTest) {
        std::to_string(expected_string_column_length)},
   };
 
-  const boost::optional<int32_t> actual_string_column_length =
+  const std::optional<int32_t> actual_string_column_length =
       connection.GetStringColumnLength(properties);
 
   EXPECT_TRUE(actual_string_column_length);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
@@ -20,6 +20,8 @@
 #include "arrow/flight/types.h"
 #include "gtest/gtest.h"
 
+#include <optional>
+
 namespace arrow::flight::sql::odbc {
 
 using arrow::flight::Location;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
@@ -28,7 +28,7 @@
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h"
 #include "arrow/io/memory.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <utility>
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/exceptions.h"
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
@@ -108,13 +108,13 @@ bool FlightSqlStatement::SetAttribute(StatementAttributeId attribute,
   }
 }
 
-boost::optional<Statement::Attribute> FlightSqlStatement::GetAttribute(
+std::optional<Statement::Attribute> FlightSqlStatement::GetAttribute(
     StatementAttributeId attribute) {
   const auto& it = attribute_.find(attribute);
   return boost::make_optional(it != attribute_.end(), it->second);
 }
 
-boost::optional<std::shared_ptr<ResultSetMetadata>> FlightSqlStatement::Prepare(
+std::optional<std::shared_ptr<ResultSetMetadata>> FlightSqlStatement::Prepare(
     const std::string& query) {
   ClosePreparedStatementIfAny(prepared_statement_, call_options_);
 
@@ -126,7 +126,7 @@ boost::optional<std::shared_ptr<ResultSetMetadata>> FlightSqlStatement::Prepare(
 
   const auto& result_set_metadata = std::make_shared<FlightSqlResultSetMetadata>(
       prepared_statement_->dataset_schema(), metadata_settings_);
-  return boost::optional<std::shared_ptr<ResultSetMetadata>>(result_set_metadata);
+  return std::optional<std::shared_ptr<ResultSetMetadata>>(result_set_metadata);
 }
 
 bool FlightSqlStatement::ExecutePrepared() {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
@@ -111,7 +111,11 @@ bool FlightSqlStatement::SetAttribute(StatementAttributeId attribute,
 std::optional<Statement::Attribute> FlightSqlStatement::GetAttribute(
     StatementAttributeId attribute) {
   const auto& it = attribute_.find(attribute);
-  return boost::make_optional(it != attribute_.end(), it->second);
+  if (it != attribute_.end()) {
+    return std::make_optional(it->second);
+  } else {
+    return std::nullopt;
+  }
 }
 
 std::optional<std::shared_ptr<ResultSetMetadata>> FlightSqlStatement::Prepare(

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.h
@@ -55,9 +55,9 @@ class FlightSqlStatement : public Statement {
 
   bool SetAttribute(StatementAttributeId attribute, const Attribute& value) override;
 
-  boost::optional<Attribute> GetAttribute(StatementAttributeId attribute) override;
+  std::optional<Attribute> GetAttribute(StatementAttributeId attribute) override;
 
-  boost::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
+  std::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
       const std::string& query) override;
 
   bool ExecutePrepared() override;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.h
@@ -26,6 +26,8 @@
 #include "arrow/flight/sql/api.h"
 #include "arrow/flight/types.h"
 
+#include <optional>
+
 namespace arrow::flight::sql::odbc {
 
 class FlightSqlStatement : public Statement {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.cc
@@ -69,7 +69,7 @@ FlightStreamChunkBuffer::FlightStreamChunkBuffer(
       // call. temp_flight_sql_client is intentionally null if the list of endpoint
       // Locations is empty.
       // After all data is fetched from reader, the temp client is closed.
-      return boost::make_optional(
+      return std::make_optional(
           is_not_ok || is_not_empty,
           std::make_pair(std::move(result), temp_flight_sql_client));
     };

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.cc
@@ -59,32 +59,37 @@ FlightStreamChunkBuffer::FlightStreamChunkBuffer(
     util::ThrowIfNotOK(result.status());
     std::shared_ptr<FlightStreamReader> stream_reader_ptr(std::move(result.ValueOrDie()));
 
-    BlockingQueue<std::pair<Result<FlightStreamChunk>,
-                            std::shared_ptr<FlightSqlClient>>>::Supplier supplier = [=] {
-      auto result = stream_reader_ptr->Next();
-      bool is_not_ok = !result.ok();
-      bool is_not_empty = result.ok() && (result.ValueOrDie().data != nullptr);
+    BlockingQueue<std::optional<
+        std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>>>::Supplier
+        supplier = [=] {
+          auto result = stream_reader_ptr->Next();
+          bool is_not_ok = !result.ok();
+          bool is_not_empty = result.ok() && (result.ValueOrDie().data != nullptr);
 
-      // If result is valid, save the temp Flight SQL Client for future stream reader
-      // call. temp_flight_sql_client is intentionally null if the list of endpoint
-      // Locations is empty.
-      // After all data is fetched from reader, the temp client is closed.
-      return std::make_optional(
-          is_not_ok || is_not_empty,
-          std::make_pair(std::move(result), temp_flight_sql_client));
-    };
+          // If result is valid, save the temp Flight SQL Client for future stream reader
+          // call. temp_flight_sql_client is intentionally null if the list of endpoint
+          // Locations is empty.
+          // After all data is fetched from reader, the temp client is closed.
+          if (is_not_ok || is_not_empty) {
+            return std::make_optional(
+                std::make_pair(std::move(result), temp_flight_sql_client));
+          } else {
+            return std::optional<
+                std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>>{};
+          }
+        };
     queue_.AddProducer(std::move(supplier));
   }
 }
 
 bool FlightStreamChunkBuffer::GetNext(FlightStreamChunk* chunk) {
-  std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>
+  std::optional<std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>>
       closeable_endpoint_stream_pair;
   if (!queue_.Pop(&closeable_endpoint_stream_pair)) {
     return false;
   }
 
-  Result<FlightStreamChunk> result = closeable_endpoint_stream_pair.first;
+  Result<FlightStreamChunk> result = closeable_endpoint_stream_pair.value().first;
   if (!result.status().ok()) {
     Close();
     throw DriverException(result.status().message());

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.h
@@ -31,8 +31,7 @@ using arrow::flight::sql::FlightSqlClient;
 using arrow::flight::sql::odbc::BlockingQueue;
 
 class FlightStreamChunkBuffer {
-  BlockingQueue<std::optional<
-      std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>>>
+  BlockingQueue<std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>>
       queue_;
 
  public:

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.h
@@ -31,7 +31,8 @@ using arrow::flight::sql::FlightSqlClient;
 using arrow::flight::sql::odbc::BlockingQueue;
 
 class FlightStreamChunkBuffer {
-  BlockingQueue<std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>>
+  BlockingQueue<std::optional<
+      std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>>>
       queue_;
 
  public:

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/util.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/util.cc
@@ -1109,7 +1109,7 @@ int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimal_
   return decimal128_type->precision();
 }
 
-boost::optional<bool> AsBool(const std::string& value) {
+std::optional<bool> AsBool(const std::string& value) {
   if (boost::iequals(value, "true") || boost::iequals(value, "1")) {
     return true;
   } else if (boost::iequals(value, "false") || boost::iequals(value, "0")) {
@@ -1119,7 +1119,7 @@ boost::optional<bool> AsBool(const std::string& value) {
   }
 }
 
-boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
+std::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
                              const std::string_view& property_name) {
   auto extracted_property = conn_property_map.find(std::string(property_name));
 
@@ -1130,7 +1130,7 @@ boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_ma
   return boost::none;
 }
 
-boost::optional<int32_t> AsInt32(int32_t min_value,
+std::optional<int32_t> AsInt32(int32_t min_value,
                                  const Connection::ConnPropertyMap& conn_property_map,
                                  const std::string_view& property_name) {
   auto extracted_property = conn_property_map.find(std::string(property_name));

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/util.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/util.cc
@@ -1115,7 +1115,7 @@ std::optional<bool> AsBool(const std::string& value) {
   } else if (boost::iequals(value, "false") || boost::iequals(value, "0")) {
     return false;
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
@@ -1127,7 +1127,7 @@ std::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
     return AsBool(extracted_property->second);
   }
 
-  return boost::none;
+  return std::nullopt;
 }
 
 std::optional<int32_t> AsInt32(int32_t min_value,
@@ -1142,7 +1142,7 @@ std::optional<int32_t> AsInt32(int32_t min_value,
       return string_column_length;
     }
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 }  // namespace util

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/util.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/util.h
@@ -121,14 +121,14 @@ int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimal_
 /// Parse a string value to a boolean.
 /// \param value            the value to be parsed.
 /// \return                 the parsed valued.
-boost::optional<bool> AsBool(const std::string& value);
+std::optional<bool> AsBool(const std::string& value);
 
 /// Looks up for a value inside the ConnPropertyMap and then try to parse it.
 /// In case it does not find or it cannot parse, the default value will be returned.
 /// \param conn_property_map    the map with the connection properties.
 /// \param property_name      the name of the property that will be looked up.
 /// \return                   the parsed valued.
-boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
+std::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
                              const std::string_view& property_name);
 
 /// Looks up for a value inside the ConnPropertyMap and then try to parse it.
@@ -139,7 +139,7 @@ boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_ma
 /// looked up. \return                             the parsed valued. \exception
 /// std::invalid_argument    exception from std::stoi \exception
 /// std::out_of_range        exception from std::stoi
-boost::optional<int32_t> AsInt32(int32_t min_value,
+std::optional<int32_t> AsInt32(int32_t min_value,
                                  const Connection::ConnPropertyMap& conn_property_map,
                                  const std::string_view& property_name);
 

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/blocking_queue.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/blocking_queue.h
@@ -43,7 +43,7 @@ class BlockingQueue {
   std::atomic<bool> closed_{false};
 
  public:
-  typedef std::function<boost::optional<T>(void)> Supplier;
+  typedef std::function<std::optional<T>(void)> Supplier;
 
   explicit BlockingQueue(size_t capacity) : capacity_(capacity), buffer_(capacity) {}
 

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/blocking_queue.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/blocking_queue.h
@@ -18,9 +18,9 @@
 #pragma once
 
 #include <atomic>
-#include <boost/optional.hpp>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <vector>
 

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/blocking_queue.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/blocking_queue.h
@@ -58,7 +58,7 @@ class BlockingQueue {
 
         // Only one thread at a time be notified and call supplier
         auto item = supplier();
-        if (!item) break;
+        if (!item.has_value()) break;
 
         Push(*item);
       }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/connection.h
@@ -18,10 +18,10 @@
 #pragma once
 
 #include <boost/algorithm/string.hpp>
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/connection.h
@@ -86,7 +86,7 @@ class Connection {
 
   /// \brief Retrieve a connection attribute
   /// \param attribute [in] Attribute to be retrieved.
-  virtual boost::optional<Connection::Attribute> GetAttribute(
+  virtual std::optional<Connection::Attribute> GetAttribute(
       Connection::AttributeId attribute) = 0;
 
   /// \brief Retrieves info from the database (see ODBC's SQLGetInfo).

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/statement.h
@@ -24,7 +24,7 @@
 
 namespace arrow::flight::sql::odbc {
 
-using boost::optional;
+using std::optional;
 
 class ResultSet;
 
@@ -76,7 +76,7 @@ class Statement {
   /// Returns ResultSetMetadata if query returns a result set,
   /// otherwise it returns `boost::none`.
   /// \param query The SQL query to prepare.
-  virtual boost::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
+  virtual std::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
       const std::string& query) = 0;
 
   /// \brief Execute the prepared statement.

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/statement.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include <map>
+#include <optional>
 #include <vector>
 
 namespace arrow::flight::sql::odbc {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/spi/statement.h
@@ -74,7 +74,7 @@ class Statement {
 
   /// \brief Prepares the statement.
   /// Returns ResultSetMetadata if query returns a result set,
-  /// otherwise it returns `boost::none`.
+  /// otherwise it returns `std::nullopt`.
   /// \param query The SQL query to prepare.
   virtual std::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
       const std::string& query) = 0;

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/platform.h"
 
 namespace arrow::flight::sql::odbc {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
@@ -171,7 +171,7 @@ enum RowStatus : uint16_t {
 };
 
 struct MetadataSettings {
-  std::optional<int32_t> string_column_length{boost::none};
+  std::optional<int32_t> string_column_length{std::nullopt};
   size_t chunk_buffer_capacity;
   bool use_wide_char;
 };

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
@@ -171,7 +171,7 @@ enum RowStatus : uint16_t {
 };
 
 struct MetadataSettings {
-  boost::optional<int32_t> string_column_length{boost::none};
+  std::optional<int32_t> string_column_length{boost::none};
   size_t chunk_buffer_capacity;
   bool use_wide_char;
 };

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
@@ -525,7 +525,7 @@ SQLRETURN ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
                                          SQLINTEGER buffer_length,
                                          SQLINTEGER* output_length, bool is_unicode) {
   using arrow::flight::sql::odbc::Connection;
-  boost::optional<Connection::Attribute> spi_attribute;
+  std::optional<Connection::Attribute> spi_attribute;
 
   switch (attribute) {
     // Internal connection attributes

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
@@ -36,6 +36,7 @@
 #include <boost/xpressive/xpressive.hpp>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <utility>
 
 using ODBC::ODBCConnection;

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
@@ -29,8 +29,8 @@
 #include <sql.h>
 #include <sqlext.h>
 #include <sqltypes.h>
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
+#include <optional>
 #include <utility>
 
 using ODBC::DescriptorRecord;

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_statement.cc
@@ -284,7 +284,7 @@ void ODBCStatement::CopyAttributesFromConnection(ODBCConnection& connection) {
 bool ODBCStatement::IsPrepared() const { return is_prepared_; }
 
 void ODBCStatement::Prepare(const std::string& query) {
-  boost::optional<std::shared_ptr<ResultSetMetadata> > metadata =
+  std::optional<std::shared_ptr<ResultSetMetadata> > metadata =
       spi_statement_->Prepare(query);
 
   if (metadata) {
@@ -378,7 +378,7 @@ void ODBCStatement::GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER outpu
                                 SQLINTEGER buffer_size, SQLINTEGER* str_len_ptr,
                                 bool is_unicode) {
   using arrow::flight::sql::odbc::Statement;
-  boost::optional<Statement::Attribute> spi_attribute;
+  std::optional<Statement::Attribute> spi_attribute;
   switch (statement_attribute) {
     // Descriptor accessor attributes
     case SQL_ATTR_APP_PARAM_DESC:


### PR DESCRIPTION
Addresses comment https://github.com/apache/arrow/pull/40939#discussion_r2099118497.
Replace boost::optional with std::optional in ODBC codebase