### PR TITLE
Fix EXPECT_EQ() to have expected on the left and actual on the right

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection_test.cc
@@ -38,7 +38,7 @@ TEST(AttributeTests, SetAndGetAttribute) {
 
   EXPECT_TRUE(first_value);
 
-  EXPECT_EQ(std::get<uint32_t>(*first_value), static_cast<uint32_t>(200));
+  EXPECT_EQ(static_cast<uint32_t>(200), std::get<uint32_t>(*first_value));
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(300));
 
@@ -46,7 +46,7 @@ TEST(AttributeTests, SetAndGetAttribute) {
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
   EXPECT_TRUE(change_value);
-  EXPECT_EQ(std::get<uint32_t>(*change_value), static_cast<uint32_t>(300));
+  EXPECT_EQ(static_cast<uint32_t>(300), std::get<uint32_t>(*change_value));
 
   connection.Close();
 }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_stream_chunk_buffer_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_stream_chunk_buffer_test.cc
@@ -117,7 +117,7 @@ TEST_F(FlightStreamChunkBufferTest, TestMultipleEndpointsInt) {
     num_chunks++;
 
     int num_cols = current_chunk.data->num_columns();
-    EXPECT_EQ(num_cols, 8);
+    EXPECT_EQ(8, num_cols);
 
     for (int i = 0; i < num_cols; i++) {
       auto array = current_chunk.data->column(i);
@@ -130,6 +130,6 @@ TEST_F(FlightStreamChunkBufferTest, TestMultipleEndpointsInt) {
 
   // Verify 5 batches of data is returned by each of the two endpoints.
   // In total 10 batches should be returned.
-  EXPECT_EQ(num_chunks, 10);
+  EXPECT_EQ(10, num_chunks);
 }
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -144,59 +144,59 @@ void CheckSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
 
   SQLRETURN ret = SQLColAttribute(stmt, idx, SQL_DESC_NAME, &name[0],
                                   (SQLSMALLINT)name.size(), &name_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_BASE_COLUMN_NAME, &base_column_name[0],
                         (SQLSMALLINT)base_column_name.size(), &column_name_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_LABEL, &label[0], (SQLSMALLINT)label.size(),
                         &label_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_TYPE, 0, 0, 0, &data_type);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_CONCISE_TYPE, 0, 0, 0, &concise_type);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_DISPLAY_SIZE, 0, 0, 0, &display_size);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_FIXED_PREC_SCALE, 0, 0, 0, &prec_scale);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_LENGTH, 0, 0, 0, &length);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_LITERAL_PREFIX, &prefix[0],
                         (SQLSMALLINT)prefix.size(), &prefix_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_LITERAL_SUFFIX, &suffix[0],
                         (SQLSMALLINT)suffix.size(), &suffix_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_PRECISION, 0, 0, 0, &size);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_SCALE, 0, 0, 0, &scale);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_NULLABLE, 0, 0, 0, &nullability);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_NUM_PREC_RADIX, 0, 0, 0, &num_prec_radix);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_OCTET_LENGTH, 0, 0, 0, &octet_length);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_SEARCHABLE, 0, 0, 0, &searchable);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_DESC_UNSIGNED, 0, 0, 0, &unsigned_col);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   std::wstring name_str = ConvertToWString(name, name_len);
   std::wstring base_column_name_str = ConvertToWString(base_column_name, column_name_len);
@@ -204,22 +204,22 @@ void CheckSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
   std::wstring prefixStr = ConvertToWString(prefix, prefix_len);
 
   // Assume column name, base column name, and label are equivalent in the result set
-  EXPECT_EQ(name_str, expected_column_name);
-  EXPECT_EQ(base_column_name_str, expected_column_name);
-  EXPECT_EQ(label_str, expected_column_name);
-  EXPECT_EQ(data_type, expected_data_type);
-  EXPECT_EQ(concise_type, expected_concise_type);
-  EXPECT_EQ(display_size, expected_display_size);
-  EXPECT_EQ(prec_scale, expected_prec_scale);
-  EXPECT_EQ(length, expected_length);
-  EXPECT_EQ(prefixStr, expected_literal_prefix);
-  EXPECT_EQ(size, expected_column_size);
-  EXPECT_EQ(scale, expected_column_scale);
-  EXPECT_EQ(nullability, expected_column_nullability);
-  EXPECT_EQ(num_prec_radix, expected_num_prec_radix);
-  EXPECT_EQ(octet_length, expected_octet_length);
-  EXPECT_EQ(searchable, expected_searchable);
-  EXPECT_EQ(unsigned_col, expected_unsigned_column);
+  EXPECT_EQ(expected_column_name, name_str);
+  EXPECT_EQ(expected_column_name, base_column_name_str);
+  EXPECT_EQ(expected_column_name, label_str);
+  EXPECT_EQ(expected_data_type, data_type);
+  EXPECT_EQ(expected_concise_type, concise_type);
+  EXPECT_EQ(expected_display_size, display_size);
+  EXPECT_EQ(expected_prec_scale, prec_scale);
+  EXPECT_EQ(expected_length, length);
+  EXPECT_EQ(expected_literal_prefix, prefixStr);
+  EXPECT_EQ(expected_column_size, size);
+  EXPECT_EQ(expected_column_scale, scale);
+  EXPECT_EQ(expected_column_nullability, nullability);
+  EXPECT_EQ(expected_num_prec_radix, num_prec_radix);
+  EXPECT_EQ(expected_octet_length, octet_length);
+  EXPECT_EQ(expected_searchable, searchable);
+  EXPECT_EQ(expected_unsigned_column, unsigned_col);
 }
 
 void CheckSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
@@ -245,52 +245,52 @@ void CheckSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
 
   SQLRETURN ret = SQLColAttributes(stmt, idx, SQL_COLUMN_NAME, &name[0],
                                    (SQLSMALLINT)name.size(), &name_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_LABEL, &label[0],
                          (SQLSMALLINT)label.size(), &label_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_TYPE, 0, 0, 0, &data_type);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_DISPLAY_SIZE, 0, 0, 0, &display_size);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(stmt, idx, SQL_COLUMN_MONEY, 0, 0, 0, &prec_scale);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_LENGTH, 0, 0, 0, &length);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_PRECISION, 0, 0, 0, &size);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_SCALE, 0, 0, 0, &scale);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_NULLABLE, 0, 0, 0, &nullability);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_SEARCHABLE, 0, 0, 0, &searchable);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttributes(stmt, idx, SQL_COLUMN_UNSIGNED, 0, 0, 0, &unsigned_col);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   std::wstring name_str = ConvertToWString(name, name_len);
   std::wstring label_str = ConvertToWString(label, label_len);
 
-  EXPECT_EQ(name_str, expected_column_name);
-  EXPECT_EQ(label_str, expected_column_name);
-  EXPECT_EQ(data_type, expected_data_type);
-  EXPECT_EQ(display_size, expected_display_size);
-  EXPECT_EQ(length, expected_length);
-  EXPECT_EQ(size, expected_column_size);
-  EXPECT_EQ(scale, expected_column_scale);
-  EXPECT_EQ(nullability, expected_column_nullability);
-  EXPECT_EQ(searchable, expected_searchable);
-  EXPECT_EQ(unsigned_col, expected_unsigned_column);
+  EXPECT_EQ(expected_column_name, name_str);
+  EXPECT_EQ(expected_column_name, label_str);
+  EXPECT_EQ(expected_data_type, data_type);
+  EXPECT_EQ(expected_display_size, display_size);
+  EXPECT_EQ(expected_length, length);
+  EXPECT_EQ(expected_column_size, size);
+  EXPECT_EQ(expected_column_scale, scale);
+  EXPECT_EQ(expected_column_nullability, nullability);
+  EXPECT_EQ(expected_searchable, searchable);
+  EXPECT_EQ(expected_unsigned_column, unsigned_col);
 }
 
 void CheckSQLColAttributeString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMALLINT idx,
@@ -301,10 +301,10 @@ void CheckSQLColAttributeString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMA
     // Execute query
     std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
     ret = SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
     ret = SQLFetch(stmt);
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
   }
 
   // check SQLColAttribute string attribute
@@ -313,10 +313,10 @@ void CheckSQLColAttributeString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMA
 
   ret = SQLColAttribute(stmt, idx, field_identifier, &str_val[0],
                         (SQLSMALLINT)str_val.size(), &str_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   std::wstring attr_str = ConvertToWString(str_val, str_len);
-  EXPECT_EQ(attr_str, expected_attr_string);
+  EXPECT_EQ(expected_attr_string, attr_str);
 }
 
 void CheckSQLColAttributeNumeric(SQLHSTMT stmt, const std::wstring& wsql,
@@ -325,16 +325,16 @@ void CheckSQLColAttributeNumeric(SQLHSTMT stmt, const std::wstring& wsql,
   // Execute query and check SQLColAttribute numeric attribute
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
   SQLRETURN ret = SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLLEN num_val = 0;
   ret = SQLColAttribute(stmt, idx, field_identifier, 0, 0, 0, &num_val);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(num_val, expected_attr_numeric);
+  EXPECT_EQ(expected_attr_numeric, num_val);
 }
 
 void CheckSQLColAttributesString(SQLHSTMT stmt, const std::wstring& wsql,
@@ -345,10 +345,10 @@ void CheckSQLColAttributesString(SQLHSTMT stmt, const std::wstring& wsql,
     // Execute query
     std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
     ret = SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
     ret = SQLFetch(stmt);
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
   }
 
   // check ODBC 2.0 API SQLColAttributes string attribute
@@ -357,10 +357,10 @@ void CheckSQLColAttributesString(SQLHSTMT stmt, const std::wstring& wsql,
 
   ret = SQLColAttributes(stmt, idx, field_identifier, &str_val[0],
                          (SQLSMALLINT)str_val.size(), &str_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  std::wstring attrStr = ConvertToWString(str_val, str_len);
-  EXPECT_EQ(attrStr, expected_attr_string);
+  std::wstring attr_str = ConvertToWString(str_val, str_len);
+  EXPECT_EQ(expected_attr_string, attr_str);
 }
 
 void CheckSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql,
@@ -369,16 +369,16 @@ void CheckSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql,
   // Execute query and check ODBC 2.0 API SQLColAttributes numeric attribute
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
   SQLRETURN ret = SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLLEN num_val = 0;
   ret = SQLColAttributes(stmt, idx, field_identifier, 0, 0, 0, &num_val);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(num_val, expected_attr_numeric);
+  EXPECT_EQ(expected_attr_numeric, num_val);
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsTestInputData) {
@@ -394,7 +394,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsTestInputData) {
                              sizeof(schema_name), table_name, sizeof(table_name),
                              column_name, sizeof(column_name));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
@@ -402,7 +402,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsTestInputData) {
   ret = SQLColumns(this->stmt, catalog_name, 0, schema_name, 0, table_name, 0,
                    column_name, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
@@ -410,7 +410,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsTestInputData) {
   ret = SQLColumns(this->stmt, 0, sizeof(catalog_name), 0, sizeof(schema_name), 0,
                    sizeof(table_name), 0, sizeof(column_name));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
   // Close statement cursor to avoid leaving in an invalid state
@@ -419,7 +419,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsTestInputData) {
   // All values and sizes are nulls
   ret = SQLColumns(this->stmt, 0, 0, 0, 0, 0, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
 
@@ -437,10 +437,10 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                              table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // mock limitation: SQLite mock server returns 10 for bigint size when spec indicates
   // should be 19
@@ -466,7 +466,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
 
   // Check 2nd Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
@@ -488,7 +488,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
 
   // Check 3rd Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
@@ -509,7 +509,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
 
   // Check 4th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
@@ -530,7 +530,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
 
   // Check 5th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
@@ -552,7 +552,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
 
   // Check 6th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
@@ -573,7 +573,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllColumns) {
 
   // Check 7th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),       // expected_catalog
@@ -611,11 +611,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllTypes) {
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                              table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Fetch SQLColumn data for 1st column in AllTypesTable
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),           // expected_catalog
@@ -638,7 +638,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllTypes) {
 
   // Check SQLColumn data for 2nd column in AllTypesTable
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),           // expected_catalog
@@ -660,7 +660,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllTypes) {
 
   // Check SQLColumn data for 3rd column in AllTypesTable
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),           // expected_catalog
@@ -682,7 +682,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllTypes) {
 
   // Check SQLColumn data for 4th column in AllTypesTable
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),           // expected_catalog
@@ -703,7 +703,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsAllTypes) {
 
   // There should be no more column data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -722,11 +722,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsUnicode) {
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                              table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check SQLColumn data for 1st column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
@@ -748,7 +748,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsUnicode) {
 
   // There should be no more column data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -764,11 +764,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                              table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check 1st Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -790,7 +790,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // Check 2nd Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -812,7 +812,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // Check 3rd Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),          // expected_schema
@@ -833,7 +833,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // Check 4th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),   // expected_schema
@@ -854,7 +854,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // Check 5th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),    // expected_schema
@@ -875,7 +875,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // Check 6th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),  // expected_schema
@@ -900,7 +900,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // Check 7th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -922,7 +922,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // Check 8th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -944,7 +944,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // Check 9th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -966,7 +966,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypes) {
 
   // There is no more column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -982,11 +982,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                              table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check 1st Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -1008,7 +1008,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // Check 2nd Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -1030,7 +1030,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // Check 3rd Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),          // expected_schema
@@ -1051,7 +1051,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // Check 4th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),   // expected_schema
@@ -1072,7 +1072,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // Check 5th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),    // expected_schema
@@ -1093,7 +1093,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // Check 6th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),  // expected_schema
@@ -1117,7 +1117,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // Check 7th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -1139,7 +1139,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // Check 8th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -1161,7 +1161,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // Check 9th Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   checkRemoteSQLColumns(
       this->stmt,
@@ -1183,7 +1183,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColumnsAllTypesODBCVer2) {
 
   // There is no more column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1199,11 +1199,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnscolumn_pattern) {
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                              table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check 1st Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
@@ -1224,7 +1224,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnscolumn_pattern) {
 
   // Check 2nd Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
@@ -1245,7 +1245,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnscolumn_pattern) {
 
   // There is no more column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1261,11 +1261,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsTablecolumn_pattern) {
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                              table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check 1st Column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
@@ -1286,7 +1286,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsTablecolumn_pattern) {
 
   // There is no more column
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1300,11 +1300,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColumnsInvalidtable_pattern) {
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                              table_pattern, SQL_NTS, column_pattern, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // There is no column from filter
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1317,10 +1317,10 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeTestInputData) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLUSMALLINT idx = 1;
   std::vector<SQLWCHAR> character_attr(ODBC_BUFFER_SIZE);
@@ -1330,19 +1330,19 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeTestInputData) {
   // All character values populated
   ret = SQLColAttribute(this->stmt, idx, SQL_DESC_NAME, &character_attr[0],
                         (SQLSMALLINT)character_attr.size(), &character_attr_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // All numeric values populated
   ret = SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, 0, &numeric_attr);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Pass null values, driver should not throw error
   ret = SQLColAttribute(this->stmt, idx, SQL_COLUMN_TABLE_NAME, 0, 0, 0, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, 0, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -1355,19 +1355,19 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeGetCharacterLen) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLSMALLINT character_attr_len = 0;
 
   // Check length of character attribute
   ret = SQLColAttribute(this->stmt, 1, SQL_DESC_BASE_COLUMN_NAME, 0, 0,
                         &character_attr_len, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(character_attr_len, 4 * ODBC::GetSqlWCharSize());
+  EXPECT_EQ(4 * ODBC::GetSqlWCharSize(), character_attr_len);
 
   this->Disconnect();
 }
@@ -1380,10 +1380,10 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeInvalidFieldId) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLUSMALLINT invalid_field_id = -100;
   SQLUSMALLINT idx = 1;
@@ -1393,7 +1393,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeInvalidFieldId) {
 
   ret = SQLColAttribute(this->stmt, idx, invalid_field_id, &character_attr[0],
                         (SQLSMALLINT)character_attr.size(), &character_attr_len, 0);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Verify invalid descriptor field identifier error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY091);
 
@@ -1408,10 +1408,10 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeInvalidColId) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLUSMALLINT invalid_col_id = 2;
   std::vector<SQLWCHAR> character_attr(ODBC_BUFFER_SIZE);
@@ -1420,7 +1420,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColAttributeInvalidColId) {
   ret = SQLColAttribute(this->stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME,
                         &character_attr[0], (SQLSMALLINT)character_attr.size(),
                         &character_attr_len, 0);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Verify invalid descriptor index error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_07009);
 
@@ -1436,10 +1436,10 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributeAllTypes) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLColAttribute(this->stmt, 1,
                        std::wstring(L"bigint_col"),  // expected_column_name
@@ -1522,10 +1522,10 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLColAttributesAllTypesODBCVer2) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   CheckSQLColAttributes(this->stmt, 1,
                         std::wstring(L"bigint_col"),  // expected_column_name
                         SQL_BIGINT,                   // expected_data_type
@@ -1586,10 +1586,10 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeAllTypes) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLColAttribute(this->stmt, 1,
                        std::wstring(L"sinteger_max"),  // expected_column_name
@@ -1756,10 +1756,10 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributeAllTypesODBCVer2) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLColAttribute(this->stmt, 1,
                        std::wstring(L"sinteger_max"),  // expected_column_name
@@ -1927,10 +1927,10 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLColAttributesAllTypesODBCVer2) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLColAttributes(this->stmt, 1,
                         std::wstring(L"sinteger_max"),  // expected_column_name
@@ -2405,18 +2405,18 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColValidateInput) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Invalid descriptor index - Bookmarks are not supported
   ret =
       SQLDescribeCol(this->stmt, bookmark_column, column_name, buf_char_len, &name_length,
                      &data_type, &column_size, &decimal_digits, &nullable);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_07009);
 
   // Invalid descriptor index - index out of range
