### PR TITLE
Fix ODBC Linux test segmentation fault

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -55,8 +55,7 @@ if ! type minio >/dev/null 2>&1; then
 fi
 case "$(uname)" in
   Linux)
-    # -AL- check CI output not segfault right away.
-    # exclude_tests+=("arrow-flight-sql-odbc-test")
+    exclude_tests+=("arrow-flight-sql-odbc-test")
     n_jobs=$(nproc)
     ;;
   Darwin)

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -55,7 +55,8 @@ if ! type minio >/dev/null 2>&1; then
 fi
 case "$(uname)" in
   Linux)
-    exclude_tests+=("arrow-flight-sql-odbc-test")
+    # -AL- check CI output not segfault right away.
+    # exclude_tests+=("arrow-flight-sql-odbc-test")
     n_jobs=$(nproc)
     ;;
   Darwin)

--- a/compose.yaml
+++ b/compose.yaml
@@ -565,6 +565,7 @@ services:
       ARROW_PARQUET: "OFF"
       ARROW_S3: "OFF"
       ARROW_SUBSTRAIT: "OFF"
+      ARROW_TEST_LINKAGE: "static"
     # Register ODBC before running tests
     command: >
       /bin/bash -c "

--- a/compose.yaml
+++ b/compose.yaml
@@ -565,6 +565,7 @@ services:
       ARROW_PARQUET: "OFF"
       ARROW_S3: "OFF"
       ARROW_SUBSTRAIT: "OFF"
+      # GH-49651 Link ODBC tests statically on Linux to fix segfault
       ARROW_TEST_LINKAGE: "static"
     # Register ODBC before running tests
     command: >

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(ARROW_FLIGHT_SQL_ODBC_TEST_SRCS
     # GH-46889: move protobuf_test_util to a more common location
     ../../../../engine/substrait/protobuf_test_util.cc)
 
+# GH-49652: TODO support static test linkage on macOS
 if(ARROW_TEST_LINKAGE STREQUAL "static")
   set(ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS arrow_flight_sql_odbc_static
                                            ${ARROW_TEST_STATIC_LINK_LIBS})
@@ -65,12 +66,13 @@ else()
   # Unix
   list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_STATIC_LINK_LIBS
        ${ARROW_FLIGHT_SQL_ODBC_TEST_LIBS} ${ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS})
-  
+
   if(NOT APPLE)
-    # Explicitly link to boost on Linux // -AL- trying to make `ARROW_TEST_LINKAGE=static` work.
-    list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_STATIC_LINK_LIBS arrow_odbc_spi_impl Boost::headers ${ARROW_PROTOBUF_LIBPROTOBUF})
+    # Links static dependencies on Linux to support ARROW_TEST_LINKAGE=static
+    list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_STATIC_LINK_LIBS arrow_odbc_spi_impl
+         ${ARROW_PROTOBUF_LIBPROTOBUF})
   endif()
-  
+
 endif()
 
 add_arrow_test(flight_sql_odbc_test

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -65,6 +65,12 @@ else()
   # Unix
   list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_STATIC_LINK_LIBS
        ${ARROW_FLIGHT_SQL_ODBC_TEST_LIBS} ${ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS})
+  
+  if(NOT APPLE)
+    # Explicitly link to boost on Linux // -AL- trying to make `ARROW_TEST_LINKAGE=static` work.
+    list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_STATIC_LINK_LIBS arrow_odbc_spi_impl Boost::headers ${ARROW_PROTOBUF_LIBPROTOBUF})
+  endif()
+  
 endif()
 
 add_arrow_test(flight_sql_odbc_test


### PR DESCRIPTION
To resolve the immediate segfault in odbc test, need be on this branch, append `-DARROW_TEST_LINKAGE=static` to the cmake command. Then rebuild ODBC and the tests.

Description of issue:
Both Arrow Flight SQL ODBC and the ODBC test executable link to bundled gRPC, and that causes segmentation fault when the ODBC is trying to connect to a gRPC-based mock server.
The solution is to pass `ARROW_TEST_LINKAGE=static` for the ODBC tests on Linux, so the odbc tests on Linux link to just one set of gRPC symbols.

This PR resolves the immediate segfault at connection start up when we run the `arrow-flight-sql-odbc-test` executable. It doesn't fix individual ODBC test failures. 