### PR TITLE
Use SqlWCharArrLen() for wide char array length on Linux

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -510,9 +510,20 @@ std::wstring GetStringColumnW(SQLHSTMT stmt, int col_id) {
   return std::wstring(buf, buf + char_count);
 }
 
+size_t SqlWCharArrLen(const SQLWCHAR* str_val) {
+  if (!str_val) {
+    return 0;
+  }
+  const SQLWCHAR* p = str_val;
+  while (*p != 0) {
+    ++p;
+  }
+  return static_cast<size_t>(p - str_val);
+}
+
 std::wstring ConvertToWString(const SQLWCHAR* str_val) {
 #ifdef __linux__
-  size_t str_len = std::wcslen(reinterpret_cast<const wchar_t*>(str_val));
+  size_t str_len = SqlWCharArrLen(str_val);
 #else
   size_t str_len = std::wcslen(str_val);
 #endif

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -44,7 +44,7 @@
     SQLWCHAR* name = name##_vec.data();
 #  define ASSIGN_SQLWCHAR_ARR_AND_LEN(name, wstring_var) \
     ASSIGN_SQLWCHAR_ARR(name, wstring_var)               \
-    size_t name##_len = std::wcslen(reinterpret_cast<const wchar_t*>(name));
+    size_t name##_len = SqlWCharArrLen(name);
 #else
 #  define ASSIGN_SQLWCHAR_ARR(name, wstring_var) SQLWCHAR name[] = wstring_var;
 #  define ASSIGN_SQLWCHAR_ARR_AND_LEN(name, wstring_var) \
@@ -280,6 +280,11 @@ bool WriteDSN(Connection::ConnPropertyMap properties);
 /// \param[in] col_id Column ID to check.
 /// \return wstring
 std::wstring GetStringColumnW(SQLHSTMT stmt, int col_id);
+
+/// \brief Get length of wide char array.
+/// \param[in] str_val Array of SQLWCHAR.
+/// \return number of wide characters in array
+size_t SqlWCharArrLen(const SQLWCHAR* str_val);
 
 /// \brief Check wide char array and convert into wstring
 /// \param[in] str_val Array of SQLWCHAR.


### PR DESCRIPTION
### Rationale for this change
Previous logic for getting wide char array length on Linux was incorrect. Now we are using a helper function to iterate and count through a wide char array.

### What changes are included in this PR?
Helper function introduced for counting wide chars in wide char array.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