@@ -2424,7 +2424,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColValidateInput) {
       SQLDescribeCol(this->stmt, out_of_range_column, column_name, buf_char_len,
                      &name_length, &data_type, &column_size, &decimal_digits, &nullable);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_07009);
 
   // Invalid descriptor index - index out of range
@@ -2432,7 +2432,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColValidateInput) {
       SQLDescribeCol(this->stmt, negative_column, column_name, buf_char_len, &name_length,
                      &data_type, &column_size, &decimal_digits, &nullable);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_07009);
 
   this->Disconnect();
@@ -2484,11 +2484,11 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -2497,16 +2497,16 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, 1024);
-    EXPECT_EQ(decimal_digits, 0);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(1024, column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;
@@ -2568,11 +2568,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -2581,16 +2581,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColQueryAllDataTypesMetadata) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, column_sizes[i]);
-    EXPECT_EQ(decimal_digits, column_decimal_digits[i]);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(column_decimal_digits[i], decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;
@@ -2632,11 +2632,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadata) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -2645,16 +2645,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadata) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, column_sizes[i]);
-    EXPECT_EQ(decimal_digits, columndecimal_digits[i]);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(columndecimal_digits[i], decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;
@@ -2696,11 +2696,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadataODBC2) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -2709,16 +2709,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLDescribeColODBCTestTableMetadataODBC2) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, column_sizes[i]);
-    EXPECT_EQ(decimal_digits, columndecimal_digits[i]);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(columndecimal_digits[i], decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;
@@ -2754,11 +2754,11 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColAllTypesTableMetadata) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -2767,16 +2767,16 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColAllTypesTableMetadata) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, column_sizes[i]);
-    EXPECT_EQ(decimal_digits, 0);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;
@@ -2811,16 +2811,16 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColUnicodeTableMetadata) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_EQ(name_length, wcslen(expected_column_name));
 
@@ -2828,8 +2828,8 @@ TEST_F(FlightSQLODBCMockTestBase, SQLDescribeColUnicodeTableMetadata) {
   EXPECT_EQ(returned, expected_column_name);
   EXPECT_EQ(column_data_type, expected_column_data_type);
   EXPECT_EQ(column_size, expected_column_size);
-  EXPECT_EQ(decimal_digits, 0);
-  EXPECT_EQ(nullable, SQL_NULLABLE);
+  EXPECT_EQ(0, decimal_digits);
+  EXPECT_EQ(SQL_NULLABLE, nullable);
 
   this->Disconnect();
 }
@@ -2866,7 +2866,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeCol) {
 
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -2875,16 +2875,16 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeCol) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, column_sizes[i]);
-    EXPECT_EQ(decimal_digits, 0);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;
@@ -2936,7 +2936,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeColODBC2) {
 
   SQLRETURN ret = SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -2945,16 +2945,16 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLColumnsGetMetadataBySQLDescribeColODBC2) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, column_sizes[i]);
-    EXPECT_EQ(decimal_digits, 0);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
@@ -34,7 +34,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAsyncDbcEventUnsupported)
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_EVENT, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Driver Manager on Windows returns error code HY118
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY118);
 
@@ -48,7 +48,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAyncEnableUnsupported) {
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_ENABLE, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -61,7 +61,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAyncDbcPcCallbackUnsuppor
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -74,7 +74,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAyncDbcPcContextUnsupport
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -87,7 +87,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAutoIpdReadOnly) {
   // Verify read-only attribute cannot be set
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_AUTO_IPD, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY092);
 
   this->Disconnect();
@@ -99,7 +99,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrConnectionDeadReadOnly) {
   // Verify read-only attribute cannot be set
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_CONNECTION_DEAD, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY092);
 
   this->Disconnect();
@@ -111,7 +111,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrDbcInfoTokenUnsupported) 
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_DBC_INFO_TOKEN, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -123,7 +123,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrEnlistInDtcUnsupported) {
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ENLIST_IN_DTC, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -136,7 +136,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ODBC_CURSORS,
                                     reinterpret_cast<SQLPOINTER>(SQL_CUR_USE_DRIVER), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   std::string connect_str = this->GetConnectionString();
   this->ConnectWithString(connect_str);
@@ -149,7 +149,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrQuietModeReadOnly) {
   // Verify read-only attribute cannot be set
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_QUIET_MODE, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY092);
 
   this->Disconnect();
@@ -161,7 +161,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTraceDMOnly) {
   // Verify DM-only attribute is settable via Driver Manager
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_TRACE,
                                     reinterpret_cast<SQLPOINTER>(SQL_OPT_TRACE_OFF), 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -177,7 +177,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTracefileDMOnly) {
   std::vector<SQLWCHAR> trace_file0(trace_file.begin(), trace_file.end());
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_TRACEFILE, &trace_file0[0],
                                     static_cast<SQLINTEGER>(trace_file0.size()));
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY000);
 
   this->Disconnect();
@@ -188,7 +188,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTranslateLabDMOnly) {
 
   // Verify DM-only attribute is handled by Driver Manager
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, 0, 0);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Checks for invalid argument return error
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY024);
 
@@ -200,7 +200,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTranslateOptionUnsupporte
 
   SQLRETURN ret = SQLSetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_OPTION, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -212,7 +212,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrTxnIsolationUnsupported) 
   SQLRETURN ret =
       SQLSetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION,
                         reinterpret_cast<SQLPOINTER>(SQL_TXN_READ_UNCOMMITTED), 0);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -226,7 +226,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrDbcInfoTokenSetOnly) {
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_DBC_INFO_TOKEN, ptr, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY092);
 
   this->Disconnect();
@@ -241,8 +241,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrOdbcCursorsDMOnly) {
   SQLRETURN ret =
       SQLGetConnectAttr(this->conn, SQL_ATTR_ODBC_CURSORS, &cursor_attr, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(cursor_attr, SQL_CUR_USE_DRIVER);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(SQL_CUR_USE_DRIVER, cursor_attr);
 
   this->Disconnect();
 }
@@ -254,8 +254,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTraceDMOnly) {
   SQLUINTEGER trace;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRACE, &trace, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(trace, SQL_OPT_TRACE_OFF);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(SQL_OPT_TRACE_OFF, trace);
 
   this->Disconnect();
 }
@@ -269,7 +269,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTraceFileDMOnly) {
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRACEFILE, out_str,
                                     ODBC_BUFFER_SIZE, &out_str_len);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Length is returned in bytes for SQLGetConnectAttr,
   // we want the number of characters
   out_str_len /= arrow::flight::sql::odbc::GetSqlWCharSize();
@@ -288,7 +288,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTranslateLibUnsupported) 
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, out_str,
                                     ODBC_BUFFER_SIZE, &out_str_len);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -300,7 +300,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTranslateOptionUnsupporte
   SQLINTEGER option;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_OPTION, &option, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -312,7 +312,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrTxnIsolationUnsupported) 
   SQLINTEGER isolation;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, &isolation, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HYC00);
 
   this->Disconnect();
@@ -328,7 +328,7 @@ TYPED_TEST(FlightSQLODBCTestBase,
   SQLRETURN ret =
       SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, &enable, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY114);
 
   this->Disconnect();
@@ -344,8 +344,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcEventDefault) {
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_EVENT, ptr, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 
   this->Disconnect();
 }
@@ -358,8 +358,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcPcallbackDefault)
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, ptr, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 
   this->Disconnect();
 }
@@ -372,8 +372,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncDbcPcontextDefault) 
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, ptr, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 
   this->Disconnect();
 }
@@ -385,8 +385,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAsyncEnableDefault) {
   SQLULEN enable;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_ENABLE, &enable, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(enable, SQL_ASYNC_ENABLE_OFF);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(SQL_ASYNC_ENABLE_OFF, enable);
 
   this->Disconnect();
 }
@@ -397,8 +397,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAutoIpdDefault) {
   SQLUINTEGER ipd;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_AUTO_IPD, &ipd, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ipd, static_cast<SQLUINTEGER>(SQL_FALSE));
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_FALSE), ipd);
 
   this->Disconnect();
 }
@@ -409,8 +409,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrAutocommitDefault) {
   SQLUINTEGER auto_commit;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_AUTOCOMMIT, &auto_commit, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(auto_commit, SQL_AUTOCOMMIT_ON);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(SQL_AUTOCOMMIT_ON, auto_commit);
 
   this->Disconnect();
 }
@@ -421,8 +421,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrEnlistInDtcDefault) {
   SQLPOINTER ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ENLIST_IN_DTC, ptr, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 
   this->Disconnect();
 }
@@ -433,8 +433,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetConnectAttrQuietModeDefault) {
   HWND ptr = NULL;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_QUIET_MODE, ptr, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ptr, reinterpret_cast<SQLPOINTER>(NULL));
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 
   this->Disconnect();
 }
@@ -448,26 +448,26 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrAccessModeValid) {
   SQLUINTEGER mode = -1;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE, &mode, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(mode, SQL_MODE_READ_WRITE);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(SQL_MODE_READ_WRITE, mode);
 
   ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE,
                           reinterpret_cast<SQLPOINTER>(SQL_MODE_READ_WRITE), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   mode = -1;
 
   ret = SQLGetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE, &mode, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(mode, SQL_MODE_READ_WRITE);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(SQL_MODE_READ_WRITE, mode);
 
   // Attempt to set to SQL_MODE_READ_ONLY, driver should return warning and not error
   ret = SQLSetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE,
                           reinterpret_cast<SQLPOINTER>(SQL_MODE_READ_ONLY), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
 
   // Verify warning status
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_01S02);
@@ -483,20 +483,20 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrConnectionTimeoutValid) {
   SQLRETURN ret =
       SQLGetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(timeout, 0);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(0, timeout);
 
   ret = SQLSetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT,
                           reinterpret_cast<SQLPOINTER>(42), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   timeout = -1;
 
   ret = SQLGetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(timeout, 42);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(42, timeout);
 
   this->Disconnect();
 }
@@ -508,20 +508,20 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrLoginTimeoutValid) {
   SQLUINTEGER timeout = -1;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(timeout, 0);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(0, timeout);
 
   ret = SQLSetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT,
                           reinterpret_cast<SQLPOINTER>(42), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   timeout = -1;
 
   ret = SQLGetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(timeout, 42);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(42, timeout);
 
   this->Disconnect();
 }
@@ -535,26 +535,26 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetConnectAttrPacketSizeValid) {
   SQLUINTEGER size = -1;
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE, &size, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(size, 0);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(0, size);
 
   ret = SQLSetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE,
                           reinterpret_cast<SQLPOINTER>(0), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   size = -1;
 
   ret = SQLGetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE, &size, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(size, 0);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(0, size);
 
   // Attempt to set to non-zero value, driver should return warning and not error
   ret = SQLSetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE,
                           reinterpret_cast<SQLPOINTER>(2), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
 
   // Verify warning status
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_01S02);

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -37,9 +37,9 @@ void Validate(SQLHDBC connection, SQLUSMALLINT info_type, SQLUSMALLINT expected_
 
   SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(info_value, expected_value);
+  EXPECT_EQ(expected_value, info_value);
 }
 
 // Validate unsigned long SQLUINTEGER return value
@@ -49,9 +49,9 @@ void Validate(SQLHDBC connection, SQLUSMALLINT info_type, SQLUINTEGER expected_v
 
   SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(info_value, expected_value);
+  EXPECT_EQ(expected_value, info_value);
 }
 
 // Validate unsigned length SQLULEN return value
@@ -61,9 +61,9 @@ void Validate(SQLHDBC connection, SQLUSMALLINT info_type, SQLULEN expected_value
 
   SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(info_value, expected_value);
+  EXPECT_EQ(expected_value, info_value);
 }
 
 // Validate wchar string SQLWCHAR return value
@@ -74,9 +74,9 @@ void Validate(SQLHDBC connection, SQLUSMALLINT info_type, SQLWCHAR* expected_val
   SQLRETURN ret =
       SQLGetInfo(connection, info_type, info_value, ODBC_BUFFER_SIZE, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(*info_value, *expected_value);
+  EXPECT_EQ(*expected_value, *info_value);
 }
 
 // Validate unsigned long SQLUINTEGER return value is greater than
@@ -87,7 +87,7 @@ void ValidateGreaterThan(SQLHDBC connection, SQLUSMALLINT info_type,
 
   SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(info_value, compared_value);
 }
@@ -100,7 +100,7 @@ void ValidateGreaterThan(SQLHDBC connection, SQLUSMALLINT info_type,
 
   SQLRETURN ret = SQLGetInfo(connection, info_type, &info_value, 0, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(info_value, compared_value);
 }
@@ -115,9 +115,9 @@ void ValidateNotEmptySQLWCHAR(SQLHDBC connection, SQLUSMALLINT info_type,
       SQLGetInfo(connection, info_type, info_value, ODBC_BUFFER_SIZE, &message_length);
 
   if (allow_truncation && ret == SQL_SUCCESS_WITH_INFO) {
-    EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   } else {
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
   }
 
   EXPECT_GT(wcslen(info_value), 0);
@@ -248,7 +248,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetInfoDriverHstmt) {
   // Value returned from driver manager is the stmt address
   SQLHSTMT local_stmt = this->stmt;
   SQLRETURN ret = SQLGetInfo(this->conn, SQL_DRIVER_HSTMT, &local_stmt, 0, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   EXPECT_GT(local_stmt, static_cast<SQLHSTMT>(0));
 
   this->Disconnect();

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -133,17 +133,17 @@ TYPED_TEST(FlightSQLODBCTestBase, TestFreeNullHandles) {
   // Attempt to free null statement handle
   SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_STMT, this->stmt);
 
-  EXPECT_EQ(ret, SQL_INVALID_HANDLE);
+  EXPECT_EQ(SQL_INVALID_HANDLE, ret);
 
   // Attempt to free null connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, this->conn);
 
-  EXPECT_EQ(ret, SQL_INVALID_HANDLE);
+  EXPECT_EQ(SQL_INVALID_HANDLE, ret);
 
   // Attempt to free null environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, this->env);
 
-  EXPECT_EQ(ret, SQL_INVALID_HANDLE);
+  EXPECT_EQ(SQL_INVALID_HANDLE, ret);
 }
 
 TEST(SQLFreeConnect, TestSQLFreeConnect) {
@@ -182,7 +182,7 @@ TEST(SQLGetEnvAttr, TestSQLGetEnvAttrODBCVersion) {
 
   EXPECT_EQ(SQL_SUCCESS, return_get);
 
-  EXPECT_EQ(version, SQL_OV_ODBC2);
+  EXPECT_EQ(SQL_OV_ODBC2, version);
 }
 
 TEST(SQLSetEnvAttr, TestSQLSetEnvAttrODBCVersionValid) {
@@ -226,7 +226,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetEnvAttrOutputNTS) {
 
   EXPECT_EQ(SQL_SUCCESS, return_get);
 
-  EXPECT_EQ(output_nts, SQL_TRUE);
+  EXPECT_EQ(SQL_TRUE, output_nts);
 
   this->Disconnect();
 }
@@ -245,7 +245,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetEnvAttrGetLength) {
 
   EXPECT_EQ(SQL_SUCCESS, return_get);
 
-  EXPECT_EQ(length, sizeof(SQLINTEGER));
+  EXPECT_EQ(sizeof(SQLINTEGER), length);
 
   this->Disconnect();
 }
@@ -319,16 +319,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnect) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Connect string
   std::string connect_str = this->GetConnectionString();
@@ -348,7 +348,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnect) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check that out_str has same content as connect_str
   std::string out_connection_string = ODBC::SqlWcharToString(out_str, out_str_len);
@@ -366,17 +366,17 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnect) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 #if defined _WIN32 || defined _WIN64
@@ -388,16 +388,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnectDsn) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Connect string
   std::string connect_str = this->GetConnectionString();
@@ -428,7 +428,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnectDsn) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Remove DSN
   EXPECT_TRUE(UnregisterDsn(wdsn));
@@ -440,17 +440,17 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLDriverConnectDsn) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLConnect) {
@@ -461,16 +461,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLConnect) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Connect string
   std::string connect_str = this->GetConnectionString();
@@ -497,7 +497,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLConnect) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Remove DSN
   EXPECT_TRUE(UnregisterDsn(wdsn));
@@ -509,17 +509,17 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLConnect) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInputUidPwd) {
@@ -530,16 +530,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInputUidPwd) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Connect string
   std::string connect_str = GetConnectionString();
@@ -575,7 +575,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInputUidPwd) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Remove DSN
   EXPECT_TRUE(UnregisterDsn(wdsn));
@@ -587,17 +587,17 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInputUidPwd) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInvalidUid) {
@@ -608,16 +608,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInvalidUid) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Connect string
   std::string connect_str = GetConnectionString();
@@ -660,12 +660,12 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectInvalidUid) {
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectDSNPrecedence) {
@@ -676,16 +676,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectDSNPrecedence) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Connect string
   std::string connect_str = GetConnectionString();
@@ -715,7 +715,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectDSNPrecedence) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Remove DSN
   EXPECT_TRUE(UnregisterDsn(wdsn));
@@ -727,17 +727,17 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLConnectDSNPrecedence) {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 #endif
@@ -750,16 +750,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLDriverConnectInvalidUid) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Invalid connect string
   std::string connect_str = GetInvalidConnectionString();
