### PR TITLE
Code style naming convention for `flightsql-odbc` tests

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/binary_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/binary_array_accessor_test.cc
@@ -25,7 +25,7 @@ namespace arrow::flight::sql::odbc {
 using arrow::ArrayFromVector;
 using arrow::BinaryType;
 
-TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Basic) {
+TEST(BinaryArrayAccessor, TestCDataTypeBinaryBasic) {
   std::vector<std::string> values = {"foo", "barx", "baz123"};
   std::shared_ptr<Array> array;
   ArrayFromVector<BinaryType, std::string>(values, &array);
@@ -56,7 +56,7 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Basic) {
   }
 }
 
-TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Truncation) {
+TEST(BinaryArrayAccessor, TestCDataTypeBinaryTruncation) {
   std::vector<std::string> values = {"ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEF"};
   std::shared_ptr<Array> array;
   ArrayFromVector<BinaryType, std::string>(values, &array);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/boolean_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/boolean_array_accessor_test.cc
@@ -25,7 +25,7 @@ using arrow::BooleanType;
 
 using arrow::ArrayFromVector;
 
-TEST(BooleanArrayFlightSqlAccessor, Test_BooleanArray_CDataType_BIT) {
+TEST(BooleanArrayFlightSqlAccessor, TestBooleanArrayCDataTypeBit) {
   const std::vector<bool> values = {true, false, true};
   std::shared_ptr<Array> array;
   ArrayFromVector<BooleanType>(values, &array);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/date_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/date_array_accessor_test.cc
@@ -31,7 +31,7 @@ using arrow::Date64Array;
 using arrow::Date64Type;
 using arrow::NumericArray;
 
-TEST(DateArrayAccessor, Test_Date32Array_CDataType_DATE) {
+TEST(DateArrayAccessor, TestDate32ArrayCDataTypeDate) {
   std::vector<int32_t> values = {7589, 12320, 18980, 19095, -1, 0};
   std::vector<tagDATE_STRUCT> expected = {
       {1990, 10, 12}, {2003, 9, 25},  {2021, 12, 19},
@@ -64,7 +64,7 @@ TEST(DateArrayAccessor, Test_Date32Array_CDataType_DATE) {
   }
 }
 
-TEST(DateArrayAccessor, Test_Date64Array_CDataType_DATE) {
+TEST(DateArrayAccessor, TestDate64ArrayCDataTypeDate) {
   std::vector<int64_t> values = {
       86400000,  172800000, 259200000,       1649793238110,  0, 345600000, 432000000,
       518400000, -86400000, -17987443200000, -24268068949000};

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/decimal_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/decimal_array_accessor_test.cc
@@ -103,7 +103,7 @@ void AssertNumericOutput(int input_precision, int input_scale,
   }
 }
 
-TEST(DecimalArrayFlightSqlAccessor, Test_Decimal128Array_CDataType_NUMERIC_SameScale) {
+TEST(DecimalArrayFlightSqlAccessor, TestDecimal128ArrayCDataTypeNumericSameScale) {
   const std::vector<std::string>& input_values = {"25.212", "-25.212", "-123456789.123",
                                                   "123456789.123"};
   const std::vector<std::string>& output_values =

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/primitive_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/primitive_array_accessor_test.cc
@@ -65,43 +65,43 @@ void TestPrimitiveArraySqlAccessor() {
   }
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_Int64Array_CDataType_SBIGINT) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestInt64ArrayCDataTypeSbigint) {
   TestPrimitiveArraySqlAccessor<Int64Array, CDataType_SBIGINT>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_Int32Array_CDataType_SLONG) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestInt32ArrayCDataTypeSlong) {
   TestPrimitiveArraySqlAccessor<Int32Array, CDataType_SLONG>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_Int16Array_CDataType_SSHORT) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestInt16ArrayCDataTypeSshort) {
   TestPrimitiveArraySqlAccessor<Int16Array, CDataType_SSHORT>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_Int8Array_CDataType_STINYINT) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestInt8ArrayCDataTypeStinyint) {
   TestPrimitiveArraySqlAccessor<Int8Array, CDataType_STINYINT>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_UInt64Array_CDataType_UBIGINT) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestUInt64ArrayCDataTypeUbigint) {
   TestPrimitiveArraySqlAccessor<UInt64Array, CDataType_UBIGINT>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_UInt32Array_CDataType_ULONG) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestUInt32ArrayCDataTypeUlong) {
   TestPrimitiveArraySqlAccessor<UInt32Array, CDataType_ULONG>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_UInt16Array_CDataType_USHORT) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestUInt16ArrayCDataTypeUshort) {
   TestPrimitiveArraySqlAccessor<UInt16Array, CDataType_USHORT>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_UInt8Array_CDataType_UTINYINT) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestUInt8ArrayCDataTypeUtinyint) {
   TestPrimitiveArraySqlAccessor<UInt8Array, CDataType_UTINYINT>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_FloatArray_CDataType_FLOAT) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestFloatArrayCDataTypeFloat) {
   TestPrimitiveArraySqlAccessor<FloatArray, CDataType_FLOAT>();
 }
 
