### PR TITLE
Only Run ODBC-related tests on CI

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -450,7 +450,7 @@ jobs:
       needs.check-labels.outputs.force == 'true' ||
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++'))
-    timeout-minutes: 75
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -87,10 +87,16 @@ case "$(uname)" in
     n_jobs=${NPROC:-1}
     ;;
 esac
-if [ "${#exclude_tests[@]}" -gt 0 ]; then
-  IFS="|"
-  ctest_options+=(--exclude-regex "${exclude_tests[*]}")
-  unset IFS
+
+if [ "$ARROW_FLIGHT_SQL_ODBC" = "ON" ]; then
+  # Only run ODBC-related tests on ODBC CI pipelines
+  ctest_options+=(--tests-regex "arrow-flight-sql-odbc-test|arrow-odbc-spi-impl-test")
+else
+  if [ "${#exclude_tests[@]}" -gt 0 ]; then
+    IFS="|"
+    ctest_options+=(--exclude-regex "${exclude_tests[*]}")
+    unset IFS
+  fi
 fi
 
 if [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -89,14 +89,12 @@ case "$(uname)" in
 esac
 
 if [ "$ARROW_FLIGHT_SQL_ODBC" = "ON" ]; then
-  # Only run ODBC-related tests on ODBC CI pipelines
+  # GH-49816: Only run ODBC tests on ODBC CI pipelines
   ctest_options+=(--tests-regex "arrow-flight-sql-odbc-test|arrow-odbc-spi-impl-test")
-else
-  if [ "${#exclude_tests[@]}" -gt 0 ]; then
-    IFS="|"
-    ctest_options+=(--exclude-regex "${exclude_tests[*]}")
-    unset IFS
-  fi
+elif [ "${#exclude_tests[@]}" -gt 0 ]; then
+  IFS="|"
+  ctest_options+=(--exclude-regex "${exclude_tests[*]}")
+  unset IFS
 fi
 
 if [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then


### PR DESCRIPTION
Only Run ODBC-related tests on ODBC CIs (`odbc-linux`, `odbc-macos`, `odbc-msvc`), all other non-ODBC related tests are excluded. 