@@ -786,12 +786,12 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLDriverConnectInvalidUid) {
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TEST(SQLDisconnect, TestSQLDisconnectWithoutConnection) {
@@ -802,16 +802,16 @@ TEST(SQLDisconnect, TestSQLDisconnectWithoutConnection) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Attempt to disconnect without a connection, expect to fail
   ret = SQLDisconnect(conn);
@@ -824,12 +824,12 @@ TEST(SQLDisconnect, TestSQLDisconnectWithoutConnection) {
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestConnect) {
@@ -845,22 +845,22 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLAllocFreeStmt) {
   // Allocate a statement using alloc statement
   SQLRETURN ret = SQLAllocStmt(this->conn, &statement);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLWCHAR sql_buffer[ODBC_BUFFER_SIZE] = L"SELECT 1";
   ret = SQLExecDirect(statement, sql_buffer, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Close statement handle
   ret = SQLFreeStmt(statement, SQL_CLOSE);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free statement handle
   ret = SQLFreeStmt(statement, SQL_DROP);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -874,16 +874,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestCloseConnectionWithOpenStatement) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Connect string
   std::string connect_str = this->GetConnectionString();
@@ -899,27 +899,27 @@ TYPED_TEST(FlightSQLODBCTestBase, TestCloseConnectionWithOpenStatement) {
                          static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                          ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a statement using alloc statement
   ret = SQLAllocStmt(conn, &statement);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Disconnect from ODBC without closing the statement first
   ret = SQLDisconnect(conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLAllocFreeDesc) {
@@ -929,12 +929,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLAllocFreeDesc) {
   // Allocate a descriptor using alloc handle
   SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free descriptor handle
   ret = SQLFreeHandle(SQL_HANDLE_DESC, descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -947,12 +947,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrDescriptor) {
   // Allocate an APD descriptor using alloc handle
   SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &apd_descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate an ARD descriptor using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &ard_descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Save implicitly allocated internal APD and ARD descriptor pointers
   SQLPOINTER internal_apd, internal_ard = nullptr;
@@ -960,63 +960,63 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrDescriptor) {
   ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &internal_apd,
                        sizeof(internal_apd), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &internal_ard,
                        sizeof(internal_ard), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Set APD descriptor to explicitly allocated handle
   ret = SQLSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
                        reinterpret_cast<SQLPOINTER>(apd_descriptor), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Set ARD descriptor to explicitly allocated handle
   ret = SQLSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC,
                        reinterpret_cast<SQLPOINTER>(ard_descriptor), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify APD and ARD descriptors are set to explicitly allocated pointers
   SQLPOINTER value = nullptr;
 
   ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value, sizeof(value), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(value, apd_descriptor);
+  EXPECT_EQ(apd_descriptor, value);
 
   ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(value, ard_descriptor);
+  EXPECT_EQ(ard_descriptor, value);
 
   // Free explicitly allocated APD and ARD descriptor handles
   ret = SQLFreeHandle(SQL_HANDLE_DESC, apd_descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFreeHandle(SQL_HANDLE_DESC, ard_descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify APD and ARD descriptors has been reverted to implicit descriptors
   value = nullptr;
 
   ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value, sizeof(value), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(value, internal_apd);
+  EXPECT_EQ(internal_apd, value);
 
   ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(value, internal_ard);
+  EXPECT_EQ(internal_ard, value);
 
   this->Disconnect();
 }

--- a/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
@@ -36,16 +36,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailure) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Invalid connect string
   std::string connect_str = this->GetInvalidConnectionString();
@@ -62,7 +62,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailure) {
                          static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                          ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Retrieve all supported header level and record level data
   SQLSMALLINT HEADER_LEVEL = 0;
@@ -75,9 +75,9 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailure) {
   ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, HEADER_LEVEL, SQL_DIAG_NUMBER, &diag_number,
                         sizeof(SQLINTEGER), &diag_number_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(diag_number, 1);
+  EXPECT_EQ(1, diag_number);
 
   // SQL_DIAG_SERVER_NAME
   SQLWCHAR server_name[ODBC_BUFFER_SIZE];
@@ -86,7 +86,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailure) {
   ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_SERVER_NAME, server_name,
                         ODBC_BUFFER_SIZE, &server_name_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // SQL_DIAG_MESSAGE_TEXT
   SQLWCHAR message_text[ODBC_BUFFER_SIZE];
@@ -95,7 +95,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailure) {
   ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
                         message_text, ODBC_BUFFER_SIZE, &message_text_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_text_length, 100);
 
@@ -106,9 +106,9 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailure) {
   ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_NATIVE, &diag_native,
                         sizeof(diag_native), &diag_native_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(diag_native, 200);
+  EXPECT_EQ(200, diag_native);
 
   // SQL_DIAG_SQLSTATE
   const SQLSMALLINT sql_state_size = 6;
@@ -118,19 +118,19 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailure) {
                         sql_state_size * arrow::flight::sql::odbc::GetSqlWCharSize(),
                         &sql_state_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"28000"));
+  EXPECT_EQ(std::wstring(L"28000"), std::wstring(sql_state));
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailureNTS) {
@@ -144,16 +144,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailureNTS) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Invalid connect string
   std::string connect_str = this->GetInvalidConnectionString();
@@ -170,7 +170,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailureNTS) {
                          static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                          ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Retrieve all supported header level and record level data
   SQLSMALLINT RECORD_1 = 1;
@@ -184,19 +184,19 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagFieldWForConnectFailureNTS) {
   ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
                         message_text, SQL_NTS, &message_text_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_text_length, 100);
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TYPED_TEST(FlightSQLODBCTestBase,
@@ -207,11 +207,11 @@ TYPED_TEST(FlightSQLODBCTestBase,
   // Allocate a descriptor using alloc handle
   SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLGetDescField(descriptor, 1, SQL_DESC_DATETIME_INTERVAL_CODE, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Retrieve all supported header level and record level data
   SQLSMALLINT HEADER_LEVEL = 0;
@@ -224,9 +224,9 @@ TYPED_TEST(FlightSQLODBCTestBase,
   ret = SQLGetDiagField(SQL_HANDLE_DESC, descriptor, HEADER_LEVEL, SQL_DIAG_NUMBER,
                         &diag_number, sizeof(SQLINTEGER), &diag_number_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(diag_number, 1);
+  EXPECT_EQ(1, diag_number);
 
   // SQL_DIAG_SERVER_NAME
   SQLWCHAR server_name[ODBC_BUFFER_SIZE];
@@ -235,7 +235,7 @@ TYPED_TEST(FlightSQLODBCTestBase,
   ret = SQLGetDiagField(SQL_HANDLE_DESC, descriptor, RECORD_1, SQL_DIAG_SERVER_NAME,
                         server_name, ODBC_BUFFER_SIZE, &server_name_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // SQL_DIAG_MESSAGE_TEXT
   SQLWCHAR message_text[ODBC_BUFFER_SIZE];
@@ -244,7 +244,7 @@ TYPED_TEST(FlightSQLODBCTestBase,
   ret = SQLGetDiagField(SQL_HANDLE_DESC, descriptor, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
                         message_text, ODBC_BUFFER_SIZE, &message_text_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_text_length, 100);
 
@@ -255,9 +255,9 @@ TYPED_TEST(FlightSQLODBCTestBase,
   ret = SQLGetDiagField(SQL_HANDLE_DESC, descriptor, RECORD_1, SQL_DIAG_NATIVE,
                         &diag_native, sizeof(diag_native), &diag_native_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(diag_native, 0);
+  EXPECT_EQ(0, diag_native);
 
   // SQL_DIAG_SQLSTATE
   const SQLSMALLINT sql_state_size = 6;
@@ -267,14 +267,14 @@ TYPED_TEST(FlightSQLODBCTestBase,
       SQL_HANDLE_DESC, descriptor, RECORD_1, SQL_DIAG_SQLSTATE, sql_state,
       sql_state_size * arrow::flight::sql::odbc::GetSqlWCharSize(), &sql_state_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"IM001"));
+  EXPECT_EQ(std::wstring(L"IM001"), std::wstring(sql_state));
 
   // Free descriptor handle
   ret = SQLFreeHandle(SQL_HANDLE_DESC, descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -287,11 +287,11 @@ TYPED_TEST(FlightSQLODBCTestBase,
   // Allocate a descriptor using alloc handle
   SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLGetDescField(descriptor, 1, SQL_DESC_DATETIME_INTERVAL_CODE, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   SQLWCHAR sql_state[6];
   SQLINTEGER native_error;
@@ -301,21 +301,21 @@ TYPED_TEST(FlightSQLODBCTestBase,
   ret = SQLGetDiagRec(SQL_HANDLE_DESC, descriptor, 1, sql_state, &native_error, message,
                       ODBC_BUFFER_SIZE, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 60);
 
-  EXPECT_EQ(native_error, 0);
+  EXPECT_EQ(0, native_error);
 
   // API not implemented error from driver manager
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"IM001"));
+  EXPECT_EQ(std::wstring(L"IM001"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
   // Free descriptor handle
   ret = SQLFreeHandle(SQL_HANDLE_DESC, descriptor);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -328,16 +328,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecForConnectFailure) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Invalid connect string
   std::string connect_str = this->GetInvalidConnectionString();
@@ -354,7 +354,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecForConnectFailure) {
                          static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                          ODBC_BUFFER_SIZE, &out_str_len, SQL_DRIVER_NOPROMPT);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   SQLWCHAR sql_state[6];
   SQLINTEGER native_error;
@@ -364,25 +364,25 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecForConnectFailure) {
   ret = SQLGetDiagRec(SQL_HANDLE_DBC, conn, 1, sql_state, &native_error, message,
                       ODBC_BUFFER_SIZE, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 120);
 
-  EXPECT_EQ(native_error, 200);
+  EXPECT_EQ(200, native_error);
 
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"28000"));
+  EXPECT_EQ(std::wstring(L"28000"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecInputData) {
@@ -398,17 +398,17 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetDiagRecInputData) {
   SQLRETURN ret = SQLGetDiagRec(SQL_HANDLE_DBC, this->conn, 0, sql_state, &native_error,
                                 message, ODBC_BUFFER_SIZE, &message_length);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Pass valid record number with null inputs
   ret = SQLGetDiagRec(SQL_HANDLE_DBC, this->conn, 1, 0, 0, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   // Invalid handle
   ret = SQLGetDiagRec(0, 0, 0, 0, 0, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_INVALID_HANDLE);
+  EXPECT_EQ(SQL_INVALID_HANDLE, ret);
 
   this->Disconnect();
 }
@@ -421,20 +421,20 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorInputData) {
   // Pass valid handles with null inputs
   SQLRETURN ret = SQLError(this->env, 0, 0, 0, 0, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   ret = SQLError(0, this->conn, 0, 0, 0, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   ret = SQLError(0, 0, this->stmt, 0, 0, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   // Invalid handle
   ret = SQLError(0, 0, 0, 0, 0, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_INVALID_HANDLE);
+  EXPECT_EQ(SQL_INVALID_HANDLE, ret);
 
   this->Disconnect();
 }
@@ -450,7 +450,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorFromDriverManager) {
   SQLRETURN ret = SQLSetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION,
                                 reinterpret_cast<void*>(SQL_OV_ODBC2), 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -459,14 +459,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorFromDriverManager) {
   ret = SQLError(this->env, 0, 0, sql_state, &native_error, message,
                  SQL_MAX_MESSAGE_LENGTH, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 50);
 
-  EXPECT_EQ(native_error, 0);
+  EXPECT_EQ(0, native_error);
 
   // Function sequence error state from driver manager
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"HY010"));
+  EXPECT_EQ(std::wstring(L"HY010"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
@@ -483,7 +483,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnError) {
   // Attempt to set unsupported attribute
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -492,14 +492,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnError) {
   ret = SQLError(0, this->conn, 0, sql_state, &native_error, message,
                  SQL_MAX_MESSAGE_LENGTH, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 60);
 
-  EXPECT_EQ(native_error, 100);
+  EXPECT_EQ(100, native_error);
 
   // optional feature not supported error state
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"HYC00"));
+  EXPECT_EQ(std::wstring(L"HYC00"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
@@ -519,7 +519,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtError) {
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -528,13 +528,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtError) {
   ret = SQLError(0, 0, this->stmt, sql_state, &native_error, message,
                  SQL_MAX_MESSAGE_LENGTH, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 70);
 
-  EXPECT_EQ(native_error, 100);
+  EXPECT_EQ(100, native_error);
 
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"HY000"));
+  EXPECT_EQ(std::wstring(L"HY000"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
@@ -550,10 +550,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtWarning) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   const int len = 17;
   SQLCHAR char_val[len];
@@ -562,7 +562,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtWarning) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -571,14 +571,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtWarning) {
   ret = SQLError(0, 0, this->stmt, sql_state, &native_error, message,
                  SQL_MAX_MESSAGE_LENGTH, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 50);
 
-  EXPECT_EQ(native_error, 1000100);
+  EXPECT_EQ(1000100, native_error);
 
   // Verify string truncation warning is reported
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"01004"));
+  EXPECT_EQ(std::wstring(L"01004"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 }
@@ -594,7 +594,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorODBCVer2FromDriverManager)
   SQLRETURN ret = SQLSetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION,
                                 reinterpret_cast<void*>(SQL_OV_ODBC2), 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -603,14 +603,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorEnvErrorODBCVer2FromDriverManager)
   ret = SQLError(this->env, 0, 0, sql_state, &native_error, message,
                  SQL_MAX_MESSAGE_LENGTH, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 50);
 
-  EXPECT_EQ(native_error, 0);
+  EXPECT_EQ(0, native_error);
 
   // Function sequence error state from driver manager
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"S1010"));
+  EXPECT_EQ(std::wstring(L"S1010"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
@@ -627,7 +627,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnErrorODBCVer2) {
   // Attempt to set unsupported attribute
   SQLRETURN ret = SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -636,14 +636,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorConnErrorODBCVer2) {
   ret = SQLError(0, this->conn, 0, sql_state, &native_error, message,
                  SQL_MAX_MESSAGE_LENGTH, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 60);
 
-  EXPECT_EQ(native_error, 100);
+  EXPECT_EQ(100, native_error);
 
   // optional feature not supported error state. Driver Manager maps state to S1C00
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"S1C00"));
+  EXPECT_EQ(std::wstring(L"S1C00"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
@@ -663,7 +663,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtErrorODBCVer2) {
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -672,14 +672,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtErrorODBCVer2) {
   ret = SQLError(0, 0, this->stmt, sql_state, &native_error, message,
                  SQL_MAX_MESSAGE_LENGTH, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 70);
 
-  EXPECT_EQ(native_error, 100);
+  EXPECT_EQ(100, native_error);
 
   // Driver Manager maps error state to S1000
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"S1000"));
+  EXPECT_EQ(std::wstring(L"S1000"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 
@@ -695,10 +695,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtWarningODBCVer2) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   const int len = 17;
   SQLCHAR char_val[len];
@@ -707,7 +707,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtWarningODBCVer2) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -716,14 +716,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLErrorStmtWarningODBCVer2) {
   ret = SQLError(0, 0, this->stmt, sql_state, &native_error, message,
                  SQL_MAX_MESSAGE_LENGTH, &message_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(message_length, 50);
 
-  EXPECT_EQ(native_error, 1000100);
+  EXPECT_EQ(1000100, native_error);
 
   // Verify string truncation warning is reported
-  EXPECT_EQ(std::wstring(sql_state), std::wstring(L"01004"));
+  EXPECT_EQ(std::wstring(L"01004"), std::wstring(sql_state));
 
   EXPECT_TRUE(!std::wstring(message).empty());
 }

--- a/cpp/src/arrow/flight/sql/odbc/tests/get_functions_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/get_functions_test.cc
@@ -65,14 +65,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsAllFunctions) {
       SQL_API_SQLTABLEPRIVILEGES};
   SQLRETURN ret = SQLGetFunctions(this->conn, SQL_API_ODBC3_ALL_FUNCTIONS, api_exists);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (int api : supported_functions) {
-    EXPECT_EQ(SQL_FUNC_EXISTS(api_exists, api), SQL_TRUE);
+    EXPECT_EQ(SQL_TRUE, SQL_FUNC_EXISTS(api_exists, api));
   }
 
   for (int api : unsupported_functions) {
-    EXPECT_EQ(SQL_FUNC_EXISTS(api_exists, api), SQL_FALSE);
+    EXPECT_EQ(SQL_FALSE, SQL_FUNC_EXISTS(api_exists, api));
   }
 
   this->Disconnect();
@@ -106,14 +106,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsAllFunctionsODBCVer2) {
       SQL_API_SQLTABLEPRIVILEGES};
   SQLRETURN ret = SQLGetFunctions(this->conn, SQL_API_ALL_FUNCTIONS, api_exists);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (int api : supported_functions) {
-    EXPECT_EQ(api_exists[api], SQL_TRUE);
+    EXPECT_EQ(SQL_TRUE, api_exists[api]);
   }
 
   for (int api : unsupported_functions) {
-    EXPECT_EQ(api_exists[api], SQL_FALSE);
+    EXPECT_EQ(SQL_FALSE, api_exists[api]);
   }
 
   this->Disconnect();
@@ -147,9 +147,9 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsSupportedSingleAPI) {
   for (SQLUSMALLINT api : supported_functions) {
     SQLRETURN ret = SQLGetFunctions(this->conn, api, &api_exists);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(api_exists, SQL_TRUE);
+    EXPECT_EQ(SQL_TRUE, api_exists);
 
     api_exists = -1;
   }
@@ -173,9 +173,9 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsUnsupportedSingleAPI) {
   for (SQLUSMALLINT api : unsupported_functions) {
     SQLRETURN ret = SQLGetFunctions(this->conn, api, &api_exists);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(api_exists, SQL_FALSE);
+    EXPECT_EQ(SQL_FALSE, api_exists);
 
     api_exists = -1;
   }
@@ -203,9 +203,9 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsSupportedSingleAPIODBCVer2)
   for (SQLUSMALLINT api : supported_functions) {
     SQLRETURN ret = SQLGetFunctions(this->conn, api, &api_exists);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(api_exists, SQL_TRUE);
+    EXPECT_EQ(SQL_TRUE, api_exists);
 
     api_exists = -1;
   }
@@ -227,9 +227,9 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetFunctionsUnsupportedSingleAPIODBCVer
   for (SQLUSMALLINT api : unsupported_functions) {
     SQLRETURN ret = SQLGetFunctions(this->conn, api, &api_exists);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(api_exists, SQL_FALSE);
+    EXPECT_EQ(SQL_FALSE, api_exists);
 
     api_exists = -1;
   }

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -31,17 +31,17 @@ void FlightSQLODBCRemoteTestBase::AllocEnvConnHandles(SQLINTEGER odbc_ver) {
   // Allocate an environment handle
   SQLRETURN ret = SQLAllocEnv(&env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION,
                       reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(odbc_ver)), 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Allocate a connection using alloc handle
   ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 void FlightSQLODBCRemoteTestBase::Connect(SQLINTEGER odbc_ver) {
@@ -79,7 +79,7 @@ void FlightSQLODBCRemoteTestBase::Disconnect() {
   // Close statement
   SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Disconnect from ODBC
   ret = SQLDisconnect(conn);
@@ -88,17 +88,17 @@ void FlightSQLODBCRemoteTestBase::Disconnect() {
     std::cerr << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn) << std::endl;
   }
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free connection handle
   ret = SQLFreeHandle(SQL_HANDLE_DBC, conn);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Free environment handle
   ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 std::string FlightSQLODBCRemoteTestBase::GetConnectionString() {
@@ -368,7 +368,7 @@ void VerifyOdbcErrorState(SQLSMALLINT handle_type, SQLHANDLE handle,
 
   std::string res = SqlWcharToString(sql_state);
 
-  EXPECT_EQ(res, expected_state);
+  EXPECT_EQ(expected_state, res);
 }
 
 std::string GetOdbcErrorMessage(SQLSMALLINT handle_type, SQLHANDLE handle) {
@@ -443,7 +443,7 @@ void CheckStringColumnW(SQLHSTMT stmt, int col_id, const std::wstring& expected)
   SQLLEN buf_len = sizeof(buf) * ODBC::GetSqlWCharSize();
 
   SQLRETURN ret = SQLGetData(stmt, col_id, SQL_C_WCHAR, buf, buf_len, &buf_len);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(buf_len, 0);
 
@@ -451,7 +451,7 @@ void CheckStringColumnW(SQLHSTMT stmt, int col_id, const std::wstring& expected)
   size_t char_count = static_cast<size_t>(buf_len) / ODBC::GetSqlWCharSize();
   std::wstring returned(buf, buf + char_count);
 
-  EXPECT_EQ(returned, expected);
+  EXPECT_EQ(expected, returned);
 }
 
 void CheckNullColumnW(SQLHSTMT stmt, int col_id) {
@@ -459,9 +459,9 @@ void CheckNullColumnW(SQLHSTMT stmt, int col_id) {
   SQLLEN buf_len = sizeof(buf);
 
   SQLRETURN ret = SQLGetData(stmt, col_id, SQL_C_WCHAR, buf, buf_len, &buf_len);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(buf_len, SQL_NULL_DATA);
+  EXPECT_EQ(SQL_NULL_DATA, buf_len);
 }
 
 void CheckIntColumn(SQLHSTMT stmt, int col_id, const SQLINTEGER& expected) {
@@ -469,9 +469,9 @@ void CheckIntColumn(SQLHSTMT stmt, int col_id, const SQLINTEGER& expected) {
   SQLLEN buf_len = sizeof(buf);
 
   SQLRETURN ret = SQLGetData(stmt, col_id, SQL_C_LONG, &buf, sizeof(buf), &buf_len);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(buf, expected);
+  EXPECT_EQ(expected, buf);
 }
 
 void CheckSmallIntColumn(SQLHSTMT stmt, int col_id, const SQLSMALLINT& expected) {
@@ -479,15 +479,15 @@ void CheckSmallIntColumn(SQLHSTMT stmt, int col_id, const SQLSMALLINT& expected)
   SQLLEN buf_len = sizeof(buf);
 
   SQLRETURN ret = SQLGetData(stmt, col_id, SQL_C_SSHORT, &buf, sizeof(buf), &buf_len);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(buf, expected);
+  EXPECT_EQ(expected, buf);
 }
 
 void ValidateFetch(SQLHSTMT stmt, SQLRETURN expected_return) {
   SQLRETURN ret = SQLFetch(stmt);
 
-  EXPECT_EQ(ret, expected_return);
+  EXPECT_EQ(expected_return, ret);
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -42,9 +42,9 @@ void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
   SQLRETURN ret =
       SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(value, expected_value);
+  EXPECT_EQ(expected_value, value);
 }
 
 // Validate SQLLEN return value
@@ -56,9 +56,9 @@ void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
   SQLRETURN ret =
       SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(value, expected_value);
+  EXPECT_EQ(expected_value, value);
 }
 
 // Validate SQLPOINTER return value
@@ -70,9 +70,9 @@ void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
   SQLRETURN ret =
       SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(value, expected_value);
+  EXPECT_EQ(expected_value, value);
 }
 
 // Validate unsigned length SQLULEN return value is greater than
@@ -83,7 +83,7 @@ void ValidateGetStmtAttrGreaterThan(SQLHSTMT statement, SQLINTEGER attribute,
 
   SQLRETURN ret = SQLGetStmtAttr(statement, attribute, &value, 0, &string_length_ptr);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_GT(value, compared_value);
 }
@@ -96,7 +96,7 @@ void ValidateGetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
 
   SQLRETURN ret = SQLGetStmtAttr(statement, attribute, &value, 0, &string_length_ptr);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   VerifyOdbcErrorState(SQL_HANDLE_STMT, statement, error_code);
 }
@@ -108,7 +108,7 @@ void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLULEN new_v
   SQLRETURN ret = SQLSetStmtAttr(
       statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 // Validate return value for call to SQLSetStmtAttr with SQLLEN
@@ -118,14 +118,14 @@ void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLLEN new_va
   SQLRETURN ret = SQLSetStmtAttr(
       statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 // Validate return value for call to SQLSetStmtAttr with SQLPOINTER
 void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLPOINTER value) {
   SQLRETURN ret = SQLSetStmtAttr(statement, attribute, value, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 }
 
 // Validate error return value and code
@@ -136,7 +136,7 @@ void ValidateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
   SQLRETURN ret = SQLSetStmtAttr(
       statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   VerifyOdbcErrorState(SQL_HANDLE_STMT, statement, error_code);
 }
@@ -420,11 +420,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowNumber) {
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(1));
 
@@ -493,7 +493,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAppParamDesc) {
   SQLRETURN ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &app_param_desc, 0,
                                  &string_length_ptr);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, static_cast<SQLULEN>(0));
 
@@ -511,7 +511,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAppRowDesc) {
   SQLRETURN ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &app_row_desc, 0,
                                  &string_length_ptr);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(0));
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -38,26 +38,26 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectSimpleQuery) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLINTEGER val;
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Verify 1 is returned
-  EXPECT_EQ(val, 1);
+  EXPECT_EQ(1, val);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
 
@@ -73,7 +73,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectInvalidQuery) {
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // ODBC provides generic error code HY000 to all statement errors
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY000);
 
@@ -87,30 +87,30 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecuteSimpleQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   SQLRETURN ret = SQLPrepare(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLExecute(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Fetch data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLINTEGER val;
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Verify 1 is returned
-  EXPECT_EQ(val, 1);
+  EXPECT_EQ(1, val);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
 
@@ -125,7 +125,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLPrepareInvalidQuery) {
 
   SQLRETURN ret = SQLPrepare(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // ODBC provides generic error code HY000 to all statement errors
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY000);
 
@@ -144,10 +144,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Numeric Types
 
@@ -158,13 +158,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(stiny_int_val, std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<int8_t>::min(), stiny_int_val);
 
   ret = SQLGetData(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(stiny_int_val, std::numeric_limits<int8_t>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<int8_t>::max(), stiny_int_val);
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val;
@@ -172,13 +172,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(utiny_int_val, std::numeric_limits<uint8_t>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<uint8_t>::min(), utiny_int_val);
 
   ret = SQLGetData(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(utiny_int_val, std::numeric_limits<uint8_t>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<uint8_t>::max(), utiny_int_val);
 
   // Signed Small Int
   int16_t ssmall_int_val;
@@ -186,13 +186,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ssmall_int_val, std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<int16_t>::min(), ssmall_int_val);
 
   ret = SQLGetData(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ssmall_int_val, std::numeric_limits<int16_t>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<int16_t>::max(), ssmall_int_val);
 
   // Unsigned Small Int
   uint16_t usmall_int_val;
@@ -200,13 +200,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 7, SQL_C_USHORT, &usmall_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(usmall_int_val, std::numeric_limits<uint16_t>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<uint16_t>::min(), usmall_int_val);
 
   ret = SQLGetData(this->stmt, 8, SQL_C_USHORT, &usmall_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(usmall_int_val, std::numeric_limits<uint16_t>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<uint16_t>::max(), usmall_int_val);
 
   // Signed Integer
   SQLINTEGER slong_val;
@@ -214,13 +214,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 9, SQL_C_SLONG, &slong_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(slong_val, std::numeric_limits<SQLINTEGER>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
   ret = SQLGetData(this->stmt, 10, SQL_C_SLONG, &slong_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(slong_val, std::numeric_limits<SQLINTEGER>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Unsigned Integer
   SQLUINTEGER ulong_val;
@@ -228,13 +228,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 11, SQL_C_ULONG, &ulong_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ulong_val, std::numeric_limits<SQLUINTEGER>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::min(), ulong_val);
 
   ret = SQLGetData(this->stmt, 12, SQL_C_ULONG, &ulong_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ulong_val, std::numeric_limits<SQLUINTEGER>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::max(), ulong_val);
 
   // Signed Big Int
   SQLBIGINT sbig_int_val;
@@ -242,13 +242,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(sbig_int_val, std::numeric_limits<SQLBIGINT>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
   ret = SQLGetData(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(sbig_int_val, std::numeric_limits<SQLBIGINT>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val;
@@ -256,13 +256,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ubig_int_val, std::numeric_limits<SQLUBIGINT>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::min(), ubig_int_val);
 
   ret = SQLGetData(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ubig_int_val, std::numeric_limits<SQLUBIGINT>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::max(), ubig_int_val);
 
   // Decimal
   SQL_NUMERIC_STRUCT decimal_val;
@@ -271,22 +271,22 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 17, SQL_C_NUMERIC, &decimal_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check for negative decimal_val value
-  EXPECT_EQ(decimal_val.sign, 0);
-  EXPECT_EQ(decimal_val.scale, 0);
-  EXPECT_EQ(decimal_val.precision, 38);
+  EXPECT_EQ(0, decimal_val.sign);
+  EXPECT_EQ(0, decimal_val.scale);
+  EXPECT_EQ(38, decimal_val.precision);
   EXPECT_THAT(decimal_val.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0, 0,
                                                       0, 0, 0, 0, 0, 0, 0, 0));
 
   memset(&decimal_val, 0, sizeof(decimal_val));
   ret = SQLGetData(this->stmt, 18, SQL_C_NUMERIC, &decimal_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check for positive decimal_val value
-  EXPECT_EQ(decimal_val.sign, 1);
-  EXPECT_EQ(decimal_val.scale, 0);
-  EXPECT_EQ(decimal_val.precision, 38);
+  EXPECT_EQ(1, decimal_val.sign);
+  EXPECT_EQ(0, decimal_val.scale);
+  EXPECT_EQ(38, decimal_val.precision);
   EXPECT_THAT(decimal_val.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0, 0,
                                                       0, 0, 0, 0, 0, 0, 0, 0));
 
@@ -296,14 +296,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 19, SQL_C_FLOAT, &float_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Get minimum negative float value
-  EXPECT_EQ(float_val, -std::numeric_limits<float>::max());
+  EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
   ret = SQLGetData(this->stmt, 20, SQL_C_FLOAT, &float_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(float_val, std::numeric_limits<float>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
@@ -311,14 +311,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 21, SQL_C_DOUBLE, &double_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Get minimum negative double value
-  EXPECT_EQ(double_val, -std::numeric_limits<SQLDOUBLE>::max());
+  EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   ret = SQLGetData(this->stmt, 22, SQL_C_DOUBLE, &double_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(double_val, std::numeric_limits<SQLDOUBLE>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
@@ -326,13 +326,13 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 23, SQL_C_BIT, &bit_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(bit_val, false);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(false, bit_val);
 
   ret = SQLGetData(this->stmt, 24, SQL_C_BIT, &bit_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(bit_val, true);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(true, bit_val);
 
   // Characters
 
@@ -342,8 +342,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(char_val[0], 'Z');
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ('Z', char_val[0]);
 
   // WChar
   SQLWCHAR wchar_val[2];
@@ -352,8 +352,8 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(wchar_val[0], L'你');
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(L'你', wchar_val[0]);
 
   // WVarchar
   SQLWCHAR wvarchar_val[3];
@@ -361,9 +361,9 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(wvarchar_val[0], L'你');
-  EXPECT_EQ(wvarchar_val[1], L'好');
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(L'你', wvarchar_val[0]);
+  EXPECT_EQ(L'好', wvarchar_val[1]);
 
   // varchar
   SQLCHAR varchar_val[4];
@@ -371,10 +371,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(varchar_val[0], 'X');
-  EXPECT_EQ(varchar_val[1], 'Y');
-  EXPECT_EQ(varchar_val[2], 'Z');
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ('X', varchar_val[0]);
+  EXPECT_EQ('Y', varchar_val[1]);
+  EXPECT_EQ('Z', varchar_val[2]);
 
   // Date and Timestamp
 
@@ -384,19 +384,19 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 29, SQL_C_TYPE_DATE, &date_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check min values for date. Min valid year is 1400.
-  EXPECT_EQ(date_var.day, 1);
-  EXPECT_EQ(date_var.month, 1);
-  EXPECT_EQ(date_var.year, 1400);
+  EXPECT_EQ(1, date_var.day);
+  EXPECT_EQ(1, date_var.month);
+  EXPECT_EQ(1400, date_var.year);
 
   ret = SQLGetData(this->stmt, 30, SQL_C_TYPE_DATE, &date_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check max values for date. Max valid year is 9999.
-  EXPECT_EQ(date_var.day, 31);
-  EXPECT_EQ(date_var.month, 12);
-  EXPECT_EQ(date_var.year, 9999);
+  EXPECT_EQ(31, date_var.day);
+  EXPECT_EQ(12, date_var.month);
+  EXPECT_EQ(9999, date_var.year);
 
   // Timestamp
   SQL_TIMESTAMP_STRUCT timestamp_var{};
@@ -404,27 +404,27 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectDataQuery) {
 
   ret = SQLGetData(this->stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check min values for date. Min valid year is 1400.
-  EXPECT_EQ(timestamp_var.day, 1);
-  EXPECT_EQ(timestamp_var.month, 1);
-  EXPECT_EQ(timestamp_var.year, 1400);
-  EXPECT_EQ(timestamp_var.hour, 0);
-  EXPECT_EQ(timestamp_var.minute, 0);
-  EXPECT_EQ(timestamp_var.second, 0);
-  EXPECT_EQ(timestamp_var.fraction, 0);
+  EXPECT_EQ(1, timestamp_var.day);
+  EXPECT_EQ(1, timestamp_var.month);
+  EXPECT_EQ(1400, timestamp_var.year);
+  EXPECT_EQ(0, timestamp_var.hour);
+  EXPECT_EQ(0, timestamp_var.minute);
+  EXPECT_EQ(0, timestamp_var.second);
+  EXPECT_EQ(0, timestamp_var.fraction);
 
   ret = SQLGetData(this->stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check max values for date. Max valid year is 9999.
-  EXPECT_EQ(timestamp_var.day, 31);
-  EXPECT_EQ(timestamp_var.month, 12);
-  EXPECT_EQ(timestamp_var.year, 9999);
-  EXPECT_EQ(timestamp_var.hour, 23);
-  EXPECT_EQ(timestamp_var.minute, 59);
-  EXPECT_EQ(timestamp_var.second, 59);
-  EXPECT_EQ(timestamp_var.fraction, 0);
+  EXPECT_EQ(31, timestamp_var.day);
+  EXPECT_EQ(12, timestamp_var.month);
+  EXPECT_EQ(9999, timestamp_var.year);
+  EXPECT_EQ(23, timestamp_var.hour);
+  EXPECT_EQ(59, timestamp_var.minute);
+  EXPECT_EQ(59, timestamp_var.second);
+  EXPECT_EQ(0, timestamp_var.fraction);
 
   this->Disconnect();
 }
@@ -443,10 +443,10 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectTimeQuery) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQL_TIME_STRUCT time_var{};
   SQLLEN buf_len = sizeof(time_var);
@@ -454,19 +454,19 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectTimeQuery) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_TYPE_TIME, &time_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check min values for time.
-  EXPECT_EQ(time_var.hour, 0);
-  EXPECT_EQ(time_var.minute, 0);
-  EXPECT_EQ(time_var.second, 0);
+  EXPECT_EQ(0, time_var.hour);
+  EXPECT_EQ(0, time_var.minute);
+  EXPECT_EQ(0, time_var.second);
 
   ret = SQLGetData(this->stmt, 2, SQL_C_TYPE_TIME, &time_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check max values for time.
-  EXPECT_EQ(time_var.hour, 23);
-  EXPECT_EQ(time_var.minute, 59);
-  EXPECT_EQ(time_var.second, 59);
+  EXPECT_EQ(23, time_var.hour);
+  EXPECT_EQ(59, time_var.minute);
+  EXPECT_EQ(59, time_var.second);
 
   this->Disconnect();
 }
@@ -481,19 +481,19 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectVarbinaryQuery) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ret = SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind);
-  EXPECT_EQ(varbinary_val[0], '\xAB');
-  EXPECT_EQ(varbinary_val[1], '\xCD');
-  EXPECT_EQ(varbinary_val[2], '\xEF');
+  EXPECT_EQ('\xAB', varbinary_val[0]);
+  EXPECT_EQ('\xCD', varbinary_val[1]);
+  EXPECT_EQ('\xEF', varbinary_val[2]);
 
   this->Disconnect();
 }
@@ -509,10 +509,10 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Numeric Types
   // Signed Integer
@@ -522,13 +522,13 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 9, SQL_C_DEFAULT, &slong_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(slong_val, std::numeric_limits<SQLINTEGER>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
   ret = SQLGetData(this->stmt, 10, SQL_C_DEFAULT, &slong_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(slong_val, std::numeric_limits<SQLINTEGER>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Signed Big Int
   SQLBIGINT sbig_int_val;
@@ -536,13 +536,13 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 13, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(sbig_int_val, std::numeric_limits<SQLBIGINT>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
   ret = SQLGetData(this->stmt, 14, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(sbig_int_val, std::numeric_limits<SQLBIGINT>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Decimal
   SQL_NUMERIC_STRUCT decimal_val;
@@ -551,22 +551,22 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 17, SQL_C_DEFAULT, &decimal_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check for negative decimal_val value
-  EXPECT_EQ(decimal_val.sign, 0);
-  EXPECT_EQ(decimal_val.scale, 0);
-  EXPECT_EQ(decimal_val.precision, 38);
+  EXPECT_EQ(0, decimal_val.sign);
+  EXPECT_EQ(0, decimal_val.scale);
+  EXPECT_EQ(0, decimal_val.precision);
   EXPECT_THAT(decimal_val.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0, 0,
                                                       0, 0, 0, 0, 0, 0, 0, 0));
 
   memset(&decimal_val, 0, sizeof(decimal_val));
   ret = SQLGetData(this->stmt, 18, SQL_C_DEFAULT, &decimal_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check for positive decimal_val value
-  EXPECT_EQ(decimal_val.sign, 1);
-  EXPECT_EQ(decimal_val.scale, 0);
-  EXPECT_EQ(decimal_val.precision, 38);
+  EXPECT_EQ(1, decimal_val.sign);
+  EXPECT_EQ(0, decimal_val.scale);
+  EXPECT_EQ(0, decimal_val.precision);
   EXPECT_THAT(decimal_val.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0, 0,
                                                       0, 0, 0, 0, 0, 0, 0, 0));
 
@@ -576,14 +576,14 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 19, SQL_C_DEFAULT, &float_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Get minimum negative float value
-  EXPECT_EQ(float_val, -std::numeric_limits<float>::max());
+  EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
   ret = SQLGetData(this->stmt, 20, SQL_C_DEFAULT, &float_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(float_val, std::numeric_limits<float>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
@@ -591,14 +591,14 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 21, SQL_C_DEFAULT, &double_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Get minimum negative double value
-  EXPECT_EQ(double_val, -std::numeric_limits<SQLDOUBLE>::max());
+  EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   ret = SQLGetData(this->stmt, 22, SQL_C_DEFAULT, &double_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(double_val, std::numeric_limits<SQLDOUBLE>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
@@ -606,13 +606,13 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 23, SQL_C_DEFAULT, &bit_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(bit_val, false);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(false, bit_val);
 
   ret = SQLGetData(this->stmt, 24, SQL_C_DEFAULT, &bit_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(bit_val, true);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(true, bit_val);
 
   // Characters
 
@@ -623,16 +623,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 25, SQL_C_DEFAULT, &wchar_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(wchar_val[0], L'Z');
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(L'Z', wchar_val[0]);
 
   // WChar
   SQLWCHAR wchar_val2[2];
   buf_len = wchar_size * 2;
   ret = SQLGetData(this->stmt, 26, SQL_C_DEFAULT, &wchar_val2, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(wchar_val2[0], L'你');
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(L'你', wchar_val2[0]);
 
   // WVarchar
   SQLWCHAR wvarchar_val[3];
@@ -640,9 +640,9 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 27, SQL_C_DEFAULT, &wvarchar_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(wvarchar_val[0], L'你');
-  EXPECT_EQ(wvarchar_val[1], L'好');
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(L'你', wvarchar_val[0]);
+  EXPECT_EQ(L'好', wvarchar_val[1]);
 
   // Varchar will be fetched as WVarchar by default
   SQLWCHAR wvarchar_val2[4];
@@ -650,10 +650,10 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 28, SQL_C_DEFAULT, &wvarchar_val2, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(wvarchar_val2[0], L'X');
-  EXPECT_EQ(wvarchar_val2[1], L'Y');
-  EXPECT_EQ(wvarchar_val2[2], L'Z');
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(L'X', wvarchar_val2[0]);
+  EXPECT_EQ(L'Y', wvarchar_val2[1]);
+  EXPECT_EQ(L'Z', wvarchar_val2[2]);
 
   // Date and Timestamp
 
@@ -663,19 +663,19 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 29, SQL_C_DEFAULT, &date_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check min values for date. Min valid year is 1400.
-  EXPECT_EQ(date_var.day, 1);
-  EXPECT_EQ(date_var.month, 1);
-  EXPECT_EQ(date_var.year, 1400);
+  EXPECT_EQ(1, date_var.day);
+  EXPECT_EQ(1, date_var.month);
+  EXPECT_EQ(1400, date_var.year);
 
   ret = SQLGetData(this->stmt, 30, SQL_C_DEFAULT, &date_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check max values for date. Max valid year is 9999.
-  EXPECT_EQ(date_var.day, 31);
-  EXPECT_EQ(date_var.month, 12);
-  EXPECT_EQ(date_var.year, 9999);
+  EXPECT_EQ(31, date_var.day);
+  EXPECT_EQ(12, date_var.month);
+  EXPECT_EQ(9999, date_var.year);
 
   // Timestamp
   SQL_TIMESTAMP_STRUCT timestamp_var{};
@@ -683,27 +683,27 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectDataQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 31, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check min values for date. Min valid year is 1400.
-  EXPECT_EQ(timestamp_var.day, 1);
-  EXPECT_EQ(timestamp_var.month, 1);
-  EXPECT_EQ(timestamp_var.year, 1400);
-  EXPECT_EQ(timestamp_var.hour, 0);
-  EXPECT_EQ(timestamp_var.minute, 0);
-  EXPECT_EQ(timestamp_var.second, 0);
-  EXPECT_EQ(timestamp_var.fraction, 0);
+  EXPECT_EQ(1, timestamp_var.day);
+  EXPECT_EQ(1, timestamp_var.month);
+  EXPECT_EQ(1400, timestamp_var.year);
+  EXPECT_EQ(0, timestamp_var.hour);
+  EXPECT_EQ(0, timestamp_var.minute);
+  EXPECT_EQ(0, timestamp_var.second);
+  EXPECT_EQ(0, timestamp_var.fraction);
 
   ret = SQLGetData(this->stmt, 32, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check max values for date. Max valid year is 9999.
-  EXPECT_EQ(timestamp_var.day, 31);
-  EXPECT_EQ(timestamp_var.month, 12);
-  EXPECT_EQ(timestamp_var.year, 9999);
-  EXPECT_EQ(timestamp_var.hour, 23);
-  EXPECT_EQ(timestamp_var.minute, 59);
-  EXPECT_EQ(timestamp_var.second, 59);
-  EXPECT_EQ(timestamp_var.fraction, 0);
+  EXPECT_EQ(31, timestamp_var.day);
+  EXPECT_EQ(12, timestamp_var.month);
+  EXPECT_EQ(9999, timestamp_var.year);
+  EXPECT_EQ(23, timestamp_var.hour);
+  EXPECT_EQ(59, timestamp_var.minute);
+  EXPECT_EQ(59, timestamp_var.second);
+  EXPECT_EQ(0, timestamp_var.fraction);
 
   this->Disconnect();
 }
@@ -715,17 +715,17 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectTimeQueryDefaultType) {
 
   std::wstring wsql =
       LR"(
-    SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
-           CAST(TIME '23:59:59' AS TIME) AS time_max;
-    )";
+   SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
+          CAST(TIME '23:59:59' AS TIME) AS time_max;
+   )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQL_TIME_STRUCT time_var{};
   SQLLEN buf_len = sizeof(time_var);
@@ -733,19 +733,19 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectTimeQueryDefaultType) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &time_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check min values for time.
-  EXPECT_EQ(time_var.hour, 0);
-  EXPECT_EQ(time_var.minute, 0);
-  EXPECT_EQ(time_var.second, 0);
+  EXPECT_EQ(0, time_var.hour);
+  EXPECT_EQ(0, time_var.minute);
+  EXPECT_EQ(0, time_var.second);
 
   ret = SQLGetData(this->stmt, 2, SQL_C_DEFAULT, &time_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check max values for time.
-  EXPECT_EQ(time_var.hour, 23);
-  EXPECT_EQ(time_var.minute, 59);
-  EXPECT_EQ(time_var.second, 59);
+  EXPECT_EQ(23, time_var.hour);
+  EXPECT_EQ(59, time_var.minute);
+  EXPECT_EQ(59, time_var.second);
 
   this->Disconnect();
 }
@@ -761,19 +761,19 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectVarbinaryQueryDefaultType) 
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ret = SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &varbinary_val[0], buf_len, &ind);
-  EXPECT_EQ(varbinary_val[0], '\xAB');
-  EXPECT_EQ(varbinary_val[1], '\xCD');
-  EXPECT_EQ(varbinary_val[2], '\xEF');
+  EXPECT_EQ('\xAB', varbinary_val[0]);
+  EXPECT_EQ('\xCD', varbinary_val[1]);
+  EXPECT_EQ('\xEF', varbinary_val[2]);
 
   this->Disconnect();
 }
@@ -787,10 +787,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectGuidQueryUnsupported) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLGUID guid_var;
   SQLLEN buf_len = sizeof(guid_var);
@@ -798,7 +798,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectGuidQueryUnsupported) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_GUID, &guid_var, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // GUID is not supported by ODBC
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY000);
 
@@ -810,58 +810,58 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectRowFetching) {
 
   std::wstring wsql =
       LR"(
-    SELECT 1 AS small_table
-    UNION ALL
-    SELECT 2
-    UNION ALL
-    SELECT 3;
-  )";
+   SELECT 1 AS small_table
+   UNION ALL
+   SELECT 2
+   UNION ALL
+   SELECT 3;
+ )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Fetch row 1
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLINTEGER val;
   SQLLEN buf_len = sizeof(val);
   SQLLEN ind;
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 1 is returned
-  EXPECT_EQ(val, 1);
+  EXPECT_EQ(1, val);
 
   // Fetch row 2
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 2 is returned
-  EXPECT_EQ(val, 2);
+  EXPECT_EQ(2, val);
 
   // Fetch row 3
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 3 is returned
-  EXPECT_EQ(val, 3);
+  EXPECT_EQ(3, val);
 
   // Verify result set has no more data beyond row 3
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
@@ -877,20 +877,20 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
 
   std::wstring wsql =
       LR"(
-    SELECT 1 AS small_table
-    UNION ALL
-    SELECT 2
-    UNION ALL
-    SELECT 3;
-  )";
+   SELECT 1 AS small_table
+   UNION ALL
+   SELECT 2
+   UNION ALL
+   SELECT 3;
+ )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Fetch row 1
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLINTEGER val;
   SQLLEN buf_len = sizeof(val);
@@ -898,43 +898,43 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollRowFetching) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Verify 1 is returned
-  EXPECT_EQ(val, 1);
+  EXPECT_EQ(1, val);
   // Verify 1 row is fetched
-  EXPECT_EQ(rows_fetched, 1);
+  EXPECT_EQ(1, rows_fetched);
 
   // Fetch row 2
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 2 is returned
-  EXPECT_EQ(val, 2);
+  EXPECT_EQ(2, val);
   // Verify 1 row is fetched in the last SQLFetchScroll call
-  EXPECT_EQ(rows_fetched, 1);
+  EXPECT_EQ(1, rows_fetched);
 
   // Fetch row 3
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 3 is returned
-  EXPECT_EQ(val, 3);
+  EXPECT_EQ(3, val);
   // Verify 1 row is fetched in the last SQLFetchScroll call
-  EXPECT_EQ(rows_fetched, 1);
+  EXPECT_EQ(1, rows_fetched);
 
   // Verify result set has no more data beyond row 3
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Invalid cursor state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);
 
@@ -950,37 +950,37 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFetchScrollUnsupportedOrientation) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_PRIOR, 0);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
 
   SQLLEN fetch_offset = 1;
 
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_RELATIVE, fetch_offset);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
 
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_ABSOLUTE, fetch_offset);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
 
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_FIRST, 0);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
 
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_LAST, 0);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HYC00);
 
   ret = SQLFetchScroll(this->stmt, SQL_FETCH_BOOKMARK, fetch_offset);
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // DM returns state HY106 for SQL_FETCH_BOOKMARK
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY106);
@@ -996,10 +996,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectVarcharTruncation) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   const int len = 17;
   SQLCHAR char_val[len];
