### PR TITLE
Initialize Arrow Compute in global test environment

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -42,11 +42,6 @@ set(ARROW_FLIGHT_SQL_ODBC_TEST_SRCS
     # GH-46889: move protobuf_test_util to a more common location
     ../../../../engine/substrait/protobuf_test_util.cc)
 
-# Resolve segmentation fault error on Windows platform due to Arrow Compute Library Initialization
-if(WIN32)
-  list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_SRCS ../../../../compute/test_env.cc)
-endif()
-
 # GH-49651 Link ODBC tests statically on Linux and dynamically on macOS/Windows
 if(WIN32 OR APPLE)
   set(ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS arrow_flight_sql_odbc_shared

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -19,6 +19,7 @@
 // with windows.h
 #include "arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h"
 
+#include "arrow/compute/api.h"
 #include "arrow/flight/sql/odbc/tests/odbc_test_suite.h"
 
 // For DSN registration
@@ -81,6 +82,17 @@ class OdbcTestEnvironment : public ::testing::Environment {
     ODBCTestBase::Disconnect(mock_odbcv2_handles.env, mock_odbcv2_handles.conn);
   }
 };
+
+#ifdef _WIN32
+// A global test "environment", to ensure Arrow compute kernel functions are registered
+class ComputeKernelEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override { ASSERT_OK(arrow::compute::Initialize()); }
+};
+
+::testing::Environment* compute_kernel_env =
+    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
+#endif  // _WIN32
 
 ::testing::Environment* mock_server_env =
     ::testing::AddGlobalTestEnvironment(new MockServerEnvironment);


### PR DESCRIPTION
### Rationale for this change
Arrow compute functions need to be initialized/registered to avoid a segfault on windows.

### What changes are included in this PR?
Defined `ComputeKernelEnvironment` which initialized arrow compute during `SetUp`.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.