-TEST(PrimitiveArrayFlightSqlAccessor, Test_DoubleArray_CDataType_DOUBLE) {
+TEST(PrimitiveArrayFlightSqlAccessor, TestDoubleArrayCDataTypeDouble) {
   TestPrimitiveArraySqlAccessor<DoubleArray, CDataType_DOUBLE>();
 }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/string_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/string_array_accessor_test.cc
@@ -26,7 +26,7 @@ namespace arrow::flight::sql::odbc {
 using arrow::ArrayFromVector;
 using arrow::StringType;
 
-TEST(StringArrayAccessor, Test_CDataType_CHAR_Basic) {
+TEST(StringArrayAccessor, TestCDataTypeCharBasic) {
   std::vector<std::string> values = {"foo", "barx", "baz123"};
   std::shared_ptr<Array> array;
   ArrayFromVector<StringType, std::string>(values, &array);
@@ -52,7 +52,7 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Basic) {
   }
 }
 
-TEST(StringArrayAccessor, Test_CDataType_CHAR_Truncation) {
+TEST(StringArrayAccessor, TestCDataTypeCharTruncation) {
   std::vector<std::string> values = {"ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEF"};
   std::shared_ptr<Array> array;
   ArrayFromVector<StringType, std::string>(values, &array);
@@ -85,7 +85,7 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Truncation) {
   ASSERT_EQ(values[0], ss.str());
 }
 
-TEST(StringArrayAccessor, Test_CDataType_WCHAR_Basic) {
+TEST(StringArrayAccessor, TestCDataTypeWcharBasic) {
   std::vector<std::string> values = {"foo", "barx", "baz123"};
   std::shared_ptr<Array> array;
   ArrayFromVector<StringType, std::string>(values, &array);
@@ -115,7 +115,7 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Basic) {
   }
 }
 
-TEST(StringArrayAccessor, Test_CDataType_WCHAR_Truncation) {
+TEST(StringArrayAccessor, TestCDataTypeWcharTruncation) {
   std::vector<std::string> values = {"ABCDEFA"};
   std::shared_ptr<Array> array;
   ArrayFromVector<StringType, std::string>(values, &array);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/time_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/time_array_accessor_test.cc
@@ -32,7 +32,7 @@ using arrow::Time64Array;
 using arrow::Time64Type;
 using arrow::TimeUnit;
 
-TEST(TEST_TIME32, TIME_WITH_SECONDS) {
+TEST(TestTime32, TimeWithSeconds) {
   auto value_field = field("f0", time32(TimeUnit::SECOND));
 
   std::vector<int32_t> t32_values = {14896, 14897, 14892, 85400, 14893, 14895};
@@ -66,7 +66,7 @@ TEST(TEST_TIME32, TIME_WITH_SECONDS) {
   }
 }
 
-TEST(TEST_TIME32, TIME_WITH_MILLI) {
+TEST(TestTime32, TimeWithMilli) {
   auto value_field = field("f0", time32(TimeUnit::MILLI));
   std::vector<int32_t> t32_values = {14896000, 14897000, 14892000,
                                      85400000, 14893000, 14895000};
@@ -102,7 +102,7 @@ TEST(TEST_TIME32, TIME_WITH_MILLI) {
   }
 }
 
-TEST(TEST_TIME64, TIME_WITH_MICRO) {
+TEST(TestTime32, TimeWithMicro) {
   auto value_field = field("f0", time64(TimeUnit::MICRO));
 
   std::vector<int64_t> t64_values = {14896000, 14897000, 14892000,
@@ -139,7 +139,7 @@ TEST(TEST_TIME64, TIME_WITH_MICRO) {
   }
 }
 
-TEST(TEST_TIME64, TIME_WITH_NANO) {
+TEST(TestTime32, TimeWithNano) {
   auto value_field = field("f0", time64(TimeUnit::NANO));
   std::vector<int64_t> t64_values = {14896000000, 14897000000, 14892000000,
                                      85400000000, 14893000000, 14895000000};

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/timestamp_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/timestamp_array_accessor_test.cc
@@ -28,7 +28,7 @@ using arrow::ArrayFromVector;
 using arrow::TimestampType;
 using arrow::TimeUnit;
 
-TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MILLI) {
+TEST(TestTimestamp, TimestampWithMilli) {
   std::vector<int64_t> values = {86400370,        172800000,      259200000,
                                  1649793238110LL, 345600000,      432000000,
                                  518400000,       -86399000,      0,
@@ -92,7 +92,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MILLI) {
   }
 }
 
-TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_SECONDS) {
+TEST(TestTimestamp, TimestampWithSeconds) {
   std::vector<int64_t> values = {86400,  172800, 259200, 1649793238,
                                  345600, 432000, 518400};
 
@@ -134,7 +134,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_SECONDS) {
   }
 }
 
-TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MICRO) {
+TEST(TestTimestamp, TimestampWithMicro) {
   std::vector<int64_t> values = {86400000000, 1649793238000000};
 
   std::shared_ptr<Array> timestamp_array;
@@ -178,7 +178,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MICRO) {
   }
 }
 
-TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_NANO) {
+TEST(TestTimestamp, TimestampWithNano) {
   std::vector<int64_t> values = {86400000010000, 1649793238000000000};
 
   std::shared_ptr<Array> timestamp_array;


### PR DESCRIPTION
Change `flightsql-odbc` test names to follow Arrow convention and remove the underscores.
Addresses comment https://github.com/apache/arrow/pull/40939#discussion_r2099160991