@@ -1008,12 +1008,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectVarcharTruncation) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   // Verify string truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01004);
 
-  EXPECT_EQ(ODBC::SqlStringToString(char_val), std::string("VERY LONG STRING"));
-  EXPECT_EQ(ind, 21);
+  EXPECT_EQ(std::string("VERY LONG STRING"), ODBC::SqlStringToString(char_val));
+  EXPECT_EQ(21, ind);
 
   // Fetch same column 2nd time
   const int len2 = 2;
@@ -1022,12 +1022,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectVarcharTruncation) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val2, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   // Verify string truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01004);
 
-  EXPECT_EQ(ODBC::SqlStringToString(char_val2), std::string(" "));
-  EXPECT_EQ(ind, 5);
+  EXPECT_EQ(std::string(" "), ODBC::SqlStringToString(char_val2));
+  EXPECT_EQ(5, ind);
 
   // Fetch same column 3rd time
   const int len3 = 5;
@@ -1037,16 +1037,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectVarcharTruncation) {
   ret = SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val3, buf_len, &ind);
 
   // Verify that there is no more truncation reports. The full string has been fetched.
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(ODBC::SqlStringToString(char_val3), std::string("here"));
-  EXPECT_EQ(ind, 4);
+  EXPECT_EQ(std::string("here"), ODBC::SqlStringToString(char_val3));
+  EXPECT_EQ(4, ind);
 
   // Attempt to fetch data 4th time
   SQLCHAR char_val4[len];
   ret = SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val4, 0, &ind);
   // Verify SQL_NO_DATA is returned
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1059,10 +1059,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectWVarcharTruncation) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   const int len = 28;
   SQLWCHAR wchar_val[len];
@@ -1072,12 +1072,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectWVarcharTruncation) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   // Verify string truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01004);
 
-  EXPECT_EQ(std::wstring(wchar_val), std::wstring(L"VERY LONG Unicode STRING 句子"));
-  EXPECT_EQ(ind, 32 * wchar_size);
+  EXPECT_EQ(std::wstring(L"VERY LONG Unicode STRING 句子"), std::wstring(wchar_val));
+  EXPECT_EQ(32 * wchar_size, ind);
 
   // Fetch same column 2nd time
   const int len2 = 2;
@@ -1086,12 +1086,12 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectWVarcharTruncation) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val2, buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   // Verify string truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01004);
 
-  EXPECT_EQ(std::wstring(wchar_val2), std::wstring(L" "));
-  EXPECT_EQ(ind, 5 * wchar_size);
+  EXPECT_EQ(std::wstring(L" "), std::wstring(wchar_val2));
+  EXPECT_EQ(5 * wchar_size, ind);
 
   // Fetch same column 3rd time
   const int len3 = 5;
@@ -1101,16 +1101,16 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectWVarcharTruncation) {
   ret = SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val3, buf_len, &ind);
 
   // Verify that there is no more truncation reports. The full string has been fetched.
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(std::wstring(wchar_val3), std::wstring(L"here"));
-  EXPECT_EQ(ind, 4 * wchar_size);
+  EXPECT_EQ(std::wstring(L"here"), std::wstring(wchar_val3));
+  EXPECT_EQ(4 * wchar_size, ind);
 
   // Attempt to fetch data 4th time
   SQLWCHAR wchar_val4[len];
   ret = SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val4, 0, &ind);
   // Verify SQL_NO_DATA is returned
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1125,10 +1125,10 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectVarbinaryTruncation) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
@@ -1137,10 +1137,10 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectVarbinaryTruncation) {
   ret = SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind);
   // Verify binary truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01004);
-  EXPECT_EQ(varbinary_val[0], '\xAB');
-  EXPECT_EQ(varbinary_val[1], '\xCD');
-  EXPECT_EQ(varbinary_val[2], '\xEF');
-  EXPECT_EQ(ind, 4);
+  EXPECT_EQ('\xAB', varbinary_val[0]);
+  EXPECT_EQ('\xCD', varbinary_val[1]);
+  EXPECT_EQ('\xEF', varbinary_val[2]);
+  EXPECT_EQ(4, ind);
 
   // Fetch same column 2nd time
   std::vector<int8_t> varbinary_val2(1);
@@ -1149,17 +1149,17 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectVarbinaryTruncation) {
   ret = SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val2[0], buf_len, &ind);
 
   // Verify that there is no more truncation reports. The full binary has been fetched.
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(varbinary_val[0], '\xAB');
-  EXPECT_EQ(ind, 1);
+  EXPECT_EQ('\xAB', varbinary_val[0]);
+  EXPECT_EQ(1, ind);
 
   // Attempt to fetch data 3rd time
   std::vector<int8_t> varbinary_val3(1);
   buf_len = varbinary_val3.size();
   ret = SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val3[0], buf_len, &ind);
   // Verify SQL_NO_DATA is returned
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1180,19 +1180,19 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectFloatTruncation) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   int16_t ssmall_int_val;
 
   ret = SQLGetData(this->stmt, 1, SQL_C_SSHORT, &ssmall_int_val, 0, 0);
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   // Verify float truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01S07);
 
-  EXPECT_EQ(ssmall_int_val, 1);
+  EXPECT_EQ(1, ssmall_int_val);
 
   this->Disconnect();
 }
@@ -1207,19 +1207,19 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectNullQuery) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLINTEGER val;
   SQLLEN ind;
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify SQL_NULL_DATA is returned for indicator
-  EXPECT_EQ(ind, SQL_NULL_DATA);
+  EXPECT_EQ(SQL_NULL_DATA, ind);
 
   this->Disconnect();
 }
@@ -1232,26 +1232,26 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectTruncationQueryNullIndicator)
 
   std::wstring wsql =
       LR"(
-        SELECT 1,
-        'VERY LONG STRING here' AS string_col,
-        'VERY LONG Unicode STRING 句子 here' AS wstring_col,
-        X'ABCDEFAB' AS c_varbinary;
-  )";
+       SELECT 1,
+       'VERY LONG STRING here' AS string_col,
+       'VERY LONG Unicode STRING 句子 here' AS wstring_col,
+       X'ABCDEFAB' AS c_varbinary;
+ )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLINTEGER val;
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Verify 1 is returned for non-truncation case.
-  EXPECT_EQ(val, 1);
+  EXPECT_EQ(1, val);
 
   // Char
   const int len = 17;
@@ -1260,7 +1260,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectTruncationQueryNullIndicator)
 
   ret = SQLGetData(this->stmt, 2, SQL_C_CHAR, &char_val, buf_len, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   // Verify string truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01004);
 
@@ -1272,7 +1272,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLExecDirectTruncationQueryNullIndicator)
 
   ret = SQLGetData(this->stmt, 3, SQL_C_WCHAR, &wchar_val, buf_len, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   // Verify string truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_01004);
 
@@ -1296,16 +1296,16 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExecDirectNullQueryNullIndicator) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLINTEGER val;
 
   ret = SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, 0);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Verify invalid null indicator is reported, as it is required
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_22002);
 
@@ -1321,10 +1321,10 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Numeric Types
 
@@ -1335,104 +1335,104 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
 
   ret = SQLGetData(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(stiny_int_val, std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<int8_t>::min(), stiny_int_val);
 
   ret = SQLGetData(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(stiny_int_val, std::numeric_limits<int8_t>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<int8_t>::max(), stiny_int_val);
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val;
 
   ret = SQLGetData(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(utiny_int_val, std::numeric_limits<uint8_t>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<uint8_t>::min(), utiny_int_val);
 
   ret = SQLGetData(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(utiny_int_val, std::numeric_limits<uint8_t>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<uint8_t>::max(), utiny_int_val);
 
   // Signed Small Int
   int16_t ssmall_int_val;
 
   ret = SQLGetData(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ssmall_int_val, std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<int16_t>::min(), ssmall_int_val);
 
   ret = SQLGetData(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ssmall_int_val, std::numeric_limits<int16_t>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<int16_t>::max(), ssmall_int_val);
 
   // Unsigned Small Int
   uint16_t usmall_int_val;
 
   ret = SQLGetData(this->stmt, 7, SQL_C_USHORT, &usmall_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(usmall_int_val, std::numeric_limits<uint16_t>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<uint16_t>::min(), usmall_int_val);
 
   ret = SQLGetData(this->stmt, 8, SQL_C_USHORT, &usmall_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(usmall_int_val, std::numeric_limits<uint16_t>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<uint16_t>::max(), usmall_int_val);
 
   // Signed Integer
   SQLINTEGER slong_val;
 
   ret = SQLGetData(this->stmt, 9, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(slong_val, std::numeric_limits<SQLINTEGER>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
   ret = SQLGetData(this->stmt, 10, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(slong_val, std::numeric_limits<SQLINTEGER>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Unsigned Integer
   SQLUINTEGER ulong_val;
 
   ret = SQLGetData(this->stmt, 11, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ulong_val, std::numeric_limits<SQLUINTEGER>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::min(), ulong_val);
 
   ret = SQLGetData(this->stmt, 12, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ulong_val, std::numeric_limits<SQLUINTEGER>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::max(), ulong_val);
 
   // Signed Big Int
   SQLBIGINT sbig_int_val;
 
   ret = SQLGetData(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(sbig_int_val, std::numeric_limits<SQLBIGINT>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
   ret = SQLGetData(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(sbig_int_val, std::numeric_limits<SQLBIGINT>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val;
 
   ret = SQLGetData(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ubig_int_val, std::numeric_limits<SQLUBIGINT>::min());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::min(), ubig_int_val);
 
   ret = SQLGetData(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(ubig_int_val, std::numeric_limits<SQLUBIGINT>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::max(), ubig_int_val);
 
   // Decimal
   SQL_NUMERIC_STRUCT decimal_val;
@@ -1440,22 +1440,22 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
 
   ret = SQLGetData(this->stmt, 17, SQL_C_NUMERIC, &decimal_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check for negative decimal_val value
-  EXPECT_EQ(decimal_val.sign, 0);
-  EXPECT_EQ(decimal_val.scale, 0);
-  EXPECT_EQ(decimal_val.precision, 38);
+  EXPECT_EQ(0, decimal_val.sign);
+  EXPECT_EQ(0, decimal_val.scale);
+  EXPECT_EQ(38, decimal_val.precision);
   EXPECT_THAT(decimal_val.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0, 0,
                                                       0, 0, 0, 0, 0, 0, 0, 0));
 
   memset(&decimal_val, 0, sizeof(decimal_val));
   ret = SQLGetData(this->stmt, 18, SQL_C_NUMERIC, &decimal_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check for positive decimal_val value
-  EXPECT_EQ(decimal_val.sign, 1);
-  EXPECT_EQ(decimal_val.scale, 0);
-  EXPECT_EQ(decimal_val.precision, 38);
+  EXPECT_EQ(1, decimal_val.sign);
+  EXPECT_EQ(0, decimal_val.scale);
+  EXPECT_EQ(38, decimal_val.precision);
   EXPECT_THAT(decimal_val.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0, 0,
                                                       0, 0, 0, 0, 0, 0, 0, 0));
 
@@ -1464,41 +1464,41 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
 
   ret = SQLGetData(this->stmt, 19, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Get minimum negative float value
-  EXPECT_EQ(float_val, -std::numeric_limits<float>::max());
+  EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
   ret = SQLGetData(this->stmt, 20, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(float_val, std::numeric_limits<float>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
 
   ret = SQLGetData(this->stmt, 21, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Get minimum negative double value
-  EXPECT_EQ(double_val, -std::numeric_limits<SQLDOUBLE>::max());
+  EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   ret = SQLGetData(this->stmt, 22, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(double_val, std::numeric_limits<SQLDOUBLE>::max());
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
 
   ret = SQLGetData(this->stmt, 23, SQL_C_BIT, &bit_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(bit_val, false);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(false, bit_val);
 
   ret = SQLGetData(this->stmt, 24, SQL_C_BIT, &bit_val, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(bit_val, true);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(true, bit_val);
 
   // Date and Timestamp
 
@@ -1507,19 +1507,19 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
 
   ret = SQLGetData(this->stmt, 29, SQL_C_TYPE_DATE, &date_var, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check min values for date. Min valid year is 1400.
-  EXPECT_EQ(date_var.day, 1);
-  EXPECT_EQ(date_var.month, 1);
-  EXPECT_EQ(date_var.year, 1400);
+  EXPECT_EQ(1, date_var.day);
+  EXPECT_EQ(1, date_var.month);
+  EXPECT_EQ(1400, date_var.year);
 
   ret = SQLGetData(this->stmt, 30, SQL_C_TYPE_DATE, &date_var, invalid_buf_len, &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check max values for date. Max valid year is 9999.
-  EXPECT_EQ(date_var.day, 31);
-  EXPECT_EQ(date_var.month, 12);
-  EXPECT_EQ(date_var.year, 9999);
+  EXPECT_EQ(31, date_var.day);
+  EXPECT_EQ(12, date_var.month);
+  EXPECT_EQ(9999, date_var.year);
 
   // Timestamp
   SQL_TIMESTAMP_STRUCT timestamp_var{};
@@ -1527,28 +1527,28 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExecDirectIgnoreInvalidBufLen) {
   ret = SQLGetData(this->stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var, invalid_buf_len,
                    &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check min values for date. Min valid year is 1400.
-  EXPECT_EQ(timestamp_var.day, 1);
-  EXPECT_EQ(timestamp_var.month, 1);
-  EXPECT_EQ(timestamp_var.year, 1400);
-  EXPECT_EQ(timestamp_var.hour, 0);
-  EXPECT_EQ(timestamp_var.minute, 0);
-  EXPECT_EQ(timestamp_var.second, 0);
-  EXPECT_EQ(timestamp_var.fraction, 0);
+  EXPECT_EQ(1, timestamp_var.day);
+  EXPECT_EQ(1, timestamp_var.month);
+  EXPECT_EQ(1400, timestamp_var.year);
+  EXPECT_EQ(0, timestamp_var.hour);
+  EXPECT_EQ(0, timestamp_var.minute);
+  EXPECT_EQ(0, timestamp_var.second);
+  EXPECT_EQ(0, timestamp_var.fraction);
 
   ret = SQLGetData(this->stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var, invalid_buf_len,
                    &ind);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
   // Check max values for date. Max valid year is 9999.
-  EXPECT_EQ(timestamp_var.day, 31);
-  EXPECT_EQ(timestamp_var.month, 12);
-  EXPECT_EQ(timestamp_var.year, 9999);
-  EXPECT_EQ(timestamp_var.hour, 23);
-  EXPECT_EQ(timestamp_var.minute, 59);
-  EXPECT_EQ(timestamp_var.second, 59);
-  EXPECT_EQ(timestamp_var.fraction, 0);
+  EXPECT_EQ(31, timestamp_var.day);
+  EXPECT_EQ(12, timestamp_var.month);
+  EXPECT_EQ(9999, timestamp_var.year);
+  EXPECT_EQ(23, timestamp_var.hour);
+  EXPECT_EQ(59, timestamp_var.minute);
+  EXPECT_EQ(59, timestamp_var.second);
+  EXPECT_EQ(0, timestamp_var.fraction);
 
   this->Disconnect();
 }
@@ -1566,80 +1566,80 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColDataQuery) {
 
   SQLRETURN ret =
       SQLBindCol(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val_min;
   uint8_t utiny_int_val_max;
 
   ret = SQLBindCol(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Signed Small Int
   int16_t ssmall_int_val_min;
   int16_t ssmall_int_val_max;
 
   ret = SQLBindCol(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Unsigned Small Int
   uint16_t usmall_int_val_min;
   uint16_t usmall_int_val_max;
 
   ret = SQLBindCol(this->stmt, 7, SQL_C_USHORT, &usmall_int_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 8, SQL_C_USHORT, &usmall_int_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Signed Integer
   SQLINTEGER slong_val_min;
   SQLINTEGER slong_val_max;
 
   ret = SQLBindCol(this->stmt, 9, SQL_C_SLONG, &slong_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 10, SQL_C_SLONG, &slong_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Unsigned Integer
   SQLUINTEGER ulong_val_min;
   SQLUINTEGER ulong_val_max;
 
   ret = SQLBindCol(this->stmt, 11, SQL_C_ULONG, &ulong_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 12, SQL_C_ULONG, &ulong_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Signed Big Int
   SQLBIGINT sbig_int_val_min;
   SQLBIGINT sbig_int_val_max;
 
   ret = SQLBindCol(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val_min;
   SQLUBIGINT ubig_int_val_max;
 
   ret = SQLBindCol(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Decimal
   SQL_NUMERIC_STRUCT decimal_val_neg;
@@ -1648,191 +1648,191 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColDataQuery) {
   memset(&decimal_val_pos, 0, sizeof(decimal_val_pos));
 
   ret = SQLBindCol(this->stmt, 17, SQL_C_NUMERIC, &decimal_val_neg, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 18, SQL_C_NUMERIC, &decimal_val_pos, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Float
   float float_val_min;
   float float_val_max;
 
   ret = SQLBindCol(this->stmt, 19, SQL_C_FLOAT, &float_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 20, SQL_C_FLOAT, &float_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Double
   SQLDOUBLE double_val_min;
   SQLDOUBLE double_val_max;
 
   ret = SQLBindCol(this->stmt, 21, SQL_C_DOUBLE, &double_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 22, SQL_C_DOUBLE, &double_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Bit
   bool bit_val_false;
   bool bit_val_true;
 
   ret = SQLBindCol(this->stmt, 23, SQL_C_BIT, &bit_val_false, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 24, SQL_C_BIT, &bit_val_true, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Characters
   SQLCHAR char_val[2];
   buf_len = sizeof(SQLCHAR) * 2;
 
   ret = SQLBindCol(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLWCHAR wchar_val[2];
   size_t wchar_size = arrow::flight::sql::odbc::GetSqlWCharSize();
   buf_len = wchar_size * 2;
 
   ret = SQLBindCol(this->stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLWCHAR wvarchar_val[3];
   buf_len = wchar_size * 3;
 
   ret = SQLBindCol(this->stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLCHAR varchar_val[4];
   buf_len = sizeof(SQLCHAR) * 4;
 
   ret = SQLBindCol(this->stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Date and Timestamp
   SQL_DATE_STRUCT date_val_min{}, date_val_max{};
   buf_len = 0;
 
   ret = SQLBindCol(this->stmt, 29, SQL_C_TYPE_DATE, &date_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 30, SQL_C_TYPE_DATE, &date_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQL_TIMESTAMP_STRUCT timestamp_val_min{}, timestamp_val_max{};
 
   ret =
       SQLBindCol(this->stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_val_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret =
       SQLBindCol(this->stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_val_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Data verification
 
   // Signed Tiny Int
-  EXPECT_EQ(stiny_int_val_min, std::numeric_limits<int8_t>::min());
-  EXPECT_EQ(stiny_int_val_max, std::numeric_limits<int8_t>::max());
+  EXPECT_EQ(std::numeric_limits<int8_t>::min(), stiny_int_val_min);
+  EXPECT_EQ(std::numeric_limits<int8_t>::max(), stiny_int_val_max);
 
   // Unsigned Tiny Int
-  EXPECT_EQ(utiny_int_val_min, std::numeric_limits<uint8_t>::min());
-  EXPECT_EQ(utiny_int_val_max, std::numeric_limits<uint8_t>::max());
+  EXPECT_EQ(std::numeric_limits<uint8_t>::min(), utiny_int_val_min);
+  EXPECT_EQ(std::numeric_limits<uint8_t>::max(), utiny_int_val_max);
 
   // Signed Small Int
-  EXPECT_EQ(ssmall_int_val_min, std::numeric_limits<int16_t>::min());
-  EXPECT_EQ(ssmall_int_val_max, std::numeric_limits<int16_t>::max());
+  EXPECT_EQ(std::numeric_limits<int16_t>::min(), ssmall_int_val_min);
+  EXPECT_EQ(std::numeric_limits<int16_t>::max(), ssmall_int_val_max);
 
   // Unsigned Small Int
-  EXPECT_EQ(usmall_int_val_min, std::numeric_limits<uint16_t>::min());
-  EXPECT_EQ(usmall_int_val_max, std::numeric_limits<uint16_t>::max());
+  EXPECT_EQ(std::numeric_limits<uint16_t>::min(), usmall_int_val_min);
+  EXPECT_EQ(std::numeric_limits<uint16_t>::max(), usmall_int_val_max);
 
   // Signed Long
-  EXPECT_EQ(slong_val_min, std::numeric_limits<SQLINTEGER>::min());
-  EXPECT_EQ(slong_val_max, std::numeric_limits<SQLINTEGER>::max());
+  EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val_min);
+  EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val_max);
 
   // Unsigned Long
-  EXPECT_EQ(ulong_val_min, std::numeric_limits<SQLUINTEGER>::min());
-  EXPECT_EQ(ulong_val_max, std::numeric_limits<SQLUINTEGER>::max());
+  EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::min(), ulong_val_min);
+  EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::max(), ulong_val_max);
 
   // Signed Big Int
-  EXPECT_EQ(sbig_int_val_min, std::numeric_limits<SQLBIGINT>::min());
-  EXPECT_EQ(sbig_int_val_max, std::numeric_limits<SQLBIGINT>::max());
+  EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val_min);
+  EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val_max);
 
   // Unsigned Big Int
-  EXPECT_EQ(ubig_int_val_min, std::numeric_limits<SQLUBIGINT>::min());
-  EXPECT_EQ(ubig_int_val_max, std::numeric_limits<SQLUBIGINT>::max());
+  EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::min(), ubig_int_val_min);
+  EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::max(), ubig_int_val_max);
 
   // Decimal
-  EXPECT_EQ(decimal_val_neg.sign, 0);
-  EXPECT_EQ(decimal_val_neg.scale, 0);
-  EXPECT_EQ(decimal_val_neg.precision, 38);
+  EXPECT_EQ(0, decimal_val_neg.sign);
+  EXPECT_EQ(0, decimal_val_neg.scale);
+  EXPECT_EQ(38, decimal_val_neg.precision);
   EXPECT_THAT(decimal_val_neg.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0,
                                                           0, 0, 0, 0, 0, 0, 0, 0, 0));
 
-  EXPECT_EQ(decimal_val_pos.sign, 1);
-  EXPECT_EQ(decimal_val_pos.scale, 0);
-  EXPECT_EQ(decimal_val_pos.precision, 38);
+  EXPECT_EQ(1, decimal_val_pos.sign);
+  EXPECT_EQ(0, decimal_val_pos.scale);
+  EXPECT_EQ(38, decimal_val_pos.precision);
   EXPECT_THAT(decimal_val_pos.val, ::testing::ElementsAre(0xFF, 0xC9, 0x9A, 0x3B, 0, 0, 0,
                                                           0, 0, 0, 0, 0, 0, 0, 0, 0));
 
   // Float
-  EXPECT_EQ(float_val_min, -std::numeric_limits<float>::max());
-  EXPECT_EQ(float_val_max, std::numeric_limits<float>::max());
+  EXPECT_EQ(-std::numeric_limits<float>::max(), float_val_min);
+  EXPECT_EQ(std::numeric_limits<float>::max(), float_val_max);
 
   // Double
-  EXPECT_EQ(double_val_min, -std::numeric_limits<SQLDOUBLE>::max());
-  EXPECT_EQ(double_val_max, std::numeric_limits<SQLDOUBLE>::max());
+  EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val_min);
+  EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val_max);
 
   // Bit
-  EXPECT_EQ(bit_val_false, false);
-  EXPECT_EQ(bit_val_true, true);
+  EXPECT_EQ(false, bit_val_false);
+  EXPECT_EQ(true, bit_val_true);
 
   // Characters
-  EXPECT_EQ(char_val[0], 'Z');
-  EXPECT_EQ(wchar_val[0], L'你');
-  EXPECT_EQ(wvarchar_val[0], L'你');
-  EXPECT_EQ(wvarchar_val[1], L'好');
+  EXPECT_EQ('Z', char_val[0]);
+  EXPECT_EQ(L'你', wchar_val[0]);
+  EXPECT_EQ(L'你', wvarchar_val[0]);
+  EXPECT_EQ(L'好', wvarchar_val[1]);
 
-  EXPECT_EQ(varchar_val[0], 'X');
-  EXPECT_EQ(varchar_val[1], 'Y');
-  EXPECT_EQ(varchar_val[2], 'Z');
+  EXPECT_EQ('X', varchar_val[0]);
+  EXPECT_EQ('Y', varchar_val[1]);
+  EXPECT_EQ('Z', varchar_val[2]);
 
   // Date
-  EXPECT_EQ(date_val_min.day, 1);
-  EXPECT_EQ(date_val_min.month, 1);
-  EXPECT_EQ(date_val_min.year, 1400);
+  EXPECT_EQ(1, date_val_min.day);
+  EXPECT_EQ(1, date_val_min.month);
+  EXPECT_EQ(1400, date_val_min.year);
 
-  EXPECT_EQ(date_val_max.day, 31);
-  EXPECT_EQ(date_val_max.month, 12);
-  EXPECT_EQ(date_val_max.year, 9999);
+  EXPECT_EQ(31, date_val_max.day);
+  EXPECT_EQ(12, date_val_max.month);
+  EXPECT_EQ(9999, date_val_max.year);
 
   // Timestamp
-  EXPECT_EQ(timestamp_val_min.day, 1);
-  EXPECT_EQ(timestamp_val_min.month, 1);
-  EXPECT_EQ(timestamp_val_min.year, 1400);
-  EXPECT_EQ(timestamp_val_min.hour, 0);
-  EXPECT_EQ(timestamp_val_min.minute, 0);
-  EXPECT_EQ(timestamp_val_min.second, 0);
-  EXPECT_EQ(timestamp_val_min.fraction, 0);
+  EXPECT_EQ(1, timestamp_val_min.day);
+  EXPECT_EQ(1, timestamp_val_min.month);
+  EXPECT_EQ(1400, timestamp_val_min.year);
+  EXPECT_EQ(0, timestamp_val_min.hour);
+  EXPECT_EQ(0, timestamp_val_min.minute);
+  EXPECT_EQ(0, timestamp_val_min.second);
+  EXPECT_EQ(0, timestamp_val_min.fraction);
 
-  EXPECT_EQ(timestamp_val_max.day, 31);
-  EXPECT_EQ(timestamp_val_max.month, 12);
-  EXPECT_EQ(timestamp_val_max.year, 9999);
-  EXPECT_EQ(timestamp_val_max.hour, 23);
-  EXPECT_EQ(timestamp_val_max.minute, 59);
-  EXPECT_EQ(timestamp_val_max.second, 59);
-  EXPECT_EQ(timestamp_val_max.fraction, 0);
+  EXPECT_EQ(31, timestamp_val_max.day);
+  EXPECT_EQ(12, timestamp_val_max.month);
+  EXPECT_EQ(9999, timestamp_val_max.year);
+  EXPECT_EQ(23, timestamp_val_max.hour);
+  EXPECT_EQ(59, timestamp_val_max.minute);
+  EXPECT_EQ(59, timestamp_val_max.second);
+  EXPECT_EQ(0, timestamp_val_max.fraction);
 
   this->Disconnect();
 }
@@ -1849,33 +1849,33 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColTimeQuery) {
 
   SQLRETURN ret =
       SQLBindCol(this->stmt, 1, SQL_C_TYPE_TIME, &time_var_min, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLBindCol(this->stmt, 2, SQL_C_TYPE_TIME, &time_var_max, buf_len, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   std::wstring wsql =
       LR"(
-    SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
-           CAST(TIME '23:59:59' AS TIME) AS time_max;
-    )";
+   SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
+          CAST(TIME '23:59:59' AS TIME) AS time_max;
+   )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check min values for time.
-  EXPECT_EQ(time_var_min.hour, 0);
-  EXPECT_EQ(time_var_min.minute, 0);
-  EXPECT_EQ(time_var_min.second, 0);
+  EXPECT_EQ(0, time_var_min.hour);
+  EXPECT_EQ(0, time_var_min.minute);
+  EXPECT_EQ(0, time_var_min.second);
 
   // Check max values for time.
-  EXPECT_EQ(time_var_max.hour, 23);
-  EXPECT_EQ(time_var_max.minute, 59);
-  EXPECT_EQ(time_var_max.second, 59);
+  EXPECT_EQ(23, time_var_max.hour);
+  EXPECT_EQ(59, time_var_max.minute);
+  EXPECT_EQ(59, time_var_max.second);
 
   this->Disconnect();
 }
@@ -1896,15 +1896,15 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLBindColVarbinaryQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check varbinary values
-  EXPECT_EQ(varbinary_val[0], '\xAB');
-  EXPECT_EQ(varbinary_val[1], '\xCD');
-  EXPECT_EQ(varbinary_val[2], '\xEF');
+  EXPECT_EQ('\xAB', varbinary_val[0]);
+  EXPECT_EQ('\xCD', varbinary_val[1]);
+  EXPECT_EQ('\xEF', varbinary_val[2]);
 
   this->Disconnect();
 }
@@ -1918,19 +1918,19 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColNullQuery) {
   SQLLEN ind;
 
   SQLRETURN ret = SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, &ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   std::wstring wsql = L"SELECT null as null_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify SQL_NULL_DATA is returned for indicator
-  EXPECT_EQ(ind, SQL_NULL_DATA);
+  EXPECT_EQ(SQL_NULL_DATA, ind);
 
   this->Disconnect();
 }
@@ -1948,11 +1948,11 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLBindColNullQueryNullIndicator) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   // Verify invalid null indicator is reported, as it is required
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_22002);
 
@@ -1972,41 +1972,41 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColRowFetching) {
 
   std::wstring wsql =
       LR"(
-    SELECT 1 AS small_table
-    UNION ALL
-    SELECT 2
-    UNION ALL
-    SELECT 3;
-  )";
+   SELECT 1 AS small_table
+   UNION ALL
+   SELECT 2
+   UNION ALL
+   SELECT 3;
+ )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Fetch row 1
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 1 is returned
-  EXPECT_EQ(val, 1);
+  EXPECT_EQ(1, val);
 
   // Fetch row 2
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 2 is returned
-  EXPECT_EQ(val, 2);
+  EXPECT_EQ(2, val);
 
   // Fetch row 3
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 3 is returned
-  EXPECT_EQ(val, 3);
+  EXPECT_EQ(3, val);
 
   // Verify result set has no more data beyond row 3
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -2029,37 +2029,37 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColRowArraySize) {
 
   std::wstring wsql =
       LR"(
-    SELECT 1 AS small_table
-    UNION ALL
-    SELECT 2
-    UNION ALL
-    SELECT 3;
-  )";
+   SELECT 1 AS small_table
+   UNION ALL
+   SELECT 2
+   UNION ALL
+   SELECT 3;
+ )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLSetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE,
                        reinterpret_cast<SQLPOINTER>(rows), 0);
 
   // Fetch 3 rows at once
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify 3 rows are fetched
-  EXPECT_EQ(rows_fetched, 3);
+  EXPECT_EQ(3, rows_fetched);
 
   // Verify 1 is returned
-  EXPECT_EQ(val[0], 1);
+  EXPECT_EQ(1, val[0]);
   // Verify 2 is returned
-  EXPECT_EQ(val[1], 2);
+  EXPECT_EQ(2, val[1]);
   // Verify 3 is returned
-  EXPECT_EQ(val[2], 3);
+  EXPECT_EQ(3, val[2]);
 
   // Verify result set has no more data beyond row 3
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -2076,31 +2076,31 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnly) {
   SQLLEN stiny_int_ind;
 
   SQLRETURN ret = SQLBindCol(this->stmt, 1, SQL_C_STINYINT, 0, 0, &stiny_int_ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Characters
   SQLLEN buf_len = sizeof(SQLCHAR) * 2;
   SQLLEN char_val_ind;
 
   ret = SQLBindCol(this->stmt, 25, SQL_C_CHAR, 0, buf_len, &char_val_ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Verify values for indicator pointer
   // Signed Tiny Int
-  EXPECT_EQ(stiny_int_ind, 1);
+  EXPECT_EQ(1, stiny_int_ind);
 
   // Char array
-  EXPECT_EQ(char_val_ind, 1);
+  EXPECT_EQ(1, char_val_ind);
   this->Disconnect();
 }
 
@@ -2116,7 +2116,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnlySQLUnbind) {
 
   SQLRETURN ret =
       SQLBindCol(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val, 0, &stiny_int_ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Characters
   SQLCHAR char_val[2];
@@ -2124,28 +2124,28 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLBindColIndicatorOnlySQLUnbind) {
   SQLLEN char_val_ind;
 
   ret = SQLBindCol(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &char_val_ind);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver should still be able to execute queries after unbinding columns
   ret = SQLFreeStmt(this->stmt, SQL_UNBIND);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // GH-47021: implement driver to return indicator value when data pointer is null and
   // uncomment the checks Verify values for indicator pointer Signed Tiny Int
-  // EXPECT_EQ(stiny_int_ind, 1);
+  // EXPECT_EQ(1, stiny_int_ind);
 
   // Char array
-  // EXPECT_EQ(char_val_ind, 1);
+  // EXPECT_EQ(1, char_val_ind);
 
   this->Disconnect();
 }
@@ -2168,41 +2168,41 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLExtendedFetchRowFetching) {
 
   std::wstring wsql =
       LR"(
-    SELECT 1 AS small_table
-    UNION ALL
-    SELECT 2
-    UNION ALL
-    SELECT 3;
-  )";
+   SELECT 1 AS small_table
+   UNION ALL
+   SELECT 2
+   UNION ALL
+   SELECT 3;
+ )";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Fetch row 1-3.
   SQLULEN row_count;
   SQLUSMALLINT row_status[rows];
 
   ret = SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count, row_status);
-  EXPECT_EQ(ret, SQL_SUCCESS);
-  EXPECT_EQ(row_count, 3);
+  EXPECT_EQ(SQL_SUCCESS, ret);
+  EXPECT_EQ(3, row_count);
 
   for (int i = 0; i < rows; i++) {
-    EXPECT_EQ(row_status[i], SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, row_status[i]);
   }
 
   // Verify 1 is returned for row 1
-  EXPECT_EQ(val[0], 1);
+  EXPECT_EQ(1, val[0]);
   // Verify 2 is returned for row 2
-  EXPECT_EQ(val[1], 2);
+  EXPECT_EQ(2, val[1]);
   // Verify 3 is returned for row 3
-  EXPECT_EQ(val[2], 3);
+  EXPECT_EQ(3, val[2]);
 
   // Verify result set has no more data beyond row 3
   SQLULEN row_count2;
   SQLUSMALLINT row_status2[rows];
   ret = SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count2, row_status2);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -2222,14 +2222,14 @@ TEST_F(FlightSQLODBCRemoteTestBase, TestSQLExtendedFetchQueryNullIndicator) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ret = SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   SQLULEN row_count1;
   SQLUSMALLINT row_status1[1];
 
   // SQLExtendedFetch should return SQL_SUCCESS_WITH_INFO for 22002 state
   ret = SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count1, row_status1);
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_22002);
 
   this->Disconnect();
@@ -2244,11 +2244,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLMoreResultsNoData) {
 
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLMoreResults(this->stmt);
 
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -2260,7 +2260,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLMoreResultsInvalidFunctionSequence) {
 
   // Verify function sequence error state is reported when SQLMoreResults is called
   // without executing any queries
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY010);
 
   this->Disconnect();
@@ -2279,14 +2279,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsInputString) {
   SQLRETURN ret = SQLNativeSql(this->conn, input_str, input_char_len, buf, buf_char_len,
                                &output_char_len);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(output_char_len, input_char_len);
+  EXPECT_EQ(input_char_len, output_char_len);
 
   // returned length is in characters
   std::wstring returned_string(buf, buf + output_char_len);
 
-  EXPECT_EQ(returned_string, expected_string);
+  EXPECT_EQ(expected_string, returned_string);
 
   this->Disconnect();
 }
@@ -2304,14 +2304,14 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsNTSInputString) {
   SQLRETURN ret =
       SQLNativeSql(this->conn, input_str, SQL_NTS, buf, buf_char_len, &output_char_len);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(output_char_len, input_char_len);
+  EXPECT_EQ(input_char_len, output_char_len);
 
   // returned length is in characters
   std::wstring returned_string(buf, buf + output_char_len);
 
-  EXPECT_EQ(returned_string, expected_string);
+  EXPECT_EQ(expected_string, returned_string);
 
   this->Disconnect();
 }
@@ -2327,15 +2327,15 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsInputStringLength) {
   SQLRETURN ret =
       SQLNativeSql(this->conn, input_str, input_char_len, nullptr, 0, &output_char_len);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(output_char_len, input_char_len);
+  EXPECT_EQ(input_char_len, output_char_len);
 
   ret = SQLNativeSql(this->conn, input_str, SQL_NTS, nullptr, 0, &output_char_len);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(output_char_len, input_char_len);
+  EXPECT_EQ(input_char_len, output_char_len);
 
   this->Disconnect();
 }
@@ -2360,15 +2360,15 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsTruncatedString) {
   SQLRETURN ret = SQLNativeSql(this->conn, input_str, input_char_len, small_buf,
                                small_buf_char_len, &output_char_len);
 
-  EXPECT_EQ(ret, SQL_SUCCESS_WITH_INFO);
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_01004);
 
   // Returned text length represents full string char length regardless of truncation
-  EXPECT_EQ(output_char_len, input_char_len);
+  EXPECT_EQ(input_char_len, output_char_len);
 
   std::wstring returned_string(small_buf, small_buf + small_buf_char_len);
 
-  EXPECT_EQ(returned_string, expected_string);
+  EXPECT_EQ(expected_string, returned_string);
 
   this->Disconnect();
 }
@@ -2385,17 +2385,17 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLNativeSqlReturnsErrorOnBadInputs) {
   SQLRETURN ret = SQLNativeSql(this->conn, nullptr, input_char_len, buf, buf_char_len,
                                &output_char_len);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY009);
 
   ret = SQLNativeSql(this->conn, nullptr, SQL_NTS, buf, buf_char_len, &output_char_len);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY009);
 
   ret = SQLNativeSql(this->conn, input_str, -100, buf, buf_char_len, &output_char_len);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, error_state_HY090);
 
   this->Disconnect();
@@ -2411,11 +2411,11 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsReturnsColumnsOnSelect) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckIntColumn(this->stmt, 1, 1);
   CheckStringColumnW(this->stmt, 2, L"One");
@@ -2423,9 +2423,9 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsReturnsColumnsOnSelect) {
 
   ret = SQLNumResultCols(this->stmt, &column_count);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(column_count, expected_value);
+  EXPECT_EQ(expected_value, column_count);
 
   this->Disconnect();
 }
@@ -2438,11 +2438,11 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsReturnsSuccessOnNullptr) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckIntColumn(this->stmt, 1, 1);
   CheckStringColumnW(this->stmt, 2, L"One");
@@ -2450,7 +2450,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsReturnsSuccessOnNullptr) {
 
   ret = SQLNumResultCols(this->stmt, nullptr);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -2463,10 +2463,10 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLNumResultColsFunctionSequenceErrorOnNoQuery
 
   SQLRETURN ret = SQLNumResultCols(this->stmt, &column_count);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY010);
 
-  EXPECT_EQ(column_count, expected_value);
+  EXPECT_EQ(expected_value, column_count);
 
   this->Disconnect();
 }
@@ -2481,11 +2481,11 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountReturnsNegativeOneOnSelect) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckIntColumn(this->stmt, 1, 1);
   CheckStringColumnW(this->stmt, 2, L"One");
@@ -2493,9 +2493,9 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountReturnsNegativeOneOnSelect) {
 
   ret = SQLRowCount(this->stmt, &row_count);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
-  EXPECT_EQ(row_count, expected_value);
+  EXPECT_EQ(expected_value, row_count);
 
   this->Disconnect();
 }
@@ -2508,11 +2508,11 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountReturnsSuccessOnNullptr) {
 
   SQLRETURN ret = SQLExecDirect(this->stmt, sql_query, query_length);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFetch(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckIntColumn(this->stmt, 1, 1);
   CheckStringColumnW(this->stmt, 2, L"One");
@@ -2520,7 +2520,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountReturnsSuccessOnNullptr) {
 
   ret = SQLRowCount(this->stmt, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -2533,10 +2533,10 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLRowCountFunctionSequenceErrorOnNoQuery) {
 
   SQLRETURN ret = SQLRowCount(this->stmt, &row_count);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY010);
 
-  EXPECT_EQ(row_count, expected_value);
+  EXPECT_EQ(expected_value, row_count);
 
   this->Disconnect();
 }
@@ -2550,11 +2550,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFreeStmtSQLClose) {
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLFreeStmt(this->stmt, SQL_CLOSE);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -2568,11 +2568,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLCloseCursor) {
   SQLRETURN ret =
       SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ret = SQLCloseCursor(this->stmt);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -2583,7 +2583,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLFreeStmtSQLCloseWithoutCursor) {
 
   SQLRETURN ret = SQLFreeStmt(this->stmt, SQL_CLOSE);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   this->Disconnect();
 }
@@ -2593,7 +2593,7 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLCloseCursorWithoutCursor) {
 
   SQLRETURN ret = SQLCloseCursor(this->stmt);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Verify invalid cursor error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_24000);

--- a/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
@@ -36,7 +36,7 @@ std::wstring GetStringColumnW(SQLHSTMT stmt, int colId) {
 
   SQLRETURN ret = SQLGetData(stmt, colId, SQL_C_WCHAR, buf, sizeof(buf), &len_indicator);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   if (len_indicator == SQL_NULL_DATA) {
     return L"";
@@ -62,7 +62,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesTestInputData) {
                             sizeof(schema_name), table_name, sizeof(table_name),
                             table_type, sizeof(table_type));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
@@ -70,7 +70,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesTestInputData) {
   ret = SQLTables(this->stmt, catalog_name, 0, schema_name, 0, table_name, 0, table_type,
                   0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
@@ -78,7 +78,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesTestInputData) {
   ret = SQLTables(this->stmt, 0, sizeof(catalog_name), 0, sizeof(schema_name), 0,
                   sizeof(table_name), 0, sizeof(table_type));
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
   // Close statement cursor to avoid leaving in an invalid state
@@ -87,7 +87,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesTestInputData) {
   // All values and sizes are nulls
   ret = SQLTables(this->stmt, 0, 0, 0, 0, 0, 0, 0, 0);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
 
@@ -105,7 +105,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesTestGetMetadataForAllCatalogs) {
   SQLRETURN ret = SQLTables(this->stmt, SQL_ALL_CATALOGS_W, SQL_NTS, empty, SQL_NTS,
                             empty, SQL_NTS, empty, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
 
@@ -135,7 +135,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesTestGetMetadataForNamedCatalog) {
   SQLRETURN ret = SQLTables(this->stmt, catalog_name, SQL_NTS, nullptr, SQL_NTS, nullptr,
                             SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(table_names) / sizeof(*table_names); ++i) {
     ValidateFetch(this->stmt, SQL_SUCCESS);
@@ -162,7 +162,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesTestGetSchemaHasNoData) {
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, SQL_ALL_SCHEMAS_W, SQL_NTS,
                             nullptr, SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
@@ -250,7 +250,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLTablesTestFilterByAllSchema) {
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, SQL_ALL_SCHEMAS_W, SQL_NTS,
                             nullptr, SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(schema_names) / sizeof(*schema_names); ++i) {
     ValidateFetch(this->stmt, SQL_SUCCESS);
@@ -285,7 +285,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLTablesGetMetadataForNamedSchema) {
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, schema_name, SQL_NTS, nullptr,
                             SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
 
@@ -315,7 +315,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesTestGetMetadataForAllTables) {
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                             SQL_ALL_TABLES_W, SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(table_names) / sizeof(*table_names); ++i) {
     ValidateFetch(this->stmt, SQL_SUCCESS);
@@ -347,7 +347,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesTestGetMetadataForTableName) {
     SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                               table_names[i], SQL_NTS, nullptr, SQL_NTS);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
     ValidateFetch(this->stmt, SQL_SUCCESS);
 
@@ -377,7 +377,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesTestGetMetadataForUnicodeTableByTable
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                             unicodetable_name, SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
 
@@ -403,7 +403,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesTestGetMetadataForInvalidTableNameNoD
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                             invalid_table_name, SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
@@ -429,21 +429,21 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesGetMetadataForTableType) {
   ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
                   table_type_table_uppercase, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
   ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
                   table_type_view, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
   ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
                   table_type_table_view, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
@@ -451,7 +451,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesGetMetadataForTableType) {
   ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
                   table_type_table_lowercase, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(table_names) / sizeof(*table_names); ++i) {
     ValidateFetch(this->stmt, SQL_SUCCESS);
@@ -483,7 +483,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLTablesGetMetadataForTableTypeTable) {
     ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
                     type_list[i], SQL_NTS);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
     ValidateFetch(this->stmt, SQL_SUCCESS);
 
@@ -508,14 +508,14 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLTablesGetMetadataForTableTypeViewHasNoDat
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, empty,
                             SQL_NTS, type_view, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
   ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
                   type_view, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_NO_DATA);
 
@@ -533,7 +533,7 @@ TEST_F(FlightSQLODBCMockTestBase, SQLTablesGetSupportedTableTypes) {
   SQLRETURN ret = SQLTables(this->stmt, empty, SQL_NTS, empty, SQL_NTS, empty, SQL_NTS,
                             SQL_ALL_TABLE_TYPES_W, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   ValidateFetch(this->stmt, SQL_SUCCESS);
 
@@ -559,7 +559,7 @@ TEST_F(FlightSQLODBCRemoteTestBase, SQLTablesGetSupportedTableTypes) {
   SQLRETURN ret = SQLTables(this->stmt, empty, SQL_NTS, empty, SQL_NTS, empty, SQL_NTS,
                             SQL_ALL_TABLE_TYPES_W, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(type_lists) / sizeof(*type_lists); ++i) {
     ValidateFetch(this->stmt, SQL_SUCCESS);
@@ -599,7 +599,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesGetMetadataBySQLDescribeCol) {
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
                             SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -608,16 +608,16 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesGetMetadataBySQLDescribeCol) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, column_sizes[i]);
-    EXPECT_EQ(decimal_digits, 0);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;
@@ -652,7 +652,7 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesGetMetadataBySQLDescribeColODBC2) {
   SQLRETURN ret = SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
                             SQL_NTS, nullptr, SQL_NTS);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
@@ -661,16 +661,16 @@ TYPED_TEST(FlightSQLODBCTestBase, SQLTablesGetMetadataBySQLDescribeColODBC2) {
         SQLDescribeCol(this->stmt, column_index, column_name, buf_char_len, &name_length,
                        &column_data_type, &column_size, &decimal_digits, &nullable);
 
-    EXPECT_EQ(ret, SQL_SUCCESS);
+    EXPECT_EQ(SQL_SUCCESS, ret);
 
-    EXPECT_EQ(name_length, wcslen(column_names[i]));
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
-    EXPECT_EQ(returned, column_names[i]);
-    EXPECT_EQ(column_data_type, column_data_types[i]);
-    EXPECT_EQ(column_size, column_sizes[i]);
-    EXPECT_EQ(decimal_digits, 0);
-    EXPECT_EQ(nullable, SQL_NULLABLE);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
 
     name_length = 0;
     column_data_type = 0;

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -49,16 +49,16 @@ void CheckSQLDescribeCol(SQLHSTMT stmt, const SQLUSMALLINT column_index,
       SQLDescribeCol(stmt, column_index, column_name, buf_char_len, &name_length,
                      &column_data_type, &column_size, &decimal_digits, &nullable);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   EXPECT_EQ(name_length, expected_name.size());
 
   std::wstring returned(column_name, column_name + name_length);
-  EXPECT_EQ(returned, expected_name);
-  EXPECT_EQ(column_data_type, expected_data_type);
-  EXPECT_EQ(column_size, expected_column_size);
-  EXPECT_EQ(decimal_digits, expected_decimal_digits);
-  EXPECT_EQ(nullable, expected_nullable);
+  EXPECT_EQ(expected_name, returned);
+  EXPECT_EQ(expected_data_type, column_data_type);
+  EXPECT_EQ(expected_column_size, column_size);
+  EXPECT_EQ(expected_decimal_digits, decimal_digits);
+  EXPECT_EQ(expected_nullable, nullable);
 }
 
 void CheckSQLDescribeColODBC2(SQLHSTMT stmt) {
@@ -192,11 +192,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_ALL_TYPES);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check bit data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"bit"),  // expected_type_name
@@ -223,7 +223,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check tinyint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"tinyint"),  // expected_type_name
@@ -250,7 +250,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check bigint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"bigint"),  // expected_type_name
@@ -277,7 +277,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check longvarbinary data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"longvarbinary"),  // expected_type_name
@@ -304,7 +304,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check varbinary data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"varbinary"),  // expected_type_name
@@ -331,7 +331,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check text data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -359,7 +359,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check longvarchar data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"longvarchar"),  // expected_type_name
@@ -386,7 +386,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check char data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -414,7 +414,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check integer data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"integer"),  // expected_type_name
@@ -441,7 +441,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check smallint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"smallint"),  // expected_type_name
@@ -468,7 +468,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check float data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"float"),  // expected_type_name
@@ -495,7 +495,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check double data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"double"),  // expected_type_name
@@ -522,7 +522,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check numeric data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Mock server treats numeric data type as a double type
   CheckSQLGetTypeInfo(this->stmt,
@@ -550,7 +550,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check varchar data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -578,7 +578,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check date data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"date"),  // expected_type_name
@@ -605,7 +605,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check time data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"time"),  // expected_type_name
@@ -632,7 +632,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypes) {
 
   // Check timestamp data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
@@ -664,11 +664,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
   this->Connect(SQL_OV_ODBC2);
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_ALL_TYPES);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check bit data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"bit"),  // expected_type_name
@@ -695,7 +695,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check tinyint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"tinyint"),  // expected_type_name
@@ -722,7 +722,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check bigint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"bigint"),  // expected_type_name
@@ -749,7 +749,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check longvarbinary data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"longvarbinary"),  // expected_type_name
@@ -776,7 +776,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check varbinary data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"varbinary"),  // expected_type_name
@@ -803,7 +803,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check text data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -831,7 +831,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check longvarchar data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"longvarchar"),  // expected_type_name
@@ -858,7 +858,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check char data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -886,7 +886,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check integer data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"integer"),  // expected_type_name
@@ -913,7 +913,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check smallint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"smallint"),  // expected_type_name
@@ -940,7 +940,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check float data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"float"),  // expected_type_name
@@ -967,7 +967,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check double data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"double"),  // expected_type_name
@@ -994,7 +994,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check numeric data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Mock server treats numeric data type as a double type
   CheckSQLGetTypeInfo(this->stmt,
@@ -1022,7 +1022,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check varchar data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -1050,7 +1050,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check date data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"date"),  // expected_type_name
@@ -1077,7 +1077,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check time data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"time"),  // expected_type_name
@@ -1104,7 +1104,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoAllTypesODBCVer2) {
 
   // Check timestamp data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
@@ -1136,11 +1136,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoBit) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_BIT);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check bit data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"bit"),  // expected_type_name
@@ -1167,7 +1167,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoBit) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1176,11 +1176,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoTinyInt) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TINYINT);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check tinyint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"tinyint"),  // expected_type_name
@@ -1207,7 +1207,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoTinyInt) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1216,11 +1216,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoBigInt) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_BIGINT);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check bigint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"bigint"),  // expected_type_name
@@ -1247,7 +1247,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoBigInt) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1256,11 +1256,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarbinary) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_LONGVARBINARY);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check longvarbinary data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"longvarbinary"),  // expected_type_name
@@ -1287,7 +1287,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarbinary) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1296,11 +1296,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoVarbinary) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_VARBINARY);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check varbinary data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"varbinary"),  // expected_type_name
@@ -1325,7 +1325,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoVarbinary) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1334,11 +1334,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarchar) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_WLONGVARCHAR);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check text data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -1366,7 +1366,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarchar) {
 
   // Check longvarchar data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"longvarchar"),  // expected_type_name
@@ -1393,7 +1393,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoLongVarchar) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1402,11 +1402,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoChar) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_WCHAR);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check char data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -1434,7 +1434,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoChar) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1443,11 +1443,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoInteger) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_INTEGER);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check integer data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"integer"),  // expected_type_name
@@ -1474,7 +1474,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoInteger) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1483,11 +1483,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSmallInt) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_SMALLINT);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check smallint data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"smallint"),  // expected_type_name
@@ -1514,7 +1514,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSmallInt) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1523,11 +1523,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoFloat) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_FLOAT);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check float data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"float"),  // expected_type_name
@@ -1554,7 +1554,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoFloat) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1563,11 +1563,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDouble) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_DOUBLE);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check double data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"double"),  // expected_type_name
@@ -1594,7 +1594,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDouble) {
 
   // Check numeric data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Mock server treats numeric data type as a double type
   CheckSQLGetTypeInfo(this->stmt,
@@ -1622,7 +1622,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDouble) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1631,11 +1631,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoVarchar) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_WVARCHAR);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check varchar data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
   CheckSQLGetTypeInfo(this->stmt,
@@ -1663,7 +1663,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoVarchar) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1672,11 +1672,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeDate) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_DATE);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check date data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"date"),  // expected_type_name
@@ -1703,7 +1703,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeDate) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1713,11 +1713,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLDate) {
 
   // Pass ODBC Ver 2 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_DATE);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check date data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"date"),  // expected_type_name
@@ -1744,7 +1744,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLDate) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1753,11 +1753,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDateODBCVer2) {
   this->Connect(SQL_OV_ODBC2);
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_DATE);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check date data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"date"),  // expected_type_name
@@ -1784,7 +1784,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoDateODBCVer2) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1795,7 +1795,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeDateODBCVer2) {
   // Pass ODBC Ver 3 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_DATE);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Driver manager returns SQL data type out of range error state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_S1004);
@@ -1807,11 +1807,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTime) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_TIME);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check time data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"time"),  // expected_type_name
@@ -1838,7 +1838,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTime) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1848,11 +1848,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTime) {
 
   // Pass ODBC Ver 2 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TIME);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check time data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"time"),  // expected_type_name
@@ -1879,7 +1879,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTime) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1888,11 +1888,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoTimeODBCVer2) {
   this->Connect(SQL_OV_ODBC2);
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TIME);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check time data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"time"),  // expected_type_name
@@ -1919,7 +1919,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoTimeODBCVer2) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1930,7 +1930,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimeODBCVer2) {
   // Pass ODBC Ver 3 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_TIME);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Driver manager returns SQL data type out of range error state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_S1004);
@@ -1942,11 +1942,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimestamp) {
   this->Connect();
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_TIMESTAMP);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check timestamp data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
@@ -1973,7 +1973,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimestamp) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -1983,11 +1983,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTimestamp) {
 
   // Pass ODBC Ver 2 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TIMESTAMP);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check timestamp data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
@@ -2014,7 +2014,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTimestamp) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -2023,11 +2023,11 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
   this->Connect(SQL_OV_ODBC2);
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TIMESTAMP);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Check timestamp data type
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   CheckSQLGetTypeInfo(this->stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
@@ -2054,7 +2054,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
 
   // No more data
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }
@@ -2065,7 +2065,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoSQLTypeTimestampODBCVer2) {
   // Pass ODBC Ver 3 data type
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_TYPE_TIMESTAMP);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
 
   // Driver manager returns SQL data type out of range error state
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_S1004);
@@ -2079,7 +2079,7 @@ TEST_F(FlightSQLODBCMockTestBase, TestSQLGetTypeInfoInvalidDataType) {
   SQLSMALLINT invalid_data_type = -114;
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, invalid_data_type);
 
-  EXPECT_EQ(ret, SQL_ERROR);
+  EXPECT_EQ(SQL_ERROR, ret);
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, error_state_HY004);
 
   this->Disconnect();
@@ -2091,11 +2091,11 @@ TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetTypeInfoUnsupportedDataType) {
 
   SQLRETURN ret = SQLGetTypeInfo(this->stmt, SQL_GUID);
 
-  EXPECT_EQ(ret, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, ret);
 
   // Result set is empty with valid data type that is unsupported by the server
   ret = SQLFetch(this->stmt);
-  EXPECT_EQ(ret, SQL_NO_DATA);
+  EXPECT_EQ(SQL_NO_DATA, ret);
 
   this->Disconnect();
 }


### PR DESCRIPTION
### Rationale for this change
Google Test assumes that `EXPECT_EQ()` has the expected value as the left argument and the actual value as the right argument so we are fixing the tests to be consistent with this.

### What changes are included in this PR?
Ensured that `EXPECT_EQ()` has the expected value as the left argument and the actual value as the right argument.

### Are these changes tested?
N/A

### Are there any user-facing changes?
No.

